### PR TITLE
Fix Launcher for Linux

### DIFF
--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -327,16 +327,14 @@ def launch_grpc(exec_file='', jobname='file', nproc=2, ram=None,
     if verbose:
         subprocess.Popen(command,
                          shell=False,
-                         cwd=run_location,
-                         env=os.environ.copy())
+                         cwd=run_location)
     else:
         subprocess.Popen(command,
                          shell=False,
                          cwd=run_location,
                          stdin=subprocess.DEVNULL,
                          stdout=subprocess.DEVNULL,
-                         stderr=subprocess.DEVNULL,
-                         env=os.environ.copy())
+                         stderr=subprocess.DEVNULL)
 
     # watch for the creation of temporary files at the run_directory.
     # This lets us know that the MAPDL process has at least started

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -309,32 +309,22 @@ def launch_grpc(exec_file='', jobname='file', nproc=2, ram=None,
         command = ' '.join(command)
 
     else:  # linux
-        # command = ' '.join(['"%s"' % exec_file, job_sw, cpu_sw,
-        #                     ram_sw, additional_switches, port_sw,
-        #                     grpc_sw])
+        command = ' '.join(['"%s"' % exec_file, job_sw, cpu_sw,
+                            ram_sw, additional_switches, port_sw,
+                            grpc_sw])
 
-        command = []
-        if 'ubuntu' in platform.platform().lower():
-            if '-smp' not in additional_switches:
-                # Ubuntu ANSYS fails to launch without I_MPI_SHM_LMT
-                command.extend(['env', 'I_MPI_SHM_LMT=shm'])
-
-        command.extend(['%s' % exec_file, job_sw, cpu_sw,
-                        ram_sw, additional_switches, port_sw,
-                        grpc_sw])
-
-    # breakpoint()
     if verbose:
         subprocess.Popen(command,
-                         shell=False,
+                         shell=os.name != 'nt',
                          cwd=run_location)
     else:
         subprocess.Popen(command,
-                         shell=False,
+                         shell=os.name != 'nt',
                          cwd=run_location,
                          stdin=subprocess.DEVNULL,
                          stdout=subprocess.DEVNULL,
                          stderr=subprocess.DEVNULL)
+
 
     # watch for the creation of temporary files at the run_directory.
     # This lets us know that the MAPDL process has at least started

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -142,8 +142,8 @@ class MapdlGrpc(_MapdlCore):
         error messages.
 
     cleanup_on_exit : bool, optional
-        Exit MAPDL when python exits or the mapdl Python instance is
-        garbage collected.
+        Exit MAPDL when Python exits or when this instance is garbage
+        collected.
 
     set_no_abort : bool, optional
         Sets MAPDL to not abort at the first error within /BATCH mode.


### PR DESCRIPTION
This PR reverts part of the launcher to permit Python to pass I_MPI_SHM_LMT=True to MAPDL.  This corrects a problem on Ubuntu that causes MAPDL with DMP to fail to launch.