### PR TITLE
Fix load_array docs and GUI launcher

### DIFF
--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -301,7 +301,6 @@ class MapdlGrpc(_MapdlCore):
 
         # TODO: version check
 
-
         # enable health check
         if enable_health_check:
             self._enable_health_check()
@@ -358,7 +357,7 @@ class MapdlGrpc(_MapdlCore):
                                   daemon=True)
         thread.start()
 
-    def _launch(self, start_parm):
+    def _launch(self, start_parm, timeout=10):
         """Launch a local session of MAPDL in gRPC mode.
 
         This should only need to be used for legacy ``open_gui``
@@ -370,6 +369,21 @@ class MapdlGrpc(_MapdlCore):
         self._exited = False  # reset exit state
         port, directory = launch_grpc(**start_parm)
         self._connect(port)
+
+        # may need to wait for viable connection in open_gui case
+        tmax = time.time() + timeout
+        success = False
+        while time.time() < tmax:
+            try:
+                self.prep7()
+                success = True
+                break
+            except:
+                pass
+
+        if not success:
+            breakpoint()
+            raise RuntimeError('Unable to reconnect to MAPDL')
 
     @property
     def post_processing(self):

--- a/docs/source/user_guide/mapdl.rst
+++ b/docs/source/user_guide/mapdl.rst
@@ -494,10 +494,10 @@ each command individually.
 Sending Arrays to MAPDL
 -----------------------
 You can send ``numpy`` arrays or Python lists directly to MAPDL using
-``load_array``.  This is far more efficient than individually sending
-parameters to MAPDL through python or MAPDL.  It uses ``*VREAD``
-behind the scenes and will be replaced with a faster interface in the
-future.
+``parameters['MY_ARRAY_NAME']``.  This is far more efficient than
+individually sending parameters to MAPDL through Python with ``run``.
+It uses ``*VREAD`` behind the scenes and will be replaced with a
+faster interface in the future.
 
 .. code:: python
 
@@ -505,20 +505,20 @@ future.
     import numpy as np
     mapdl = launch_mapdl()
     arr = np.random.random((5, 3))
-    mapdl.load_array(arr, 'MYARR')
+    mapdl.parameters['MYARR'] = arr
 
-Verify the data has been properly loaded to MAPDL by accessing the
-first element.  Note that MAPDL uses fortran (1) based indexing.
+Verify the data has been properly loaded to MAPDL by indexing
+``mapdl.parameters`` as if it was a Python dictionary:
 
 .. code:: python
 
-   >>> mapdl.read_float_parameter('MYARR(1, 1)')
-   2020-07-03 21:49:54,387 [INFO] mapdl: MYARR(1, 1) = MYARR(1, 1)
-
-   PARAMETER MYARR(1,1) =    0.7960742456
-
-   >>> arr[0]
-   0.7960742456194109
+   >>> array_from_mapdl = mapdl.parameters['MYARR']
+   >>> array_from_mapdl
+   array([[0.65516567, 0.96977939, 0.3224993 ],
+          [0.58634927, 0.84392263, 0.18152529],
+          [0.76719759, 0.45748876, 0.56432361],
+          [0.78548338, 0.01042177, 0.57420062],
+          [0.33189362, 0.9681039 , 0.47525875]])
 
 
 Downloading a Remote MAPDL File

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -15,7 +15,9 @@ except:
 
 # CORBA and console available versions
 versions = [
-    '182',
+    '170',  # 17.0
+    '182',  # 18.2
+    '182',  # 18.2
     '190',  # 19.0
     '191',  # 19.1
     '192',  # 19.2


### PR DESCRIPTION
Resolves #390 and #389 by correcting the documentation on `load_array` noting the shift to ``parameters``.

When resolving #390, identified the GUI will launch properly, but will fail to return to the console in certain cases.  A timeout for `_launch` was added along with correct treatment of "Begin Level" vs "BEGIN" for SMP vs. DMP.
