### PR TITLE
Improve parameters setter stability

### DIFF
--- a/ansys/mapdl/core/io_commands.py
+++ b/ansys/mapdl/core/io_commands.py
@@ -1,0 +1,75 @@
+import os
+
+
+class _MapdlIoCommands():
+    """Methods specific to MAPDL IO"""
+
+    def parres(self, lab="", fname="", ext="", **kwargs):
+        """APDL Command: PARRES
+
+        Reads parameters from a file.
+
+        Parameters
+        ----------
+        lab
+            Read operation.
+
+            NEW - Replace current parameter set with these parameters (default).
+
+            CHANGE - Extend current parameter set with these
+            parameters, replacing any that already exist.
+
+        fname
+            File name and directory path (248 characters maximum,
+            including the characters needed for the directory path).
+            An unspecified directory path defaults to the working
+            directory; in this case, you can use all 248 characters
+            for the file name.
+
+            The file name defaults to Jobname.
+
+        ext
+            Filename extension (eight-character maximum).  The
+            extension defaults to PARM if Fname is blank.
+
+        Examples
+        --------
+        Read a local parameter file.
+
+        >>> mapdl.parres('parm.PARM')
+
+        Notes
+        -----
+        Reads parameters from a coded file.  The parameter file may
+        have been written with the PARSAV command.  The parameters
+        read may replace or change the current parameter set.
+
+        This command is valid in any processor.
+        """
+        if ext:
+            fname = fname + '.' + ext
+        elif not fname:
+            fname = '.' + 'PARM'
+
+        if hasattr(self, '_local'):  # gRPC mode
+            if self._local:
+                if not os.path.isfile(fname):
+                    raise FileNotFoundError('Unable to locate filename "%s"' % fname)
+
+                if not os.path.dirname(fname):
+                    filename = os.path.join(os.getcwd(), fname)
+                else:
+                    filename = fname
+            else:
+                if not os.path.dirname(fname):
+                    # might be trying to run a local file.  Check if the
+                    # file exists remotely.
+                    if fname not in self.list_files():
+                        self.upload(fname, progress_bar=False)
+                else:
+                    self.upload(fname, progress_bar=False)
+                filename = os.path.basename(fname)
+        else:
+            filename = fname
+
+        return self.input(filename)

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1300,6 +1300,8 @@ class _MapdlCore(_MapdlCommands):
 
         self._store_commands = False
         self._stored_commands = []
+
+        # interactive result
         _ = self.input(tmp_inp, write_to_log=False)
         time.sleep(0.1)  # allow MAPDL to close the file
         if os.path.isfile(tmp_out):

