### PR TITLE
Added examples to multiple commands

### DIFF
--- a/ansys/mapdl/core/_commands/database/components.py
+++ b/ansys/mapdl/core/_commands/database/components.py
@@ -63,6 +63,12 @@ def cm(self, cname="", entity="", **kwargs):
     components and subassemblies are deleted.
 
     This command is valid in any processor.
+
+    Examples
+    --------
+
+    >>> mapdl.asel('S', 'LOC', 'Y', t/2)  # where t is some local float
+    >>> mapdl.cm('PRES_A', 'AREA')  # This names the selected areas 'PRES_A'
     """
     command = "CM,%s,%s" % (str(cname), str(entity))
     return self.run(command, **kwargs)

--- a/ansys/mapdl/core/_commands/database/components.py
+++ b/ansys/mapdl/core/_commands/database/components.py
@@ -67,8 +67,11 @@ def cm(self, cname="", entity="", **kwargs):
     Examples
     --------
 
-    >>> mapdl.asel('S', 'LOC', 'Y', t/2)  # where t is some local float
-    >>> mapdl.cm('PRES_A', 'AREA')  # This names the selected areas 'PRES_A'
+    Create a component selection named ``"PRES_A"`` after
+    selecting the areas located in the Y plane at `loc`.
+
+    >>> mapdl.asel('S', 'LOC', 'Y', loc)
+    >>> mapdl.cm('PRES_A', 'AREA')
     """
     command = "CM,%s,%s" % (str(cname), str(entity))
     return self.run(command, **kwargs)

--- a/ansys/mapdl/core/_commands/database/coord_sys.py
+++ b/ansys/mapdl/core/_commands/database/coord_sys.py
@@ -385,8 +385,8 @@ def csys(self, kcn="", **kwargs):
 
     Examples
     --------
-    Suppose we want to create a cylindrical surface in cylindrical y (5)
-    with a radius of 6 and spanning `30 < θ < -90` and `0 < z < 4`
+    Create a cylindrical surface in cylindrical y (CSYS=5) with
+    a radius of 6 and spanning `30 < θ < -90` and `0 < z < 4`.
 
     >>> mapdl.csys(5)
     >>> mapdl.k(1, 6, 30)

--- a/ansys/mapdl/core/_commands/database/coord_sys.py
+++ b/ansys/mapdl/core/_commands/database/coord_sys.py
@@ -359,22 +359,43 @@ def csys(self, kcn="", **kwargs):
     command.
 
     The active coordinate system for files created via the CDWRITE command
-    is Cartesian (CSYS,0).
+    is Cartesian
+
+    >>> mapdl.csys(0)
 
     This command is valid in any processor.
 
-    CSYS,4 (or CSYS,WP) activates working plane tracking, which updates the
-    coordinate system to follow working plane changes. To deactivate
-    working plane tracking, activate any other coordinate system (for
-    example, CSYS,0 or CSYS,11).
+    >>> mapdl.csys(4)
+    >>> # or
+    >>> mapdl.csys('WP')
 
-    CSYS,5 is a cylindrical coordinate system with global Cartesian Y as
+    activates working plane tracking, which updates the
+    coordinate system to follow working plane changes. To deactivate
+    working plane tracking, activate any other coordinate system.
+
+    >>> mapdl.csys(5)
+
+    is a cylindrical coordinate system with global Cartesian Y as
     the axis. The local x, y and z axes are radial, θ, and axial
     (respectively). The R-Theta plane is the global X-Z plane, as it is for
-    an axisymmetric model. Thus, at θ = 0.0, CSYS,5 has a specific
+    an axisymmetric model. Thus, at `θ = 0.0`, `mapdl.csys(5)` has a specific
     orientation: the local x is in the global +X direction, local y is in
     the global -Z direction, and local z (the cylindrical axis) is in the
     global +Y direction.
