### PR TITLE
Feature: Health Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tests/cyclic/htmlcov
 .coverage
 *,cover
 .benchmarks/
+test-output.xml
 
 \#*
 .\#*

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1920,7 +1920,8 @@ class _MapdlCore(_MapdlCommands):
             pass
 
         # os independent path format
-        self._path = self._path.replace('\\', '/')
+        if self._path is not None:
+            self._path = self._path.replace('\\', '/')
         return self._path
 
     @property

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -349,8 +349,11 @@ class MapdlGrpc(_MapdlCore):
                                     ' the MAPDL server')
 
         self._health_response_queue = Queue()
+
+        # allow main process to exit by setting daemon to true
         thread = threading.Thread(target=_consume_responses,
-                                  args=(rendezvous, self._health_response_queue))
+                                  args=(rendezvous, self._health_response_queue),
+                                  daemon=True)
         thread.start()
 
 

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -327,6 +327,12 @@ class MapdlGrpc(_MapdlCore):
         self._health_stub = health_pb2_grpc.HealthStub(self._channel)
         rendezvous = self._health_stub.Watch(request)
 
+        try:
+            status = rendezvous.next()
+            status = health_pb2.HealthCheckResponse.SERVING
+        except:
+            breakpoint()
+
         self._health_response_queue = Queue()
         thread = threading.Thread(target=_consume_responses,
                                   args=(rendezvous, self._health_response_queue))

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,10 @@ install_requires = [
     'pyiges>=0.1.2',
     'scipy>=1.3.0',  # for sparse (consider optional?)
     'google-api-python-client',
-    'grpcio>=1.30.0',
+    'grpcio>=1.30.0',  # tested up to grpcio==1.35
     'ansys-grpc-mapdl==0.2.0',
     'ansys-mapdl-reader>=0.50.0',
+    'grpcio-health-checking>=1.30.0',
     'ansys-corba',  # pending depreciation to ansys-mapdl-corba
 ]
 


### PR DESCRIPTION
Implement health checking.  While we don't actually do much server-side handling of the status, merely adding this health check service will inform the user if you loose connection with MAPDL.  This is a huge plus as you don't actually have to send a command to get the status of the server.

As it's going to be implemented in 2021R2, this feature has a huge try/except that handles the `NOTIMPLEMENTED` status.