### PR TITLE
Append NOSTART to /CLEAR even when run as string

### DIFF
--- a/ansys/mapdl/core/mapdl_functions.py
+++ b/ansys/mapdl/core/mapdl_functions.py
@@ -16787,50 +16787,6 @@ class _MapdlCommands(_MapdlGeometryCommands):  # pragma: no cover
         command = "MAGSOLV,%s,%s,%s,%s,%s,%s,%s" % (str(opt), str(nramp), str(cnvcsg), str(cnvflux), str(neqit), str(biot), str(cnvtol))
         return self.run(command, **kwargs)
 
-    def clear(self, read="NOSTART", **kwargs):
-        """APDL Command: /CLEAR
-
-        Clears the database.
-
-        Parameters
-        ----------
-        read
-            File read option:
-
-            START - Reread startXXX.ans file.
-
-            NOSTART - Do not reread startXXX.ans file (default).
-
-        Notes
-        -----
-        Resets the ANSYS database to the conditions at the beginning of the
-        problem.  Sets the import and Boolean options back to the ANSYS
-        default. All items are deleted from the database and memory values are
-        set to zero for items derived from database information.  All files are
-        left intact.  This command is useful between multiple analyses in the
-        same run, or between passes of a multipass analysis (such as between
-        the substructure generation, use, and expansion passes).  Should not be
-        used in a do-loop since loop counters will be reset.  The start162.ans
-        file will be reread (by default) after the database is cleared, unless
-        Read is set to NOSTART.  Additional commands cannot be stacked (using
-        the $ separator) on the same line as the /CLEAR command.
-
-        Use care when placing the /CLEAR command within branching constructs
-        (for example, those employing \*DO or \*IF commands).  The command
-        deletes all parameters including the looping parameter for do-loops.
-        (You can preserve your iteration parameter by issuing a PARSAV command
-        prior to the /CLEAR command, then following the /CLEAR command with a
-        PARRES command.)
-
-        /CLEAR resets the jobname to match the currently open session .LOG and
-        .ERR files. This will return the jobname to its original value, or to
-        the most recent value specified on /FILNAME with KEY = 1.
-
-        This command is valid only at the Begin level.
-        """
-        command = "/CLEAR,%s" % (str(read))
-        return self.run(command, **kwargs)
-
     def hrexp(self, angle="", **kwargs):
         """APDL Command: HREXP
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -14,10 +14,19 @@ def test_clear_nostart(mapdl):
     assert 'CLEAR ANSYS DATABASE AND RESTART' in resp
 
 
+# NOTE: This command cannot be run repeately, otherwise we end up with
+# to many levels of /INPUT.  2021R2 should have a fix for this
 def test_clear(mapdl):
     resp = mapdl._send_command('FINISH')
     resp = mapdl._send_command('/CLEAR')
     assert 'CLEAR' in resp
+
+
+def test_clear_multiple(mapdl):
+    # simply should not fail.  See:
+    # https://github.com/pyansys/pymapdl/issues/380
+    for i in range(20):
+        mapdl.run('/CLEAR')
 
 
 def test_invalid_get(mapdl):


### PR DESCRIPTION
Append NOSTART based on feedback from #380.  Includes an additional test for this.

On MAPDL server side, will ensure that commands from an input file with `/CLEAR` have NOSTART appended.