### PR TITLE
Feat/issue 504 nsel and ksel

### DIFF
--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -11,6 +11,33 @@ class SelectionStatus(IntEnum):
     UNSELECTED = -1
     UNDEFINED = 0
     SELECTED = 1
+
+    Examples
+    --------
+    The following example is taken from ``Query.nsel`` and demonstrates
+    how `SelectionSatus` appears in PyMAPDL.
+
+    Here we create a single node and interrogate its selection
+    status.
+    >>> from ansys.mapdl.core import launch_mapdl
+    >>> from ansys.mapdl.core.inline_functions import Query
+    >>> mapdl = launch_mapdl()
+    >>> mapdl.prep7()
+    >>> n1 = mapdl.n(1, 0, 0, 0)
+    >>> n1
+    1
+    We can use ``Query.nsel`` to interrogate the selection status
+    of the node. The response is an ``enum.IntEnum`` object. If
+    you query a node that does not exist, it will return a status
+    ``SelectionStatus.UNDEFINED``.
+    >>> q = Query(mapdl)
+    >>> q.nsel(n1)
+    <SelectionStatus.SELECTED: 1>
+    >>> mapdl.nsel('NONE')
+    >>> q.nsel(n1)
+    <SelectionStatus.UNSELECTED: -1>
+    >>> q.nsel(0)
+    <SelectionStatus.UNDEFINED: 0>
     """
     UNSELECTED = -1
     UNDEFINED = 0

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -19,6 +19,7 @@ class SelectionStatus(IntEnum):
 
     Here we create a single node and interrogate its selection
     status.
+    
     >>> from ansys.mapdl.core import launch_mapdl
     >>> from ansys.mapdl.core.inline_functions import Query
     >>> mapdl = launch_mapdl()
@@ -26,10 +27,12 @@ class SelectionStatus(IntEnum):
     >>> n1 = mapdl.n(1, 0, 0, 0)
     >>> n1
     1
+
     We can use ``Query.nsel`` to interrogate the selection status
     of the node. The response is an ``enum.IntEnum`` object. If
     you query a node that does not exist, it will return a status
     ``SelectionStatus.UNDEFINED``.
+
     >>> q = Query(mapdl)
     >>> q.nsel(n1)
     <SelectionStatus.SELECTED: 1>
@@ -653,6 +656,7 @@ class _SelectionStatusQueries(_ParameterParsing):
         --------
         Here we create a single node and interrogate its selection
         status.
+
         >>> from ansys.mapdl.core import launch_mapdl
         >>> from ansys.mapdl.core.inline_functions import Query
         >>> mapdl = launch_mapdl()

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -702,6 +702,7 @@ class _SelectionStatusQueries(_ParameterParsing):
         --------
         Here we create a single keypoint and interrogate its selection
         status.
+
         >>> from ansys.mapdl.core import launch_mapdl
         >>> from ansys.mapdl.core.inline_functions import Query
         >>> mapdl = launch_mapdl()

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -710,10 +710,12 @@ class _SelectionStatusQueries(_ParameterParsing):
         >>> k1 = mapdl.k(1, 0, 0, 0)
         >>> k1
         1
+
         We can use ``Query.ksel`` to interrogate the selection status
         of the node. The response is an ``enum.IntEnum`` object. If
         you query a node that does not exist, it will return a status
         ``SelectionStatus.UNDEFINED``.
+
         >>> q = Query(mapdl)
         >>> q.ksel(k1)
         <SelectionStatus.SELECTED: 1>

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -1,4 +1,14 @@
 import warnings
+from enum import IntEnum
+
+
+class SelectionStatus(IntEnum):
+    """
+    Enumeration for Status Information to use with Inline.
+    """
+    UNSELECTED = -1
+    UNDEFINED = 0
+    SELECTED = 1
 
 
 class _ParameterParsing:
@@ -584,9 +594,108 @@ class _DisplacementComponentQueries(_ParameterParsing):
         return self._parse_parameter_float_response(response)
 
 
+class _SelectionStatusQueries(_ParameterParsing):
+    _mapdl = None
+
+    def nsel(self, n: int) -> float:
+        """Returns selection status of a node.
+
+        Returns a ``SelectionStatus`` object with values:
+
+        1  - SELECTED
+        0  - UNDEFINED
+        -1 - UNSELECTED
+
+        Parameters
+        ----------
+        n : int
+            Node number
+
+        Returns
+        -------
+        mapdl.ansys.core.inline_functions.SelectionStatus
+            Status of node
+
+        Examples
+        --------
+        Here we create a single node and interrogate its selection
+        status.
+        >>> from ansys.mapdl.core import launch_mapdl
+        >>> from ansys.mapdl.core.inline_functions import Query
+        >>> mapdl = launch_mapdl()
+        >>> mapdl.prep7()
+        >>> n1 = mapdl.n(1, 0, 0, 0)
+        >>> n1
+        1
+        We can use ``Query.nsel`` to interrogate the selection status
+        of the node. The response is an ``enum.IntEnum`` object. If
+        you query a node that does not exist, it will return a status
+        ``SelectionStatus.UNDEFINED``.
+        >>> q = Query(mapdl)
+        >>> q.nsel(n1)
+        <SelectionStatus.SELECTED: 1>
+        >>> mapdl.nsel('NONE')
+        >>> q.nsel(n1)
+        <SelectionStatus.UNSELECTED: -1>
+        >>> q.nsel(0)
+        <SelectionStatus.UNDEFINED: 0>
+        """
+        response = self._mapdl.run(f'_=NSEL({n})')
+        integer = self._parse_parameter_integer_response(response)
+        return SelectionStatus(integer)
+
+    def ksel(self, k: int) -> float:
+        """Returns selection status of a keypoint.
+
+        Returns a ``SelectionStatus`` object with values:
+
+        1  - SELECTED
+        0  - UNDEFINED
+        -1 - UNSELECTED
+
+        Parameters
+        ----------
+        k : int
+            Keypoint number
+
+        Returns
+        -------
+        mapdl.ansys.core.inline_functions.SelectionStatus
+            Status of keypoint
+
+        Examples
+        --------
+        Here we create a single keypoint and interrogate its selection
+        status.
+        >>> from ansys.mapdl.core import launch_mapdl
+        >>> from ansys.mapdl.core.inline_functions import Query
+        >>> mapdl = launch_mapdl()
+        >>> mapdl.prep7()
+        >>> k1 = mapdl.k(1, 0, 0, 0)
+        >>> k1
+        1
+        We can use ``Query.ksel`` to interrogate the selection status
+        of the node. The response is an ``enum.IntEnum`` object. If
+        you query a node that does not exist, it will return a status
+        ``SelectionStatus.UNDEFINED``.
+        >>> q = Query(mapdl)
+        >>> q.ksel(k1)
+        <SelectionStatus.SELECTED: 1>
+        >>> mapdl.ksel('NONE')
+        >>> q.ksel(k1)
+        <SelectionStatus.UNSELECTED: -1>
+        >>> q.ksel(0)
+        <SelectionStatus.UNDEFINED: 0>
+        """
+        response = self._mapdl.run(f'_=KSEL({k})')
+        integer = self._parse_parameter_integer_response(response)
+        return SelectionStatus(integer)
+
+
 class Query(_ComponentQueries,
             _InverseGetComponentQueries,
-            _DisplacementComponentQueries):
+            _DisplacementComponentQueries,
+            _SelectionStatusQueries):
     """Class containing all the inline functions of APDL.
 
     Most of the results of these methods are shortcuts for specific

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -733,6 +733,58 @@ class _SelectionStatusQueries(_ParameterParsing):
         integer = self._parse_parameter_integer_response(response)
         return SelectionStatus(integer)
 
