### PR TITLE
Fix logging on MAPDL task

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -53,8 +53,9 @@ jobs:
         set -ex
         echo $(GH_PAT) | docker login -u $(GH_USERNAME) --password-stdin docker.pkg.github.com
         docker pull $(MAPDL_IMAGE)
+        touch log.txt
         docker run -e ANSYSLMD_LICENSE_FILE=1055@$(LICENSE_SERVER) --restart always --name mapdl -p $(PYMAPDL_PORT):50052 $(MAPDL_IMAGE) -smp > log.txt &
-        grep -q 'Server listening on' <(timeout 60 tail -f log.txt)
+        grep -q 'Server listening on' <(timeout 60 tail --retry -f log.txt)
         python -c "from ansys.mapdl.core import launch_mapdl; print(launch_mapdl())"
       displayName: Pull, launch, and validate MAPDL service
 


### PR DESCRIPTION
Our builds fail sometimes on the "Pull, launch, and validate MAPDL service".  Issue arises from `tail -f` of a non-existant logging file.  For more details see:
https://dev.azure.com/pyansys/pyansys/_build/results?buildId=753&view=results

Simple fix is to touch `log.txt` to ensure the file exists, but and to also add `--reply` to give tail a few extra chances to check if the file exists. 