### PR TITLE
add back in input

### DIFF
--- a/ansys/mapdl/core/_commands/session/run_controls.py
+++ b/ansys/mapdl/core/_commands/session/run_controls.py
@@ -161,7 +161,7 @@ def filname(self, fname="", key="", **kwargs):
     return self.run(command, **kwargs)
 
 
-def input(self, fname="", ext="", dir_="", line="", log="", **kwargs):
+def input(self, fname="", ext="", dir="", line="", log="", **kwargs):
     """Switches the input file for the commands that follow.
 
     APDL Command: /INPUT
@@ -169,30 +169,31 @@ def input(self, fname="", ext="", dir_="", line="", log="", **kwargs):
     Parameters
     ----------
     fname
-        File name and directory path (248 characters maximum, including the
-        characters needed for the directory path).  An unspecified
-        directory path defaults to the working directory; in this case, you
-        can use all 248 characters for the file name.
+        File name and directory path (248 characters maximum,
+        including the characters needed for the directory path).  An
+        unspecified directory path defaults to the working directory;
+        in this case, you can use all 248 characters for the file
+        name.
 
     ext
         Filename extension (eight-character maximum).
 
-    dir\_
+    dir
         Directory path (64 characters maximum). Defaults to current
         directory.
 
     line
         A value indicating either a line number in the file or a user-
-        defined label in the file from which to begin reading the input
-        file.
+        defined label in the file from which to begin reading the
+        input file.
 
         (blank), 0, or 1 - Begins reading from the top of the file (default).
 
         LINE_NUMBER - Begins reading from the specified line number in the file.
 
-        :label - Begins reading from the first line beginning with the matching user-defined
-                 label :label (beginning with a colon (:), 8 characters
-                 maximum).
+        :label - Begins reading from the first line beginning with the
+                 matching user-defined label :label (beginning with a
+                 colon (:), 8 characters maximum).
 
     log
         Indicates whether secondary input from this command should be
@@ -204,36 +205,40 @@ def input(self, fname="", ext="", dir_="", line="", log="", **kwargs):
 
     Notes
     -----
-    Switches the input file for the next commands.  Commands are read from
-    this file until an end-of-file or another file switching directive is
-    read.  An end-of-file occurs after the last record of the file or when
-    a /EOF command is read.  An automatic switch back one level (to the
-    previous file) occurs when an end-of-file is encountered.  Twenty
-    levels of nested file switching are allowed.  Note that files including
-    *DO, *USE, *ULIB, and the "Unknown Command" Macro have less nesting
-    available because each of these operations also uses a level of file
-    switching.  For an interactive run, a /INPUT,TERM switches to the
-    terminal for the next input.  A /EOF read from the terminal then
-    switches back to the previous file.  A /INPUT (with a blank second
-    field) switches back to the primary input file.
+    Switches the input file for the next commands.  Commands are read
+    from this file until an end-of-file or another file switching
+    directive is read.  An end-of-file occurs after the last record of
+    the file or when a /EOF command is read.  An automatic switch back
+    one level (to the previous file) occurs when an end-of-file is
+    encountered.  Twenty levels of nested file switching are allowed.
+    Note that files including *DO, *USE, *ULIB, and the "Unknown
+    Command" Macro have less nesting available because each of these
+    operations also uses a level of file switching.  For an
+    interactive run, a /INPUT,TERM switches to the terminal for the
+    next input.  A /EOF read from the terminal then switches back to
+    the previous file.  A /INPUT (with a blank second field) switches
+    back to the primary input file.
 
-    Setting LOG = 1 on /INPUT causes all commands read from the specified
-    file to be recorded in the command log (File.LOG) and the internal
-    database command log [LGWRITE].  This option is recommended if the log
-    file will be used later .  The LOG = 1 option is only valid when the
-    /INPUT occurs in the primary input file.  Using LOG = 1 on a nested
-    /INPUT or on a /INPUT within a do-loop will have no effect (i.e.,
-    commands in the secondary input file are not written to the command
-    log).
+    Setting LOG = 1 on /INPUT causes all commands read from the
+    specified file to be recorded in the command log (File.LOG) and
+    the internal database command log [LGWRITE].  This option is
+    recommended if the log file will be used later .  The LOG = 1
+    option is only valid when the /INPUT occurs in the primary input
+    file.  Using LOG = 1 on a nested /INPUT or on a /INPUT within a
+    do-loop will have no effect (i.e., commands in the secondary input
+    file are not written to the command log).
 
     The Dir option is optional as the directory path can be included
     directly in Fname.
 
-    This command is valid in any processor.
+    Examples
+    --------
+    Run an input file relative to the location of MAPDL.
+
+    >>> mapdl.input('my_input_file.inp')
+
     """