+    def lsel(self, n: int) -> SelectionStatus:
+        """Returns selection status of a line.
+
+        Returns a ``SelectionStatus`` object with values:
+
+        1  - SELECTED
+        0  - UNDEFINED
+        -1 - UNSELECTED
+
+        Parameters
+        ----------
+        n : int
+            Line number
+
+        Returns
+        -------
+        mapdl.ansys.core.inline_functions.SelectionStatus
+            Status of line
+
+        Examples
+        --------
+        Here we create a single line and interrogate its selection
+        status.
+
+        >>> from ansys.mapdl.core import launch_mapdl
+        >>> from ansys.mapdl.core.inline_functions import Query
+        >>> mapdl = launch_mapdl()
+        >>> mapdl.prep7()
+        >>> k1 = mapdl.k(1, 0, 0, 0)
+        >>> k2 = mapdl.k(2, 1, 1, 1)
+        >>> L1 = mapdl.l(k1, k2)
+        >>> L1
+        1
+
+        We can use ``Query.lsel`` to interrogate the selection status
+        of the line. The response is an ``enum.IntEnum`` object. If
+        you query a line that does not exist, it will return a status
+        ``SelectionStatus.UNDEFINED``.
+
+        >>> q = Query(mapdl)
+        >>> q.lsel(L1)
+        <SelectionStatus.SELECTED: 1>
+        >>> mapdl.lsel('NONE')
+        >>> q.lsel(L1)
+        <SelectionStatus.UNSELECTED: -1>
+        >>> q.lsel(0)
+        <SelectionStatus.UNDEFINED: 0>
+        """
+        response = self._mapdl.run(f'_=LSEL({n})')
+        integer = self._parse_parameter_integer_response(response)
+        return SelectionStatus(integer)
+
 
 class Query(_ComponentQueries,
             _InverseGetComponentQueries,

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -3,8 +3,14 @@ from enum import IntEnum
 
 
 class SelectionStatus(IntEnum):
-    """
-    Enumeration for Status Information to use with Inline.
+    """Enumeration class for selection status information.
+
+    This class is used with methods on the ``Query`` class and has the
+    following options.
+
+    UNSELECTED = -1
+    UNDEFINED = 0
+    SELECTED = 1
     """
     UNSELECTED = -1
     UNDEFINED = 0

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -660,10 +660,12 @@ class _SelectionStatusQueries(_ParameterParsing):
         >>> n1 = mapdl.n(1, 0, 0, 0)
         >>> n1
         1
+
         We can use ``Query.nsel`` to interrogate the selection status
         of the node. The response is an ``enum.IntEnum`` object. If
         you query a node that does not exist, it will return a status
         ``SelectionStatus.UNDEFINED``.
+
         >>> q = Query(mapdl)
         >>> q.nsel(n1)
         <SelectionStatus.SELECTED: 1>

--- a/ansys/mapdl/core/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions.py
@@ -633,7 +633,7 @@ class _DisplacementComponentQueries(_ParameterParsing):
 class _SelectionStatusQueries(_ParameterParsing):
     _mapdl = None
 
-    def nsel(self, n: int) -> float:
+    def nsel(self, n: int) -> SelectionStatus:
         """Returns selection status of a node.
 
         Returns a ``SelectionStatus`` object with values:
@@ -683,7 +683,7 @@ class _SelectionStatusQueries(_ParameterParsing):
         integer = self._parse_parameter_integer_response(response)
         return SelectionStatus(integer)
 
-    def ksel(self, k: int) -> float:
+    def ksel(self, k: int) -> SelectionStatus:
         """Returns selection status of a keypoint.
 
         Returns a ``SelectionStatus`` object with values:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,7 +306,8 @@ def selection_test_geometry(mapdl, cleared):
     mapdl.vmesh('ALL')
     return Query(mapdl)
 
-  
+
+@pytest.fixture
 def twisted_sheet(mapdl, cleared):
     mapdl.prep7()
     mapdl.et(1, 'SHELL181')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,6 +292,21 @@ def solved_box(mapdl, cleared):
     return q, get_details_of_nodes(mapdl)
 
 
+@pytest.fixture
+def selection_test_geometry(mapdl, cleared):
+    mapdl.prep7()
+    k0 = mapdl.k(1, 0, 0, 0)
+    k1 = mapdl.k(2, 0, 0, 1)
+    k2 = mapdl.k(3, 0, 1, 0)
+    k3 = mapdl.k(4, 1, 0, 0)
+    v0 = mapdl.v(k0, k1, k2, k3)
+    mapdl.mshape(1, '3D')
+    mapdl.et(1, "SOLID98")
+    mapdl.esize(0.5)
+    mapdl.vmesh('ALL')
+    return Query(mapdl)
+
+
 def create_geometry(mapdl):
     mapdl.prep7()
     k0 = mapdl.k(1, 0, 0, 0)

--- a/tests/test_inline_functions/test_selection_queries.py
+++ b/tests/test_inline_functions/test_selection_queries.py
@@ -1,0 +1,57 @@
+from ansys.mapdl.core.inline_functions import SelectionStatus
+import pytest
+
+
+class TestSelectionStatus:
+    @pytest.mark.parametrize('value', [1, -1, 0, 1., -1., 0.])
+    def test_happy(self, value):
+        select = SelectionStatus(value)
+        assert select == value
+        assert select is not value
+
+    @pytest.mark.parametrize('value', [1.5, 999, 99., '1'])
+    def test_unhappy(self, value):
+        with pytest.raises(ValueError):
+            SelectionStatus(value)
+
+
+class TestNSEL:
+    def test_selected(self, selection_test_geometry):
+        q = selection_test_geometry
+        q._mapdl.nsel('S', 'LOC', 'X', 0)
+        node = q.node(0, 0, 0)
+        select = q.nsel(node)
+        assert select == 1
+
+    def test_unselected(self, selection_test_geometry):
+        q = selection_test_geometry
+        node = q.node(0, 0, 0)
+        q._mapdl.nsel('NONE')
+        select = q.nsel(node)
+        assert select == -1
+
+    def test_undefined(self, selection_test_geometry):
+        q = selection_test_geometry
+        select = q.nsel(999)
+        assert select == 0
+
+
+class TestKSEL:
+    def test_selected(self, selection_test_geometry):
+        q = selection_test_geometry
+        q._mapdl.ksel('S', 'LOC', 'X', 0)
+        node = q.kp(0, 0, 0)
+        select = q.ksel(node)
+        assert select == 1
+
+    def test_unselected(self, selection_test_geometry):
+        q = selection_test_geometry
+        node = q.kp(0, 0, 0)
+        q._mapdl.ksel('NONE')
+        select = q.ksel(node)
+        assert select == -1
+
+    def test_undefined(self, selection_test_geometry):
+        q = selection_test_geometry
+        select = q.ksel(999)
+        assert select == 0

--- a/tests/test_inline_functions/test_selection_queries.py
+++ b/tests/test_inline_functions/test_selection_queries.py
@@ -55,3 +55,25 @@ class TestKSEL:
         q = selection_test_geometry
         select = q.ksel(999)
         assert select == 0
+
+
+class TestLSEL:
+    def test_selected(self, selection_test_geometry):
+        q = selection_test_geometry
+        q._mapdl.lsel('all')
+        # there are 6 lines numbered 1-6
+        for line in range(1, 7, 1):
+            select = q.lsel(line)
+            assert select == 1
+
+    def test_unselected(self, selection_test_geometry):
+        q = selection_test_geometry
+        q._mapdl.lsel('NONE')
+        for line in range(1, 7, 1):
+            select = q.lsel(line)
+            assert select == -1
+
+    def test_undefined(self, selection_test_geometry):
+        q = selection_test_geometry
+        select = q.lsel(999)
+        assert select == 0


### PR DESCRIPTION
NSEL and KSEL inline functions. Example to follow in the TnT bits, but given they are just two commands the example will probably be combined with ASEL, VSEL, LSEL, and ESEL, which are on the way.