### PR TITLE
Fix Version casematch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,11 +212,11 @@ License and Acknowledgments
 ---------------------------
 ``PyMAPDL`` is licensed under the MIT license.
 
-This module, ``ansys-mapdl-core`` makes no commercial claim over ANSYS
+This module, ``ansys-mapdl-core`` makes no commercial claim over Ansys
 whatsoever.  This tool extends the functionality of ``MAPDL`` by
 adding a Python interface to the MAPDL service without changing the
 core behavior or license of the original software.  The use of the
 interactive APDL control of ``PyMAPDL`` requires a legally licensed
-local copy of ANSYS.
+local copy of Ansys.
 
-To get a copy of ANSYS, please visit `ANSYS <https://www.ansys.com/>`_.
+To get a copy of Ansys, please visit `Ansys <https://www.ansys.com/>`_.

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -532,14 +532,14 @@ def change_default_ansys_path(exe_loc):
 
     Examples
     --------
-    Change default ansys location on Linux
+    Change default Ansys location on Linux
 
     >>> from ansys.mapdl.core import launcher
     >>> launcher.change_default_ansys_path('/ansys_inc/v201/ansys/bin/ansys201')
     >>> launcher.get_ansys_path()
     '/ansys_inc/v201/ansys/bin/ansys201'
 
-    Change default ansys location on Windows
+    Change default Ansys location on Windows
 
     >>> ans_pth = 'C:/Program Files/ANSYS Inc/v193/ansys/bin/win64/ANSYS193.exe'
     >>> launcher.change_default_ansys_path(ans_pth)

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -425,7 +425,7 @@ def _get_available_base_ansys():
     """
     base_path = None
     if os.name == 'nt':
-        supported_versions = [194, 202, 211, 212]
+        supported_versions = [194, 202, 211, 212, 221]
         awp_roots = {ver: os.environ.get(f'AWP_ROOT{ver}', '') for ver in supported_versions}
         installed_versions = {ver: path for ver, path in awp_roots.items() if path and os.path.isdir(path)}
         if installed_versions:

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -76,7 +76,8 @@ def _version_from_path(path):
     """
     # expect v<ver>/ansys
     # replace \\ with / to account for possible windows path
-    matches = re.findall(r'v(\d\d\d).ansys', path.replace('\\', '/'))
+    matches = re.findall(r'v(\d\d\d).ansys', path.replace('\\', '/'),
+                         re.IGNORECASE)
     if not matches:
         raise RuntimeError(f'Unable to extract Ansys version from {path}')
     return int(matches[-1])

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -417,11 +417,11 @@ class MapdlGrpc(_MapdlCore):
 
         Examples
         --------
-        Run a basic command
+        Run a basic command.
 
         >>> mapdl.run('/PREP7')
 
-        Run a command and supress its output
+        Run a command and suppress its output.
 
         >>> mapdl.run('/PREP7', mute=True)
 

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -402,7 +402,7 @@ class MapdlGrpc(_MapdlCore):
         return self._mesh_rep
 
     def _run(self, cmd, verbose=False, mute=False):
-        """Sends a command and returns the response as a string.
+        """Sens a command and return the response as a string.
 
         Parameters
         ----------
@@ -414,6 +414,21 @@ class MapdlGrpc(_MapdlCore):
 
         mute : bool, optional
             Request that no output be sent from the gRPC server.
+
+        Examples
+        --------
+        Run a basic command
+
+        >>> mapdl.run('/PREP7')
+
+        Run a command and supress its output
+
+        >>> mapdl.run('/PREP7', mute=True)
+
+        Run a command and stream its output while it is being run.
+
+        >>> mapdl.run('/PREP7', mute=True)
+
         """
         if self._exited:
             raise MapdlExitedError

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ warnings.filterwarnings(
 # -- Project information -----------------------------------------------------
 
 project = 'ansys.mapdl.core'
-copyright = '2020, ANSYS'
+copyright = '2021, ANSYS'
 author = 'ANSYS Open Source Developers'
 
 # The short X.Y version
@@ -93,8 +93,12 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Copy button customization ---------------------------------------------------
+# exclude traditional Python prompts from the copied code
+copybutton_prompt_text = ">>> "
 
-# -- Sphinx Gallery Options
+
+# -- Sphinx Gallery Options ---------------------------------------------------
 from sphinx_gallery.sorting import FileNameSortKey
 
 sphinx_gallery_conf = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,7 +60,7 @@ Quick Code
 ----------
 Here's a brief example of how PyMAPDL works:
 
-.. code:: 
+.. code:: python
 
     >>> from ansys.mapdl.core import launch_mapdl
     >>> mapdl = launch_mapdl()

--- a/docs/source/user_guide/mapdl.rst
+++ b/docs/source/user_guide/mapdl.rst
@@ -100,6 +100,33 @@ using the ``convert_script`` function and setting
     >>> pymapdl.convert_script(apdl_inputfile, pyscript, macros_as_functions=True)
 
 
+
+Additional Options When Running Commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Commands can be run in ``mute`` or ``verbose`` mode, which allows you
+to supress or print the output in as it is being run for any MAPDL
+command.  This can be especially helpful for long-running commands
+like ``SOLVE``.  This works for the pythonic wrapping of all commands
+and when using ``run``.
+
+Run a command and supress its output
+
+.. code:: python
+
+    >>> mapdl.run('/PREP7', mute=True)
+    >>> mapdl.prep7(mute=True)
+
+Run a command and stream its output while it is being run.
+
+.. code:: python
+
+    >>> mapdl.run('SOLVE', mute=True)
+    >>> mapdl.solve(verbose=True)
+
+.. note::
+    This feature is only available when running MAPDL in gRPC mode.
+
+
 Conditional Statements and Loops
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 APDL conditional statements such as ``*IF`` must be either implemented

--- a/docs/source/user_guide/mapdl.rst
+++ b/docs/source/user_guide/mapdl.rst
@@ -104,12 +104,12 @@ using the ``convert_script`` function and setting
 Additional Options When Running Commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Commands can be run in ``mute`` or ``verbose`` mode, which allows you
-to supress or print the output in as it is being run for any MAPDL
+to suppress or print the output in as it is being run for any MAPDL
 command.  This can be especially helpful for long-running commands
 like ``SOLVE``.  This works for the pythonic wrapping of all commands
 and when using ``run``.
 
-Run a command and supress its output
+Run a command and suppress its output:
 
 .. code:: python
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -10,5 +10,5 @@ pytest-sphinx
 sphinx-notfound-page>=0.3.0
 sphinx-copybutton
 sphinx-gallery>=0.8.1
-pydata-sphinx-theme
+pydata-sphinx-theme==0.5.0
 pypandoc


### PR DESCRIPTION
Ansys paths used to be capitalized in older versions of Ansys (e.g. ansys vs ANSYS) and the `_version_from_path` reports being unable to extract the path.

This PR fixes this and includes additional documentation based on user feedback when installing MAPDL on Ubuntu.
