### PR TITLE
Fix menu and push docs using github action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,8 +4,7 @@ name: Documentation Build
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  docs_build:
     runs-on: ubuntu-20.04
 
     env:
@@ -62,21 +61,11 @@ jobs:
           path: docs/build/html
           retention-days: 7
 
-      - name: Deploy Documentation
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          git clone --no-checkout --depth 1 https://$GH_PAT@github.com/pyansys/pymapdl.git /tmp/gh_pages
-          cd /tmp/gh_pages
-          git checkout --orphan gh-pages
-          rm -rf *
-          git config user.name $GH_USERNAME
-          git config user.email $GH_EMAIL
-          cp -r $GITHUB_WORKSPACE/docs/build/html/* .
-          touch .nojekyll
-          git add .
-          git commit -am "CI: Updated site via $GITHUB_SHA"
-          git push -u origin gh-pages -f
-        env:
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          GH_PAT: ${{ secrets.REPO_DOWNLOAD_PAT }}
-          GH_EMAIL: ${{ secrets.GH_EMAIL }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/build/html
+          CLEAN: true

--- a/docs/source/_static/css/ansys.css
+++ b/docs/source/_static/css/ansys.css
@@ -14,6 +14,9 @@ h1, h2, h3, h4, h5, h6 {
     font-family: 'Source Sans Pro', sans-serif;
 }
 
+.navbar-toggler-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255,255,255, 0.9)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E") !important;
+}
 
 .sig-prename {
     color: var(--ansysBronze);


### PR DESCRIPTION
This PR patches the `ci-build.yml` documentation deployment step when tagged.  Previously, home built step triggers additional unnecessary CI and is overly complicated.  This PR proposes using `JamesIves/github-pages-deploy-action` instead as in DPF-Core and DPF-Post.

Also, like DPF-Core and DPF-Post, this PR implements a white menu when the doc page is narrow enough to obscure the section titles in the navbar.  The Ansys css modifications to the pydata theme makes the nav-bar black, making this change necessary to use the menu.
