### PR TITLE
add ability to ignore errors

### DIFF
--- a/ansys/mapdl/core/_version.py
+++ b/ansys/mapdl/core/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-core module."""
 
 # major, minor, patch
-version_info = 0, 57, 4
+version_info = 0, 57, 5
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -194,9 +194,22 @@ def test_al(cleared, mapdl):
     assert a0 == 1
 
 
-def test_invalid_area(mapdl):
+def test_error(mapdl):
     with pytest.raises(MapdlRuntimeError):
         mapdl.a(0, 0, 0, 0)
+
+
+def test_ignore_error(mapdl):
+    assert not mapdl.ignore_errors
+    mapdl.ignore_errors = True
+    assert mapdl.ignore_errors is True
+
+    # verify that an error is not raised
+    out = mapdl._run('A, 0, 0, 0')
+    assert '*** ERROR ***' in out
+
+    mapdl.ignore_error = False
+    assert mapdl.ignore_error is False
 
 
 def test_invalid_input(mapdl):


### PR DESCRIPTION
This PR corrects a bug where the following error is mis-reported by Python:

```py

 *** ERROR ***                           CP =      64.000   TIME= XX:XX:XX
 Element 1 (PLANE182) is turning inside out.
```

This PR also adds the ability to ignore errors when setting ``mapdl.ignore_errors = True``:

```py
mapdl.ignore_errors = True
mapdl.a(0, 0, 0, 0)  # normally raises an error
```

Bumps version to 0.57.5