+
+    Examples
+    --------
+    Suppose we want to create a cylindrical surface in cylindrical y (5)
+    with a radius of 6 and spanning `30 < θ < -90` and `0 < z < 4`
+
+    >>> mapdl.csys(5)
+    >>> mapdl.k(1, 6, 30)
+    >>> mapdl.k(2, 6, -90)
+    >>> mapdl.k(3, 6, -90, 4)
+    >>> mapdl.k(4, 6, 30, 4)
+    >>> mapdl.a(1, 2, 3, 4)
+    >>> mapdl.aplot()
+
     """
     command = "CSYS,%s" % (str(kcn))
     return self.run(command, **kwargs)

--- a/ansys/mapdl/core/_commands/database/selecting.py
+++ b/ansys/mapdl/core/_commands/database/selecting.py
@@ -63,9 +63,7 @@ def allsel(self, labt="", entity="", **kwargs):
 
     Examples
     --------
-
     >>> mapdl.allsel()
-
     """
     command = "ALLSEL,%s,%s" % (str(labt), str(entity))
     return self.run(command, **kwargs)

--- a/ansys/mapdl/core/_commands/database/selecting.py
+++ b/ansys/mapdl/core/_commands/database/selecting.py
@@ -134,7 +134,7 @@ def asel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
     Selects a subset of areas. For example, to select those areas with area
     numbers 1 through 7, use
 
-    >>> mapdl.asel('S','AREA',,1,7)
+    >>> mapdl.asel('S','AREA', '', 1, 7)
 
     The selected subset is then used when the ALL label is entered
     (or implied) on other commands, such as
@@ -164,7 +164,7 @@ def asel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
 
     If VMIN = VMAX = 0.0, Toler = 1.0E-6.
 
-     If VMAX ≠ VMIN, Toler = 1.0E-8 x (VMAX-VMIN).
+    If VMAX ≠ VMIN, Toler = 1.0E-8 x (VMAX-VMIN).
 
     Use the SELTOL command to override this default and specify Toler
     explicitly.
@@ -173,13 +173,17 @@ def asel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
 
     Examples
     --------
+    Select area(s) at location x == 0.  Note that value of seltol is
+    used since ``vmin == vmax``.
 
-    >>> mapdl.asel('S', 'LOC', 'X', 0)  # Select area(s) at location x=0
+    >>> mapdl.asel('S', 'LOC', 'X', 0)
 
-    >>> mapdl.asel('S', 'LOC', 'Y', t/2)  # where t is some local float
+    Select areas between ``y == 2`` and ``y == 4``
+
+    >>> mapdl.asel('S', 'LOC', 'Y', 2, 4)
+
     """
-    command = "ASEL,%s,%s,%s,%s,%s,%s,%s" % (str(type_), str(
-        item), str(comp), str(vmin), str(vmax), str(vinc), str(kswp))
+    command = f"ASEL,{type_},{item},{comp},{vmin},{vmax},{vinc},{kswp}"
     return self.run(command, **kwargs)
 
 
@@ -205,8 +209,7 @@ def aslv(self, type_="", **kwargs):
     -----
     This command is valid in any processor.
     """
