### PR TITLE
Doc/docstring fixes and examples

### DIFF
--- a/ansys/mapdl/core/_commands/database/selecting.py
+++ b/ansys/mapdl/core/_commands/database/selecting.py
@@ -591,7 +591,10 @@ def ksel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
     -----
     Selects a subset of keypoints or hard points.  For example, to select a
     new set of keypoints based on keypoint numbers 1 through 7, use
-    KSEL,S,KP,,1,7.  The selected subset is used when the ALL label is
+
+    >>> mapdl.ksel('S', 'KP', '', 1, 7)
+
+    The selected subset is used when the ALL label is
     entered (or implied) on other commands, such as KLIST,ALL.  Only data
     identified by keypoint number are selected.  Data are flagged as
     selected and unselected; no data are actually deleted from the
@@ -614,6 +617,12 @@ def ksel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
     explicitly.
 
     Table: 203:: : KSEL - Valid Item and Component Labels
+
+    Examples
+    --------
+
+    To select a single keypoint (keypoint 1)
+    >>> mapdl.ksel('S', 'KP', '', 1)
     """
     command = "KSEL,%s,%s,%s,%s,%s,%s,%s" % (str(type_), str(
         item), str(comp), str(vmin), str(vmax), str(vinc), str(kabs))

--- a/ansys/mapdl/core/_commands/database/selecting.py
+++ b/ansys/mapdl/core/_commands/database/selecting.py
@@ -620,8 +620,8 @@ def ksel(self, type_="", item="", comp="", vmin="", vmax="", vinc="",
 
     Examples
     --------
-
     To select a single keypoint (keypoint 1)
+
     >>> mapdl.ksel('S', 'KP', '', 1)
     """
     command = "KSEL,%s,%s,%s,%s,%s,%s,%s" % (str(type_), str(

--- a/ansys/mapdl/core/_commands/preproc/elements.py
+++ b/ansys/mapdl/core/_commands/preproc/elements.py
@@ -690,6 +690,13 @@ def emodif(self, iel: Union[str, int] = "", stloc: Union[str, int] = "",
     >>> mapdl.emodif('ALL', 'MAT', i1=mp_num)
     'MODIFY ALL SELECTED ELEMENTS TO HAVE  MAT  =         2'
 
+    Use `emodif` to modify all of volume 2's elements
+    after meshing.
+
+    >>> mapdl.vmesh('S', 'VOLU', '', 2)
+    >>> mapdl.allsel('BELOW', 'VOLU')
+    >>> mapdl.emodif('ALL', 'MAT', 2)
+
     Notes
     -----
     The nodes and/or attributes (MAT, TYPE, REAL, ESYS, and SECNUM

--- a/ansys/mapdl/core/_commands/preproc/meshing.py
+++ b/ansys/mapdl/core/_commands/preproc/meshing.py
@@ -1561,6 +1561,12 @@ def mat(self, mat="", **kwargs):
     elements.  This number refers to the material number (MAT) defined with
     the material properties [MP].  Material numbers may be displayed
     [/PNUM].
+
+    Examples
+    --------
+    Set the material ID pointer to 2
+
+    >>> mapdl.mat(2)
     """
     command = f"MAT,{mat}"
     return self.run(command, **kwargs)
@@ -2633,6 +2639,12 @@ def type(self, itype="", **kwargs):
     logical element type has been assigned via TYPE or XATT,,,TYPE.  For
     more information, see the discussion on setting element attributes in
     Meshing Your Solid Model in the Modeling and Meshing Guide.
+
+    Examples
+    --------
+
+    Set the type pointer to 2
+    >>> mapdl.type(2)
     """
     command = f"TYPE,{itype}"
     return self.run(command, **kwargs)
@@ -2793,6 +2805,15 @@ def vmesh(self, nv1="", nv2="", ninc="", **kwargs):
 
     Tetrahedral mesh expansion [MOPT,TETEXPND,Value] is supported for both
     the VMESH and FVMESH commands.
+
+    Examples
+    --------
+
+    Set the material ID and type pointers to 2, then mesh volume #1
+    using mat 2 and type 2.
+    >>> mapdl.mat(2)
+    >>> mapdl.type(2)
+    >>> mapdl.vmesh(1)
     """
     command = f"VMESH,{nv1},{nv2},{ninc}"
     return self.run(command, **kwargs)

--- a/ansys/mapdl/core/_commands/preproc/meshing.py
+++ b/ansys/mapdl/core/_commands/preproc/meshing.py
@@ -2644,6 +2644,7 @@ def type(self, itype="", **kwargs):
     --------
 
     Set the type pointer to 2
+
     >>> mapdl.type(2)
     """
     command = f"TYPE,{itype}"
@@ -2809,8 +2810,9 @@ def vmesh(self, nv1="", nv2="", ninc="", **kwargs):
     Examples
     --------
 
-    Set the material ID and type pointers to 2, then mesh volume #1
+    Set the material ID and type pointers to 2, then mesh volume 1
     using mat 2 and type 2.
+
     >>> mapdl.mat(2)
     >>> mapdl.type(2)
     >>> mapdl.vmesh(1)

--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -742,7 +742,7 @@ class PostProcessing():
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.plot_nodal_component_stress('1')
+        >>> mapdl.post_processing.plot_nodal_principal_stress('1')
         """
         disp = self.nodal_principal_stress(component)
         kwargs.setdefault('stitle', '%s Nodal\nPrincipal Stress' % component)
@@ -922,15 +922,15 @@ class PostProcessing():
 
     def plot_nodal_total_component_strain(self, component, show_node_numbering=False,
                                           **kwargs):
-        """Plot nodal principal stress.
+        """Plot nodal total component starin.
 
         Includes elastic, plastic, and creep strain.
 
         Parameters
         ----------
-        component : str
-            Nodal component stress component to plot.  Must be
-            ``'1'``, ``'2'``, or ``'3'``
+        component : str, optional
+            Component to retrieve.  Must be ``'X'``, ``'Y'``, ``'Z'``,
+            ``'XY'``, ``'YZ'``, or ``'XZ'``.
 
         Returns
         --------
@@ -941,11 +941,11 @@ class PostProcessing():
 
         Examples
         --------
-        Plot the nodal principal stress "1" for the second result set
+        Plot Total component strain in the X direction for the first result
 
         >>> mapdl.post1()
-        >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.plot_nodal_component_stress('1')
+        >>> mapdl.set(1, 1)
+        >>> mapdl.post_processing.plot_nodal_total_component_strain('X')
         """
         disp = self.nodal_total_component_strain(component)
         kwargs.setdefault('stitle', '%s Total Nodal\nComponent Strain' % component)
@@ -1014,11 +1014,11 @@ class PostProcessing():
 
         Examples
         --------
-        Plot the nodal principal stress "1" for the second result set
+        Plot the principal nodal strain in the S1 direction for the first result
 
         >>> mapdl.post1()
-        >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.plot_nodal_component_stress('1')
+        >>> mapdl.set(1, 1)
+        >>> mapdl.post_processing.nodal_total_principal_strain('1')
         """
         disp = self.nodal_total_principal_strain(component)
         kwargs.setdefault('stitle', '%s Nodal\nPrincipal Strain' % component)


### PR DESCRIPTION
Fixes #344 . Multiple
docstrings have been identified with inconsistent names used with them.

For example plot_nodal_toal_component_strain contained references to
total_nodal_principal_stress. I have sorted the docstrings out by
comparing them to the code called in the methods and using the non-plot
methods to get examples from. They should now all be consistent.

&

Added some examples to docstrings as well.