### PR TITLE
Improve Elastic Licencing Compatibility 

### DIFF
--- a/ansys/mapdl/core/_version.py
+++ b/ansys/mapdl/core/_version.py
@@ -1,7 +1,14 @@
-"""Version of ansys-mapdl-core module."""
+"""Version of ansys-mapdl-core module.
+
+On the ``master`` branch, use 'dev0' to denote a development version.
+For example:
+
+version_info = 0, 58, 'dev0'
+
+"""
 
 # major, minor, patch
-version_info = 0, 58, 0
+version_info = 0, 58, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -91,7 +91,7 @@ def port_in_use(port, host=LOCALHOST):
 def launch_grpc(exec_file='', jobname='file', nproc=2, ram=None,
                 run_location=None, port=MAPDL_DEFAULT_PORT,
                 additional_switches='', custom_bin=None,
-                override=True, timeout=10) -> int:
+                override=True, timeout=20, verbose=False) -> int:
     """Start MAPDL locally in gRPC mode.
 
     Parameters
@@ -135,6 +135,11 @@ def launch_grpc(exec_file='', jobname='file', nproc=2, ram=None,
         Attempts to delete the lock file at the run_location.
         Useful when a prior MAPDL session has exited prematurely and
         the lock file has not been deleted.
+
+    verbose : bool, optional
+        Print all output when launching and running MAPDL.  Not
+        recommended unless debugging the MAPDL start.  Default
+        ``False``.
 
     Returns
     -------
@@ -277,13 +282,22 @@ def launch_grpc(exec_file='', jobname='file', nproc=2, ram=None,
     port_sw = '-port %d' % port
     grpc_sw = '-grpc'
 
+    # remove any temporary error files at the run location.  This is
+    # important because we need to know if MAPDL is already running
+    # here and because we're looking for any temporary files that are
+    # created to tell when the process has started
+    for filename in os.listdir(run_location):
+        if ".err" == filename[-4:] and jobname in filename:
+            try:
+                os.remove(filename)
+            except:
+                raise IOError('Unable to remove {filename}.  There might be '
+                              'an instance of MAPDL running at this location')
+
     # Windows will spawn a new window, only linux will let you use pexpect...
     if os.name == 'nt':
 
-        # # track PIDs since MAPDL isn't directly launched within the shell
-        # import psutil
-        # orig_pids = psutil.pids()
-
+        # track PIDs since MAPDL isn't directly launched within the shell
         tmp_inp = '.__tmp__.inp'
         with open(os.path.join(run_location, tmp_inp), 'w') as f:
             f.write('FINISH\r\n')
@@ -294,63 +308,39 @@ def launch_grpc(exec_file='', jobname='file', nproc=2, ram=None,
                    additional_switches, port_sw, grpc_sw]
         command = ' '.join(command)
 
-        subprocess.Popen(command, shell=False, cwd=run_location,
+    else:  # linux
+        # command = ' '.join(['"%s"' % exec_file, job_sw, cpu_sw,
+        #                     ram_sw, additional_switches, port_sw,
+        #                     grpc_sw])
+
+        command = ['%s' % exec_file, job_sw, cpu_sw,
+                   ram_sw, additional_switches, port_sw,
+                   grpc_sw]
+
+    if verbose:
+        subprocess.Popen(command,
+                         shell=False,
+                         cwd=run_location)
+    else:
+        subprocess.Popen(command,
+                         shell=False,
+                         cwd=run_location,
                          stdin=subprocess.DEVNULL,
                          stdout=subprocess.DEVNULL,
                          stderr=subprocess.DEVNULL)
 
-        # watch for the creation of temporary files at the run_directory
-        for _ in range(100):
-            # check if any error files have been created.  This is
-            # more reliable than using the lock file
+    # watch for the creation of temporary files at the run_directory.
+    # This lets us know that the MAPDL process has at least started
+    sleep_time = 0.1
+    for _ in range(int(timeout/sleep_time)):
+        # check if any error files have been created.  This is
+        # more reliable than using the lock file
 
-            files = os.listdir(run_location)
-            has_ans = any([filename for filename in files if ".err" in filename])
-            if has_ans:
-                break
-            time.sleep(0.1)
-
-    else:
-        # use pexpect on linux for better error reporting
-        import pexpect
-        from pexpect import popen_spawn
-
-        command = ' '.join(['"%s"' % exec_file, job_sw, cpu_sw,
-                            ram_sw, additional_switches, port_sw,
-                            grpc_sw])
-
-        process = popen_spawn.PopenSpawn(command,
-                                         timeout=timeout,
-                                         cwd=run_location)
-
-        try:
-            idx = process.expect(['Server listening',
-                                  'Another ANSYS job with the same job name',
-                                  'PRESS <CR> OR <ENTER> TO CONTINUE',
-                                  'Address already in use',
-                                  'ERROR'])
-
-            if idx == 1:
-                raise LockFileException()
-
-            if idx == 2:
-                process.sendline('')  # enter to continue
-                process.expect('Server listening', timeout=1)
-            elif idx == 3:
-                raise RuntimeError('Failed to start MAPDL gRPC at port %d.  ' % port
-                                   + 'Port appears to be already in use.  Please '
-                                   'specify a different port with the ``port`` '
-                                   'argument.')
-            elif idx > 3:  # catch all
-                msg = process.read().decode()
-                raise RuntimeError('Failed to start local MAPDL instance:\n"%s"'
-                                   % msg)
-        except pexpect.EOF:
-            msg = process.read().decode()
-            raise RuntimeError('Failed to start local MAPDL instance:\n"%s"' % msg)
-        except pexpect.TIMEOUT:
-            msg = process.before.decode()
-            raise RuntimeError('Failed to start local MAPDL instance:\n"%s"' % msg)
+        files = os.listdir(run_location)
+        has_ans = any([filename for filename in files if ".err" in filename])
+        if has_ans:
+            break
+        time.sleep(sleep_time)
 
     return port, run_location
 
@@ -575,7 +565,8 @@ def launch_mapdl(exec_file=None, run_location=None, jobname='file',
                  start_timeout=120, port=None,
                  custom_bin=None, cleanup_on_exit=True,
                  start_instance=True, ip=LOCALHOST,
-                 clear_on_connect=True, log_apdl=False, **kwargs):
+                 clear_on_connect=True, log_apdl=False,
+                 verbose_mapdl=False, **kwargs):
     """Start MAPDL locally in gRPC mode.
 
     Parameters
