### PR TITLE
added requirement that python version be less than 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     url='https://github.com/pyansys/pymapdl',
-    python_requires='>=3.6.*',
+    python_requires='>=3.6.*, <3.9',
     keywords='ANSYS MAPDL gRPC',
     package_data={'ansys.mapdl.core.examples': ['verif/*.dat',
                                                 'wing.dat']},


### PR DESCRIPTION
I have tested that this does block the install with python 3.9 (and it does).

Closes issue #394 