### PR TITLE
clean up path and fix pool testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import os
 import time
 
@@ -188,7 +189,7 @@ def mapdl(request, tmpdir_factory):
         mapdl._local = request.param  # CI: override for testing
 
     if mapdl._local:
-        assert mapdl.directory == run_path
+        assert Path(mapdl.directory) == Path(run_path)
         assert mapdl._distributed
 
     # using yield rather than return here to be able to test exit

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -19,6 +19,13 @@ skip_launch_mapdl = pytest.mark.skipif(get_start_instance() is False or IGNORE_P
 
 TWAIT = 90
 
+valid_rver = ['211', '202', '201', '195', '194', '193', '192', '191']
+EXEC_FILE = None
+for rver in valid_rver:
+    if os.path.isfile(get_ansys_bin(rver)):
+        EXEC_FILE = get_ansys_bin(rver)
+        break
+
 
 @pytest.fixture(scope="module")
 def pool():


### PR DESCRIPTION
Resolve #430 to deal with mixed slash/backslashes in path in `conftest.py`.