@@ -673,6 +664,11 @@ def launch_mapdl(exec_file=None, run_location=None, jobname='file',
 
     remove_temp_files : bool, optional
         Removes temporary files on exit.  Default ``False``.
+
+    verbose_mapdl : bool, optional
+        Enable printing of all output when launching and running
+        MAPDL.  This should be used for debugging only as output can
+        be tracked within pymapdl.  Default ``False``.
 
     Examples
     --------

--- a/ansys/mapdl/core/mapdl_console.py
+++ b/ansys/mapdl/core/mapdl_console.py
@@ -2,10 +2,11 @@
 
 Used when launching Mapdl via pexpect on Linux when <= 17.0
 """
+import os
 import time
 import re
 
-from ansys.mapdl.core.misc import kill_process
+# from ansys.mapdl.core.misc import kill_process
 from ansys.mapdl.core.mapdl import _MapdlCore
 from ansys.mapdl.core.errors import MapdlExitedError
 
@@ -200,5 +201,8 @@ class MapdlConsole(_MapdlCore):
             try:
                 self.exit()
             except:
-                kill_process(self._process.pid)
-                self._log.debug('Killed process %d' % self._process.pid)
+                try:
+                    os.kill(self._process.pid, 9)
+                except:
+                    self._log.warning('Unable to kill process %d', self._process.pid)
+                self._log.debug('Killed process %d', self._process.pid)

--- a/ansys/mapdl/core/misc.py
+++ b/ansys/mapdl/core/misc.py
@@ -34,13 +34,13 @@ def get_ansys_bin(rver):
     return mapdlbin
 
 
-def kill_process(proc_pid):
-    """Kill a process with extreme prejudice"""
-    import psutil  # imported here to avoid import errors when unused in windows
-    process = psutil.Process(proc_pid)
-    for proc in process.children(recursive=True):
-        proc.kill()
-    process.kill()
+# def kill_process(proc_pid):
+#     """Kill a process with extreme prejudice"""
+#     import psutil  # imported here to avoid import errors when unused in windows
+#     process = psutil.Process(proc_pid)
+#     for proc in process.children(recursive=True):
+#         proc.kill()
+#     process.kill()
 
 
 class Report(scooby.Report):
@@ -71,15 +71,14 @@ class Report(scooby.Report):
             a report.
 
         """
-        # Mandatory packages.
-        core = ['pyvista', 'vtk', 'numpy', 'scipy', 'appdirs', 'pexpect',
+        # Mandatory packages
+        core = ['pyvista', 'vtk', 'numpy', 'scipy', 'appdirs',
                 'ansys.mapdl.core', 'ansys.mapdl.reader']
-
         if os.name == 'linux':
-            core.extend(['psutil', 'pexpect'])
+            core.extend(['pexpect'])
 
-        # Optional packages.
-        optional = ['matplotlib', 'ansys.mapdl.corba']
+        # Optional packages
+        optional = ['matplotlib', 'ansys_corba']
 
         # Information about the GPU - bare except in case there is a rendering
         # bug that the user is trying to report.

--- a/docker/README.md
+++ b/docker/README.md
@@ -46,8 +46,17 @@ MAPDL with:
 LICENSE_SERVER=1055@XXX.XXX.XXX.XXX
 VERSION=v21.1.0
 
-IMAGE=docker.pkg.github.com/pyansys/mapdl/mapdl:$VERSION
-docker run -e ANSYSLMD_LICENSE_FILE=$LICENSE_SERVER -p 50052:50052 $IMAGE -smp
+IMAGE=docker.pkg.github.com/pyansys/pymapdl/mapdl:$VERSION
+docker run -e ANSYSLMD_LICENSE_FILE=$LICENSE_SERVER -p 50052:50052 $IMAGE
+```
+
+Note that if you use elastic licencing, input your elastic licencing
+credentials with:
+```
+ANSYS_ELASTIC_CLS=<CLSID>:<PIN>
+VERSION=v21.1.0
+IMAGE=docker.pkg.github.com/pyansys/pymapdl/mapdl:$VERSION
+docker run -e ANSYS_ELASTIC_CLS=$ANSYS_ELASTIC_CLS -p 50052:50052 $IMAGE
 ```
 
 Note that port `50052` (local to the container) is being mapped to
@@ -91,7 +100,7 @@ ANSYS Mechanical Enterprise
 
  Analysis type. . . . . . . . . . . . .Modal
 
- pyansys version: 0.53.0
+ pyansys version: 0.58.0
 ```
 
 Should you need to connect to the instance externally, simply set the

--- a/setup.py
+++ b/setup.py
@@ -24,15 +24,16 @@ install_requires = [
     'grpcio>=1.30.0',  # tested up to grpcio==1.35
     'ansys-grpc-mapdl==0.2.0',
     'ansys-mapdl-reader>=0.50.0',
-    'grpcio-health-checking>=1.30.0',
     'ansys-corba',  # pending depreciation to ansys-mapdl-corba
     'protobuf>=3.1.4',  # had an issue with gRPC health checking with this version
 ]
+# 'grpcio-health-checking>=1.30.0',
+
 
 # these are only used when launching a MAPDL via a console.  This
 # feature is subject to be removed or moved out of this module.
 if os.name == 'linux':
-    install_requires.extend(['psutil>=5.0.0', 'pexpect>=4.8.0'])
+    install_requires.extend(['pexpect>=4.8.0'])
 
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import pytest
 import pyvista
@@ -50,6 +51,17 @@ alexander.kaszynski@ansys.com
 
 if START_INSTANCE and EXEC_FILE is None:
     raise RuntimeError(ERRMSG)
+
+
+def check_pid(pid):
+    """ Check For the existence of a pid."""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -188,6 +200,11 @@ def mapdl(request, tmpdir_factory):
             mapdl._send_command('/PREP7')
         with pytest.raises(MapdlExitedError):
             mapdl._send_command_stream('/PREP7')
+
+        # verify PIDs are closed
+        time.sleep(1)  # takes a second for the processes to shutdown
+        for pid in mapdl._pids:
+            assert not check_pid(pid)
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -17,8 +17,9 @@ for rver in valid_rver:
         EXEC_FILE = get_ansys_bin(rver)
         break
 
+IGNORE_POOL = os.environ.get('IGNORE_POOL', '').upper() == 'TRUE'
 
-skip_launch_mapdl = pytest.mark.skipif(get_start_instance() is False,
+skip_launch_mapdl = pytest.mark.skipif(get_start_instance() is False or IGNORE_POOL,
                                        reason="Must be able to launch MAPDL locally")
 
 TWAIT = 90


### PR DESCRIPTION
This PR makes `mapdl_grpc` compatible with ANSYS elastic licencing.  Removing `pexpect` under Linux was necessary as the output is slightly different when using it locally.

Adds minor documentation fixes and bumps the version to a "development version".