### PR TITLE
fix/pool v202

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,11 +1,7 @@
 # Build documentation
 name: Documentation Build
 
-on:
-  push:
-    branches-ignore:
-      - 'gh-pages'
-  pull_request:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,12 +1,7 @@
 # check spelling, codestyle
 name: Style Check
 
-on:
-  push:
-    branches-ignore:
-      # Push events to branches matching refs/heads/mona/octocat
-      - 'gh-pages'
-  pull_request:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/ansys/mapdl/core/_version.py
+++ b/ansys/mapdl/core/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-core module."""
 
 # major, minor, patch
-version_info = 0, 57, 1
+version_info = 0, 57, 2
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -893,7 +893,11 @@ def check_mode(mode, version):
         mode = mode.lower()
         if mode == 'grpc':
             if version < 211:
-                raise VersionError('gRPC mode requires MAPDL 2021R1 or newer.')
+                if version < 202 and os.name == 'nt':
+                    raise VersionError('gRPC mode requires MAPDL 2020R2 or newer '
+                                       'on Windows.')
+                elif os.name == 'posix':
+                    raise VersionError('gRPC mode requires MAPDL 2021R1 or newer.')
         elif mode == 'corba':
             if version < 170:
                 raise VersionError('CORBA AAS mode requires MAPDL v17.0 or newer.')

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -913,6 +913,9 @@ def check_mode(mode, version):
     else:  # auto-select based on best version
         if version >= 211:
             mode = 'grpc'
+        elif version == 202 and os.name == 'nt':
+            # Windows supports it as of 2020R2
+            mode = 'grpc'
         elif version >= 170:
             mode = 'corba'
         else:

--- a/ansys/mapdl/core/pool.py
+++ b/ansys/mapdl/core/pool.py
@@ -93,6 +93,7 @@ class LocalMapdlPool():
         self._instances = []
         self._root_dir = run_location
         kwargs['remove_temp_files'] = remove_temp_files
+        kwargs['mode'] = 'grpc'
         self._spawn_kwargs = kwargs
 
         # grab available ports

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,30 +41,27 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--corba"):
+    if not config.getoption("--corba"):
         # --corba given in cli: run CORBA interface tests
-        return
-    skip_corba = pytest.mark.skip(reason="need --corba option to run")
-    for item in items:
-        if "corba" in item.keywords:
-            item.add_marker(skip_corba)
+        skip_corba = pytest.mark.skip(reason="need --corba option to run")
+        for item in items:
+            if "corba" in item.keywords:
+                item.add_marker(skip_corba)
 
-    if config.getoption("--console"):
+    if not config.getoption("--console"):
         # --console given in cli: run console interface tests
-        return
-    skip_console = pytest.mark.skip(reason="need --console option to run")
-    for item in items:
-        if "console" in item.keywords:
-            item.add_marker(skip_console)
+        skip_console = pytest.mark.skip(reason="need --console option to run")
+        for item in items:
+            if "console" in item.keywords:
+                item.add_marker(skip_console)
 
 
 @pytest.fixture(scope="session")
 def mapdl_console(request):
-    ansys_base_paths = _get_available_base_ansys()
-
     if os.name != 'posix':
         raise RuntimeError('"--console" testing option unavailable.  '
                            'Only Linux is supported.')
+    ansys_base_paths = _get_available_base_ansys()
 
     # find a valid version of corba
     console_path = None
@@ -78,6 +75,8 @@ def mapdl_console(request):
                            'Valid versions are up to 2020R2.')
 
     mapdl = launch_mapdl(console_path)
+    from ansys.mapdl.core.mapdl_console import MapdlConsole
+    assert isinstance(mapdl, MapdlConsole)
     mapdl._show_matplotlib_figures = False  # CI: don't show matplotlib figures
 
     # using yield rather than return here to be able to test exit
@@ -98,7 +97,7 @@ def mapdl_corba(request):
     # find a valid version of corba
     corba_path = None
     for version in ansys_base_paths:
-        if version >= 170 and version < 211:
+        if version >= 170 and version < 202:
             corba_path = get_ansys_bin(str(version))
 
     if corba_path is None:
@@ -107,6 +106,8 @@ def mapdl_corba(request):
                            'Valid versions are ANSYS 17.0 up to 2020R2.')
 
     mapdl = launch_mapdl(corba_path)
+    from ansys.mapdl.core.mapdl_corba import MapdlCorba
+    assert isinstance(mapdl, MapdlCorba)
     mapdl._show_matplotlib_figures = False  # CI: don't show matplotlib figures
 
     # using yield rather than return here to be able to test exit

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,6 +1,6 @@
-"""Test legacy MAPDL CORBA interface
+"""Test legacy MAPDL console interface
 
-This has been copied from ma
+This has been copied from test_mapdl.py
 
 """
 import time
@@ -21,7 +21,7 @@ import ansys.mapdl.core as pymapdl
 skip_no_xserver = pytest.mark.skipif(not system_supports_plotting(),
                                      reason="Requires active X Server")
 
-# skip entire module unless --corba is enabled
+# skip entire module unless --console is enabled
 pytestmark = pytest.mark.console
 
 

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -1,6 +1,6 @@
 """Test legacy MAPDL CORBA interface
 
-This has been copied from ma
+This has been copied from test_mapdl.py
 
 """
 import time
@@ -23,6 +23,7 @@ skip_no_xserver = pytest.mark.skipif(not system_supports_plotting(),
 
 # skip entire module unless --corba is enabled
 pytestmark = pytest.mark.corba
+
 
 @pytest.fixture(scope='function')
 def cleared(mapdl_corba):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -52,7 +52,6 @@ def test_find_ansys_linux():
     assert isinstance(ver, float)
 
 
-@pytest.mark.skipif(not get_start_instance(), reason="Requires ANSYS install")
 def test_invalid_mode():
     with pytest.raises(ValueError):
         exec_file = get_ansys_bin(valid_versions[0])


### PR DESCRIPTION
This PR patches `launch_mapdl` so that it works in Windows 2020R2.  The ``LocalMapdlPool`` also now requires `grpc` mode.  There are also some misc. testing fixes for windows under CORBA as well as patches for github workflow CI.

Commits:

- allow launcher to use v202
- fix trigger config on github workflow
- hotfix for mapdl pool 2020R2
- patch corba testing for windows

Bumps version to 0.57.2