-    command = "ASLV,%s" % (str(type_))
-    return self.run(command, **kwargs)
+    return self.run(f"ASLV,{type_}", **kwargs)
 
 
 def dofsel(self, type_="", dof1="", dof2="", dof3="", dof4="", dof5="",
@@ -389,14 +392,24 @@ def esel(self, type_: str = "", item: str = "", comp: str = "",
 
     Examples
     --------
+    Select elements using material numbers 2, 4 and 6.
 
-    >>> mapdl.esel('S', 'MAT', '', 2, 6, 2)  # elect elements using material numbers 2, 4 and 6
-    >>> mapdl.esel('R', 'ENAME', '', 185)  # Of these, reselect SOLID185 element types
+    >>> mapdl.esel('S', 'MAT', '', 2, 6, 2)
 
-    >>> mapdl.esel('S', 'MAT', '', 2)  # Select elements assigned to material property 2
+    Of these, reselect SOLID185 element types
+
+    >>> mapdl.esel('R', 'ENAME', '', 185)
+
+    Select elements assigned to material property 2
+
+    >>> mapdl.esel('S', 'MAT', '', 2)
+
+    Note, this command is equivalent to:
+
+    >>> mapdl.esel('S', 'MAT', vmin=2)
+
     """
-    command = f"ESEL,{type_},{item},{comp},{vmin},{vmax},{vinc}," \
-              f"{kabs}"
+    command = f"ESEL,{type_},{item},{comp},{vmin},{vmax},{vinc},{kabs}"
     return self.run(command, **kwargs)
 
 
@@ -872,26 +885,45 @@ def nsel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
 
     Examples
     --------
+    Select nodes at `x == 0`, Of these, reselect nodes between ``1 < Y
+    < 10``, then finally unselect nodes between ``5 < Y < 6``.
 
-    >>> mapdl.nsel('S', 'LOC', 'X', 0)  # select nodes at x=0
-    >>> mapdl.nsel('R', 'LOC', 'Y', 1, 10)  # Of these, reselect nodes between 1<Y<10
-    >>> mapdl.nsel('U', 'LOC', 'Y', 5, 6)  # unselect nodes between 5<Y<6
+    >>> mapdl.nsel('S', 'LOC', 'X', 0)
+    >>> mapdl.nsel('R', 'LOC', 'Y', 1, 10)
+    >>> mapdl.nsel('U', 'LOC', 'Y', 5, 6)
 
-    for other coordinate systems activate the coord system first
+    For other coordinate systems activate the coord system first.
+    First, change to cylindrical coordinate system, select nodes at
+    ``radius == 5``.  Reselect nodes from 0 to 90 degrees.
 
-    >>> mapdl.csys(1)  # Change to cylindrical coordinate system
-    >>> mapdl.nsel('S', 'LOC', 'X', 5)  # Select nodes at radius = 5
-    >>> mapdl.nsel('R', 'LOC', 'Y', 0, 90)  # Reselect nodes from 0 to 90 degrees
+    >>> mapdl.csys(1)
+    >>> mapdl.nsel('S', 'LOC', 'X', 5)
+    >>> mapdl.nsel('R', 'LOC', 'Y', 0, 90)
 
-    The labels X, Y, and Z are always used, regardless of which coordinate
-    system is activated. They take on different meanings in different systems
-    Additionally, angles are always in degrees and NOT radians.
+    Note that the labels X, Y, and Z are always used, regardless of which
+    coordinate system is activated. They take on different meanings in
+    different systems Additionally, angles are always in degrees and
+    NOT radians.
 
-    >>> mapdl.esel('S', 'MAT', '', 2)  # Select elements assigned to material property 2
-    >>> mapdl.nsle()  # Select the nodes these elements use
-    >>> mapdl.nsel('R', 'EXT')  # Reselect nodes on the element external surfaces
-    >>> mapdl.csys(1)  # Change to cylindrical coordinates
-    >>> mapdl.nsel('R', 'LOC', 'X', 5)  # Reselect nodes with radius=5
+    Select elements assigned to material property 2
+
+    >>> mapdl.esel('S', 'MAT', '', 2)
+
+    Select the nodes these elements use
+
+    >>> mapdl.nsle()
+
+    Reselect nodes on the element external surfaces
+
+    >>> mapdl.nsel('R', 'EXT')
+
+    Change to cylindrical coordinates
+
+    >>> mapdl.csys(1)
+
+    Reselect nodes with radius=5
+
+    >>> mapdl.nsel('R', 'LOC', 'X', 5)
     """
     command = "NSEL,%s,%s,%s,%s,%s,%s,%s" % (str(type_), str(
         item), str(comp), str(vmin), str(vmax), str(vinc), str(kabs))
@@ -933,9 +965,14 @@ def nsla(self, type_="", nkey="", **kwargs):
 
     Examples
     --------
+    Select area(s) at location x=0.  Note that the selection tolerance
+    above and below 0 will depend on the value of ``mapdl.seltol``
 
-    >>> mapdl.asel('S', 'LOC', 'X', 0)  # Select area(s) at location x=0
-    >>> mapdl.nsla('S', 1)  # Select nodes residing on the areas at x=0
+    >>> mapdl.asel('S', 'LOC', 'X', 0)
+
+    Select nodes residing on those areas.
+
+    >>> mapdl.nsla('S', 1)
     """
     command = "NSLA,%s,%s" % (str(type_), str(nkey))
     return self.run(command, **kwargs)
@@ -994,9 +1031,11 @@ def nsle(self, type_="", nodetype="", num="", **kwargs):
 
     Examples
     --------
+    Select elements assigned to material property 2 and then select
+    the nodes these elements use.
 
-    >>> mapdl.esel('S', 'MAT', '', 2)  # Select elements assigned to material property 2
-    >>> mapdl.nsle()  # Select the nodes these elements use
+    >>> mapdl.esel('S', 'MAT', '', 2)
+    >>> mapdl.nsle()
     """
     command = "NSLE,%s,%s,%s" % (str(type_), str(nodetype), str(num))
     return self.run(command, **kwargs)
@@ -1264,3 +1303,47 @@ def vsla(self, type_="", vlkey="", **kwargs):
     """
     command = "VSLA,%s,%s" % (str(type_), str(vlkey))
     return self.run(command, **kwargs)
+
+
+def seltol(self, toler="", **kwargs):
+    """Select those volumes containing the selected areas.
+
+    APDL Command: SELTOL
+
+    Parameters
+    ----------
+    toler
+        Tolerance value. If blank, restores the default tolerance
+        logic.
+
+    Notes
+    -----
+    For selects based on non-integer numbers (e.g. coordinates,
+    results, etc.), items within the range VMIN - Toler and VMAX +
+    Toler are selected, where VMIN and VMAX are the range values input
+    on the xSEL commands (ASEL, ESEL, KSEL, LSEL, NSEL, and VSEL).
+
+    The default tolerance logic is based on the relative values of
+    VMIN and VMAX as follows:
+
+    If ``vmin == vmax``, ``toler = 0.005*vmin``
+
+    If ``vmin == vmax == 0.0``, ``toler = 1.0E-6``.
+
+    If ``vmax != vmin``, ``toler = 1.0E-8 x (vmax - vmin)``.
+
+    This command is typically used when ``vmax - vmin`` is very large so
+    that the computed default tolerance is therefore large and the
+    xSEL commands selects more than what is desired.
+
+    Toler remains active until respecified by a subsequent seltol
+    command. ``seltol()`` resets back to the default toler value.
+
+    Examples
+    --------
+    Set selection tolarance to 1E-5
+
+    >>> seltol(1E-5)
+
+    """
+    return self.run(f"SELTOL{toler}", **kwargs)

--- a/ansys/mapdl/core/_commands/database/selecting.py
+++ b/ansys/mapdl/core/_commands/database/selecting.py
@@ -16,11 +16,11 @@ def allsel(self, labt="", entity="", **kwargs):
     labt
         Type of selection to be made:
 
-        ALL - Selects all items of the specified entity type and all items of lower entity
-              types (default).
+        ALL - Selects all items of the specified entity type and all
+              items of lower entity types (default).
 
-        BELOW - Selects all items directly associated with and below the selected items of the
-                specified entity type.
+        BELOW - Selects all items directly associated with and below
+                the selected items of the specified entity type.
 
     entity
         Entity type on which selection is based:
@@ -1023,9 +1023,10 @@ def nsle(self, type_="", nodetype="", num="", **kwargs):
     elements. Only nodes on elements in the currently-selected element set
     can be selected.
 
-    Note:: : When using degenerate hexahedral elements, NSLE, U,CORNER and
-    NSLE,S,MID will not select the same set of nodes because some nodes
-    appear as both corner and midside nodes.
+    .. note::
+        When using degenerate hexahedral elements, NSLE, U,CORNER and
+        NSLE,S,MID will not select the same set of nodes because some
+        nodes appear as both corner and midside nodes.
 
     This command is valid in any processor.
 
@@ -1259,7 +1260,7 @@ def vsel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
 
     If VMIN = VMAX = 0.0, Toler = 1.0E-6.
 
-     If VMAX ≠ VMIN, Toler = 1.0E-8 x (VMAX-VMIN).
+    If VMAX ≠ VMIN, Toler = 1.0E-8 x (VMAX-VMIN).
 
     Use the SELTOL command to override this default and specify Toler
     explicitly.

--- a/ansys/mapdl/core/_commands/database/selecting.py
+++ b/ansys/mapdl/core/_commands/database/selecting.py
@@ -60,6 +60,12 @@ def allsel(self, labt="", entity="", **kwargs):
     The $ character should not be used after the  ALLSEL  command.
 
     This command is valid in any processor.
+
+    Examples
+    --------
+
+    >>> mapdl.allsel()
+
     """
     command = "ALLSEL,%s,%s" % (str(labt), str(entity))
     return self.run(command, **kwargs)
@@ -128,9 +134,16 @@ def asel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
     Notes
     -----
     Selects a subset of areas. For example, to select those areas with area
-    numbers 1 through 7, use ASEL,S,AREA,,1,7.  The selected subset is then
-    used when the ALL label is entered (or implied) on other commands, such
-    as ALIST,ALL.  Only data identified by area number are selected.  Data
+    numbers 1 through 7, use
+
+    >>> mapdl.asel('S','AREA',,1,7)
+
+    The selected subset is then used when the ALL label is entered
+    (or implied) on other commands, such as
+
+    >>> mapdl.alist('ALL')
+
+    Only data identified by area number are selected.  Data
     are flagged as selected and unselected; no data are actually deleted
     from the database.
 
@@ -159,6 +172,13 @@ def asel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
     explicitly.
 
     Table: 127:: : ASEL - Valid Item and Component Labels
+
+    Examples
+    --------
+
+    >>> mapdl.asel('S', 'LOC', 'X', 0)  # Select area(s) at location x=0
+
+    >>> mapdl.asel('S', 'LOC', 'Y', t/2)  # where t is some local float
     """
     command = "ASEL,%s,%s,%s,%s,%s,%s,%s" % (str(type_), str(
         item), str(comp), str(vmin), str(vmax), str(vinc), str(kswp))
@@ -324,9 +344,16 @@ def esel(self, type_: str = "", item: str = "", comp: str = "",
     Selects elements based on values of a labeled item and
     component. For example, to select a new set of elements
     based on element numbers 1
-    through 7, use ESEL,S,ELEM,,1,7.  The subset is used when the
-    ALL label is entered (or implied) on other commands, such as
-    ELIST, ALL. Only data identified by element number are
+    through 7, use
+
+    >>> mapdl.esel('S', 'ELEM', '', 1, 7)
+
+    The subset is used when the ALL label is entered (or implied)
+    on other commands, such as
+
+    >>> mapdl.elist('ALL')
+
+    Only data identified by element number are
     selected. Selected data are internally flagged; no actual
     removal of data from the database occurs. Different element
     subsets cannot be used for different load steps [SOLVE] in a
@@ -361,6 +388,14 @@ def esel(self, type_: str = "", item: str = "", comp: str = "",
     Toler explicitly.
 
     Table: 133:: : ESEL - Valid Item and Component Labels
+
+    Examples
+    --------
+
+    >>> mapdl.esel('S', 'MAT', '', 2, 6, 2)  # elect elements using material numbers 2, 4 and 6
+    >>> mapdl.esel('R', 'ENAME', '', 185)  # Of these, reselect SOLID185 element types
+
+    >>> mapdl.esel('S', 'MAT', '', 2)  # Select elements assigned to material property 2
     """
     command = f"ESEL,{type_},{item},{comp},{vmin},{vmax},{vinc}," \
               f"{kabs}"
@@ -788,9 +823,16 @@ def nsel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
     Notes
     -----
     Selects a subset of nodes.  For example, to select a new set of nodes
-    based on node numbers 1 through 7, use NSEL,S,NODE,,1,7.  The subset is
-    used when the ALL label is entered (or implied) on other commands, such
-    as NLIST,ALL.  Only data identified by node number are selected.  Data
+    based on node numbers 1 through 7, do
+
+    >>> mapdl.nsel('S','NODE','',1,7)
+
+    The subset is used when the `'ALL'` label is entered (or implied)
+    on other commands, such as
+
+    >>> mapdl.nlist('ALL')
+
+    Only data identified by node number are selected.  Data
     are flagged as selected and unselected; no data are actually deleted
     from the database.
 
@@ -829,6 +871,29 @@ def nsel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
 
     Table: 209:: : NSEL - Valid Item and Component Labels for Nodal DOF
     Result Values
+
+    Examples
+    --------
+
+    >>> mapdl.nsel('S', 'LOC', 'X', 0)  # select nodes at x=0
+    >>> mapdl.nsel('R', 'LOC', 'Y', 1, 10)  # Of these, reselect nodes between 1<Y<10
+    >>> mapdl.nsel('U', 'LOC', 'Y', 5, 6)  # unselect nodes between 5<Y<6
+
+    for other coordinate systems activate the coord system first
+
+    >>> mapdl.csys(1)  # Change to cylindrical coordinate system
+    >>> mapdl.nsel('S', 'LOC', 'X', 5)  # Select nodes at radius = 5
+    >>> mapdl.nsel('R', 'LOC', 'Y', 0, 90)  # Reselect nodes from 0 to 90 degrees
+
+    The labels X, Y, and Z are always used, regardless of which coordinate
+    system is activated. They take on different meanings in different systems
+    Additionally, angles are always in degrees and NOT radians.
+
+    >>> mapdl.esel('S', 'MAT', '', 2)  # Select elements assigned to material property 2
+    >>> mapdl.nsle()  # Select the nodes these elements use
+    >>> mapdl.nsel('R', 'EXT')  # Reselect nodes on the element external surfaces
+    >>> mapdl.csys(1)  # Change to cylindrical coordinates
+    >>> mapdl.nsel('R', 'LOC', 'X', 5)  # Reselect nodes with radius=5
     """
     command = "NSEL,%s,%s,%s,%s,%s,%s,%s" % (str(type_), str(
         item), str(comp), str(vmin), str(vmax), str(vinc), str(kabs))
@@ -867,6 +932,12 @@ def nsla(self, type_="", nkey="", **kwargs):
     [AMESH, VMESH] on a solid model that contains the selected areas.
 
     This command is valid in any processor.
+
+    Examples
+    --------
+
+    >>> mapdl.asel('S', 'LOC', 'X', 0)  # Select area(s) at location x=0
+    >>> mapdl.nsla('S', 1)  # Select nodes residing on the areas at x=0
     """
     command = "NSLA,%s,%s" % (str(type_), str(nkey))
     return self.run(command, **kwargs)
@@ -922,6 +993,12 @@ def nsle(self, type_="", nodetype="", num="", **kwargs):
     appear as both corner and midside nodes.
 
     This command is valid in any processor.
+
+    Examples
+    --------
+
+    >>> mapdl.esel('S', 'MAT', '', 2)  # Select elements assigned to material property 2
+    >>> mapdl.nsle()  # Select the nodes these elements use
     """
     command = "NSLE,%s,%s,%s" % (str(type_), str(nodetype), str(num))
     return self.run(command, **kwargs)

--- a/ansys/mapdl/core/commands.py
+++ b/ansys/mapdl/core/commands.py
@@ -103,6 +103,7 @@ class Commands:
     partsel = database.selecting.partsel
     vsel = database.selecting.vsel
     vsla = database.selecting.vsla
+    seltol = database.selecting.seltol
 
     resume = database.setup.resume
     save = database.setup.save


### PR DESCRIPTION
Added examples to commands based on the lectures 1-6 in the MAPDL
lecture course. The commands have been converted to pymapdl from raw
APDL. They have not been tested where the commands obviously line-up
with what they should be (they all follow what the documentation says 
they should do, so they should work fine).

This PR is based on lectures 1-6. There are 21 lectures in total and I am slowly
 working through them all. Do not delete this branch as I will use it for future 
PRs on the same topic.