--- a/ansys/mapdl/core/mapdl_functions.py
+++ b/ansys/mapdl/core/mapdl_functions.py
@@ -23073,27 +23073,31 @@ class _MapdlCommands(_MapdlGeometryCommands,
         lab
             Write operation:
 
-            Write only scalar parameters (default). - Write scalar and array parameters.  Parameters may be numeric or alphanumeric.
+            - ``'SCALAR'`` : Write only scalar parameters (default). 
+            - ``'ALL'`` : Write scalar and array parameters.
+              Parameters may be numeric or alphanumeric.
 
         fname
-            File name and directory path (248 characters maximum, including the
-            characters needed for the directory path).  An unspecified
-            directory path defaults to the working directory; in this case, you
-            can use all 248 characters for the file name.
+            File name and directory path (248 characters maximum,
+            including the characters needed for the directory path).
+            An unspecified directory path defaults to the working
+            directory; in this case, you can use all 248 characters
+            for the file name.
 
         ext
             Filename extension (eight-character maximum).
 
         Notes
         -----
-        Writes the current parameters to a coded file.  Previous parameters on
-        this file, if any, will be overwritten.  The parameter file may be read
-        with the PARRES command.
+        Writes the current parameters to a coded file.  Previous
+        parameters on this file, if any, will be overwritten.  The
+        parameter file may be read with the PARRES command.
 
-        PARSAV/PARRES operations truncate some long decimal strings, and can
-        cause differing values in your solution data when other operations are
-        performed. A good practice is to limit the number of decimal places you
-        will use before and after these operations.
+        PARSAV/PARRES operations truncate some long decimal strings,
+        and can cause differing values in your solution data when
+        other operations are performed. A good practice is to limit
+        the number of decimal places you will use before and after
+        these operations.
 
         This command is valid in any processor.
         """

--- a/ansys/mapdl/core/mapdl_functions.py
+++ b/ansys/mapdl/core/mapdl_functions.py
@@ -2,10 +2,11 @@
 
 from .mesh_commands import _MapdlMeshingCommands
 from .geometry_commands import _MapdlGeometryCommands
-
+from .io_commands import _MapdlIoCommands
 
 class _MapdlCommands(_MapdlGeometryCommands,
-                     _MapdlMeshingCommands):  # pragma: no cover
+                     _MapdlMeshingCommands,
+                     _MapdlIoCommands):  # pragma: no cover
     """ANSYS class containing MAPDl functions."""
 
     def mforder(self, fnumb1="", fnumb2="", fnumb3="", fnumb4="", fnumb5="",
@@ -30838,45 +30839,6 @@ class _MapdlCommands(_MapdlGeometryCommands,
         analyses results processing.
         """
         command = "PLCINT,%s,%s,%s,%s,%s" % (str(action), str(id), str(node), str(cont), str(dtype))
-        return self.run(command, **kwargs)
-
-    def parres(self, lab="", fname="", ext="", **kwargs):
-        """APDL Command: PARRES
-
-        Reads parameters from a file.
-
-        Parameters
-        ----------
-        lab
-            Read operation.
-
-            NEW - Replace current parameter set with these parameters (default).
-
-            CHANGE - Extend current parameter set with these
-            parameters, replacing any that already exist.
-
-        fname
-            File name and directory path (248 characters maximum,
-            including the characters needed for the directory path).
-            An unspecified directory path defaults to the working
-            directory; in this case, you can use all 248 characters
-            for the file name.
-
-            The file name defaults to Jobname.
-
-        ext
-            Filename extension (eight-character maximum).  The
-            extension defaults to PARM if Fname is blank.
-
-        Notes
-        -----
-        Reads parameters from a coded file.  The parameter file may
-        have been written with the PARSAV command.  The parameters
-        read may replace or change the current parameter set.
-
-        This command is valid in any processor.
-        """
-        command = "PARRES,%s,%s,%s" % (str(lab), str(fname), str(ext))
         return self.run(command, **kwargs)
 
     def stef(self, value="", **kwargs):

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -957,7 +957,7 @@ class MapdlGrpc(_MapdlCore):
         # write to a temporary input file
         def build_rand_tmp():
             return os.path.join(tempfile.gettempdir(),
-                                f'tmp_{random_string()}.out')
+                                f'tmp_{random_string()}.inp')
 
         # rare case of duplicated tmpfile (birthday problem)
         tmp_filename = build_rand_tmp()

--- a/ansys/mapdl/core/parameters.py
+++ b/ansys/mapdl/core/parameters.py
@@ -419,13 +419,10 @@ class Parameters():
         filename = '_tmp.dat'
         self._write_numpy_array(filename, arr)
 
-        self._mapdl.dim(name, imax=idim, jmax=jdim, kmax=kdim)
+        cmd = f'{name}(1, 1),{filename},,,IJK,{idim},{jdim},{kdim}$(1F20.12)'
         with self._mapdl.non_interactive:
-            self._mapdl.vread('%s(1, 1),%s,,,IJK, %d, %d, %d' % (name,
-                                                                 filename,
-                                                                 idim,
-                                                                 jdim,
-                                                                 kdim))
+            self._mapdl.dim(name, imax=idim, jmax=jdim, kmax=kdim)
+            self._mapdl.vread(cmd)
             self._mapdl.run('(1F20.12)')
 
     def _write_numpy_array(self, filename, arr):

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -38,6 +38,14 @@ def test_jobname(mapdl, cleared):
     assert mapdl.jobname == other_jobname
 
 
+def test_parsav_parres(mapdl, cleared, tmpdir):
+    arr = np.random.random((10, 3))
+    mapdl.parameters['MYARR'] = arr
+    mapdl.parsav('', 'tmp.txt')
+    mapdl.parres('', 'tmp.txt')
+    assert np.allclose(mapdl.parameters['MYARR'], arr)
+
+
 def test_no_results(mapdl, cleared, tmpdir):
     pth = str(tmpdir.mkdir("tmpdir"))
     mapdl.jobname = random_string()

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -41,8 +41,9 @@ def test_jobname(mapdl, cleared):
 def test_parsav_parres(mapdl, cleared, tmpdir):
     arr = np.random.random((10, 3))
     mapdl.parameters['MYARR'] = arr
-    mapdl.parsav('', 'tmp.txt')
-    mapdl.parres('', 'tmp.txt')
+    mapdl.parsav('ALL', 'tmp.txt')
+    mapdl.clear()
+    mapdl.parres('ALL', 'tmp.txt')
     assert np.allclose(mapdl.parameters['MYARR'], arr)
 
 


### PR DESCRIPTION
This PR improves the stability of the parameter array setter.  The `*DIM` command was moved within `non_interactive`, providing a slight improvement to performance as well.

Additionally, it was discoverd that `PARRES` runs `\INPUT` under the hood, leading to the too many nested `/INPUT` error.  This PR also moves that command into a new `_MapdlIoCommands` class to protect the gRPC/CORBA server.
