### PR TITLE
Add matplotlib to imports

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License
+MIT License
 
-ANSYS INC. Copyright (c) 1986-2021
+Copyright (c) 2021 ANSYS, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with io_open(version_file, mode='r') as fd:
     exec(fd.read())
 
 install_requires = [
+    'matplotlib>=3.0.0'  # for colormaps for pyvista
     'numpy>=1.14.0',
     'pyvista>=0.30.1',
     'appdirs>=1.4.0',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     'google-api-python-client',
     'grpcio>=1.30.0',  # tested up to grpcio==1.35
     'ansys-grpc-mapdl==0.4.0',  # supports at least 2020R2 - 2021R2
-    'ansys-mapdl-reader>=0.50.0',
+    'ansys-mapdl-reader>=0.50.15',
     'ansys-corba',  # pending depreciation to ansys-mapdl-corba
     'protobuf>=3.1.4',  # had an issue with gRPC health checking with this version
 ]


### PR DESCRIPTION
Due to recent changes in pyvista themes, require `matplotlib` for theme setting.  This will be necessary when setting themes within pymapdl.