-    command = "/INPUT,%s,%s,%s,%s,%s" % (str(fname),
-                                         str(ext), str(dir_), str(line), str(log))
-    return self.run(command, **kwargs)
+    return self.run(f"/INPUT,{fname},{ext},{dir},{line},{log}", **kwargs)
 
 
 def keyw(self, keyword="", key="", **kwargs):

--- a/ansys/mapdl/core/commands.py
+++ b/ansys/mapdl/core/commands.py
@@ -12,6 +12,7 @@ class Commands:
     config = session.run_controls.config
     cwd = session.run_controls.cwd
     filname = session.run_controls.filname
+    input = session.run_controls.input
     keyw = session.run_controls.keyw
     memm = session.run_controls.memm
     nerr = session.run_controls.nerr

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -204,9 +204,6 @@ def test_invalid_area(mapdl_corba):
 
 @skip_no_xserver
 def test_kplot(cleared, mapdl_corba, tmpdir):
-    with pytest.raises(MapdlRuntimeError):
-        mapdl_corba.kplot(vtk=True)
-
     mapdl_corba.k("", 0, 0, 0)
     mapdl_corba.k("", 1, 0, 0)
     mapdl_corba.k("", 1, 1, 0)
@@ -288,8 +285,7 @@ def test_lines(cleared, mapdl_corba):
 
 @skip_no_xserver
 def test_lplot(cleared, mapdl_corba, tmpdir):
-    with pytest.raises(MapdlRuntimeError):
-        mapdl_corba.lplot(vtk=True)
+    mapdl_corba.lplot(vtk=True)
 
     k0 = mapdl_corba.k("", 0, 0, 0)
     k1 = mapdl_corba.k("", 1, 0, 0)
@@ -301,7 +297,7 @@ def test_lplot(cleared, mapdl_corba, tmpdir):
     mapdl_corba.l(k3, k0)
 
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.png'))
-    cpos = mapdl_corba.lplot(show_keypoint_numbering=True, screenshot=filename)
+    cpos = mapdl_corba.lplot(show_keypoint_numbering=True, savefig=filename)
     assert isinstance(cpos, CameraPosition)
     assert os.path.isfile(filename)
 
@@ -366,8 +362,7 @@ def test_enum(mapdl_corba, make_block):
 @pytest.mark.parametrize('knum', [True, False])
 @skip_no_xserver
 def test_nplot_vtk(cleared, mapdl_corba, knum):
-    with pytest.raises(RuntimeError):
-        mapdl_corba.nplot()
+    mapdl_corba.nplot()
 
     mapdl_corba.n(1, 0, 0, 0)
     mapdl_corba.n(11, 10, 0, 0)
@@ -473,12 +468,6 @@ def test_builtin_parameters(mapdl_corba, cleared):
     assert mapdl_corba.parameters.real == 1
 
 
-def test_eplot_fail(mapdl_corba):
-    # must fail with empty mesh
-    with pytest.raises(RuntimeError):
-        mapdl_corba.eplot()
-
-
 @skip_no_xserver
 def test_eplot(mapdl_corba, make_block):
     init_elem = mapdl_corba.mesh.n_elem
@@ -492,7 +481,7 @@ def test_eplot(mapdl_corba, make_block):
 def test_eplot_screenshot(mapdl_corba, make_block, tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.png'))
     mapdl_corba.eplot(background='w', show_edges=True, smooth_shading=True,
-                window_size=[1920, 1080], savefig=filename)
+                      window_size=[1920, 1080], savefig=filename)
     assert os.path.isfile(filename)
 
 


### PR DESCRIPTION
The `input` method is broken for legacy console and CORBA interfaces as of 9db6768420260898d3b0f54bde8bd822f49896f9.  This PR adds `input` back in and fixes unit testing for the ``test_corba.py``.
