### PR TITLE
fix path edge case

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2029,6 +2029,8 @@ class _MapdlCore(_MapdlCommands):
         # os independent path format
         if self._path is not None:
             self._path = self._path.replace('\\', '/')
+            # new line to fix path issue, see #416
+            self._path = self._path.replace('\n', '/n')
         return self._path
 
     @property

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2030,7 +2030,7 @@ class _MapdlCore(_MapdlCommands):
         if self._path is not None:
             self._path = self._path.replace('\\', '/')
             # new line to fix path issue, see #416
-            self._path = self._path.replace('\n', '/n')
+            self._path = repr(pth)[1:-1]
         return self._path
 
     @property

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2030,7 +2030,7 @@ class _MapdlCore(_MapdlCommands):
         if self._path is not None:
             self._path = self._path.replace('\\', '/')
             # new line to fix path issue, see #416
-            self._path = repr(pth)[1:-1]
+            self._path = repr(self._path)[1:-1]
         return self._path
 
     @property


### PR DESCRIPTION
As noted in #416, when the MAPDL directory contains `'\n'`, those fail to be replaced.  This resolves #416 using inputs from @natter1
