### PR TITLE
Fix ambigious imports

### DIFF
--- a/ansys/mapdl/core/_version.py
+++ b/ansys/mapdl/core/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-core module."""
 
 # major, minor, patch
-version_info = 0, 57, 3
+version_info = 0, 57, 4
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/core/convert.py
+++ b/ansys/mapdl/core/convert.py
@@ -46,7 +46,7 @@ def convert_script(filename_in, filename_out, loglevel='WARNING', auto_exit=True
 
     Examples
     --------
-    >>> import ansys.mapdl.core as pymapdl
+    >>> from ansys.mapdl import core as pymapdl
     >>> from ansys.mapdl.core import examples
     >>> clines = pymapdl.convert_script(examples.vmfiles['vm1'], 'vm1.py')
     """

--- a/ansys/mapdl/core/examples/downloads.py
+++ b/ansys/mapdl/core/examples/downloads.py
@@ -5,7 +5,7 @@ import os
 import urllib.request
 import zipfile
 
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 
 
 def get_ext(filename):

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -10,7 +10,7 @@ import socket
 import time
 import subprocess
 
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core.misc import is_float, random_string, create_temp_dir
 from ansys.mapdl.core.errors import LockFileException, VersionError
 from ansys.mapdl.core.mapdl_grpc import MapdlGrpc

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -15,7 +15,7 @@ import scooby
 
 from ansys.mapdl.reader import Archive
 
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core.mapdl_functions import _MapdlCommands
 from ansys.mapdl.core.misc import (random_string, supress_logging,
                                    run_as_prep7, last_created)

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -158,7 +158,7 @@ class MapdlGrpc(_MapdlCore):
     Connect to an instance of MAPDL already running on locally on the
     default port 50052.
 
-    >>> import ansys.mapdl.core as pymapdl
+    >>> from ansys.mapdl import core as pymapdl
     >>> mapdl = pymapdl.Mapdl()
 
     Connect to an instance of MAPDL running on the LAN on a default port

--- a/ansys/mapdl/core/parameters.py
+++ b/ansys/mapdl/core/parameters.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ansys.mapdl.reader._reader import write_array
 
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core.mapdl import _MapdlCore
 from ansys.mapdl.core.misc import supress_logging
 

--- a/docs/source/user_guide/convert.rst
+++ b/docs/source/user_guide/convert.rst
@@ -131,7 +131,7 @@ This verification file was translated using:
 
 .. code:: python
 
-    >>> import ansys.mapdl.core as pymapdl
+    >>> from ansys.mapdl import core as pymapdl
     >>> from ansys.mapdl.core import examples
     >>> pymapdl.convert_script(examples.vmfiles['vm1'], 'vm1.py')
 

--- a/docs/source/user_guide/launcher.rst
+++ b/docs/source/user_guide/launcher.rst
@@ -32,7 +32,7 @@ the path again.  If you need to change the default ansys path
 
 .. code:: python
 
-    import ansys.mapdl.core as pymapdl
+    from ansys.mapdl import core as pymapdl
     new_path = 'C:\\Program Files\\ANSYS Inc\\v211\\ANSYS\\bin\\winx64\\ansys211.exe'
     pymapdl.change_default_ansys_path(new_path)
 

--- a/docs/source/user_guide/mapdl.rst
+++ b/docs/source/user_guide/mapdl.rst
@@ -96,7 +96,7 @@ using the ``convert_script`` function and setting
 
 .. code:: python
 
-    >>> import ansys.mapdl.core as pymapdl
+    >>> from ansys.mapdl import core as pymapdl
     >>> pymapdl.convert_script(apdl_inputfile, pyscript, macros_as_functions=True)
 
 

--- a/docs/source/user_guide/mapdl_examples.rst
+++ b/docs/source/user_guide/mapdl_examples.rst
@@ -6,7 +6,7 @@ simply use the built-in ``convert_script`` function within ``ansys-mapdl-core`` 
 
 .. code:: python
 
-    >>> import ansys.mapdl.core as pymapdl
+    >>> from ansys.mapdl import core as pymapdl
     >>> inputfile = 'ansys_inputfile.inp'
     >>> pyscript = 'pyscript.py'
     >>> pymapdl.convert_script(inputfile, pyscript)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -16,7 +16,7 @@ from ansys.mapdl.reader import examples
 
 from ansys.mapdl.core.misc import random_string
 from ansys.mapdl.core.errors import MapdlRuntimeError
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 
 skip_no_xserver = pytest.mark.skipif(not system_supports_plotting(),
                                      reason="Requires active X Server")

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core import examples
 
 

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -16,7 +16,7 @@ from ansys.mapdl.reader import examples
 
 from ansys.mapdl.core.misc import random_string
 from ansys.mapdl.core.errors import MapdlRuntimeError
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 
 skip_no_xserver = pytest.mark.skipif(not system_supports_plotting(),
                                      reason="Requires active X Server")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -3,7 +3,7 @@ import weakref
 import os
 import pytest
 
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core.misc import get_ansys_bin
 from ansys.mapdl.core.launcher import get_start_instance
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -12,7 +12,7 @@ from ansys.mapdl.reader import examples
 
 from ansys.mapdl.core.misc import random_string
 from ansys.mapdl.core.errors import MapdlRuntimeError
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 
 skip_no_xserver = pytest.mark.skipif(not system_supports_plotting(),
                                      reason="Requires active X Server")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,7 @@ import pyvista as pv
 import pytest
 from pyvista.plotting import system_supports_plotting
 
-import ansys.mapdl.core as pymapdl
+from ansys.mapdl import core as pymapdl
 
 def test_report():
     report = pymapdl.Report(gpu=system_supports_plotting())


### PR DESCRIPTION
This PR fixes a potential bug with imports with:
```py
import ansys.mapdl.core as pymapdl
```
by changing it to:
```py
from ansys.mapdl import core as pymapdl
```

There is some unexplained behavior with the first import style occurring on certain configurations, and to make it platform/environment independent, the `from ... import` is employed with this PR. 
