### PR TITLE
Disable health check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     'ansys-mapdl-reader>=0.50.0',
     'grpcio-health-checking>=1.30.0',
     'ansys-corba',  # pending depreciation to ansys-mapdl-corba
-    'protobuf>=3.1.4',  # had an issue with gRPC health checking
+    'protobuf>=3.1.4',  # had an issue with gRPC health checking with this version
 ]
 
 # these are only used when launching a MAPDL via a console.  This


### PR DESCRIPTION
Internal testing shows health check to be unable with MAPDL development version.  Disabling check by default, but leaving method included in source.

Move imports to within the health check method.  Lazy imports can be an anti-pattern, but in this case it's useful as we avoid loading the health check module upon loading the package.  Improves load time, reduces possibility of running into import issues.

Unit testing will reveal faults if/when health check is fully implemented server-side.