### PR TITLE
Cache documentation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,7 +50,6 @@ jobs:
           path: doc/build
           key: ${{ env.PYMAPDL_VERSION }}
 
-
       - name: Pull, launch, and validate MAPDL service
         run: |
           echo $GH_PAT | docker login -u $GH_USERNAME --password-stdin docker.pkg.github.com

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           export PYMAPDL_VERSION=$(python -c "from ansys.mapdl import core; print(core.__version__)")
           echo "::set-env name=PYMAPDL_VERSION::$PYMAPDL_VERSION"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Cache Documentation
         id: cache-documentation

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,6 +36,19 @@ jobs:
           pip install dist/ansys*.whl
           python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
 
+      - name: Cache pymapdl version
+        run: |
+          export PYMAPDL_VERSION=$(python -c "from ansys.mapdl import core; print(core.__version__)")
+          echo "::set-env name=PYMAPDL_VERSION::$PYMAPDL_VERSION"
+
+      - name: Cache Documentation
+        id: cache-documentation
+        uses: actions/cache@v2
+        with:
+          path: doc/build
+          key: ${{ PYMAPDL_VERSION }}
+
+
       - name: Pull, launch, and validate MAPDL service
         run: |
           echo $GH_PAT | docker login -u $GH_USERNAME --password-stdin docker.pkg.github.com

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: doc/build
-          key: ${{ PYMAPDL_VERSION }}
+          key: ${{ env.PYMAPDL_VERSION }}
 
 
       - name: Pull, launch, and validate MAPDL service

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1542,6 +1542,8 @@ class _MapdlCore(Commands):
         self.filname(new_jobname, mute=True)
         self._jobname = new_jobname
 
+    # TODO: add static_analysis
+
     def modal_analysis(self, method='lanb', nmode='', freqb='', freqe='', cpxmod='',
                        nrmkey='', modtype='', memory_option='', elcalc=False):
         """Run a modal with basic settings analysis


### PR DESCRIPTION
This PR adds a documentation cache which restores the `doc/build` directory to reduce the amount of time it takes to rebuild the documentation.  Functional examples will still be run, but individual page documentation will be only regenerated if the source changes.  Cache key is set to the version of `ansys-mapdl-core`.  This way, documentation will be rebuilt from scratch upon any version bump.  This step will be run pre-release on our release branches.

---

Turns out the way to do this is to have two "modes" for building documentation.  One mode is the "smoke test" that doesn't generate the full API documentation and the other builds the API docs.  See:
https://github.com/pyansys/PyAEDT/blob/docs/cleanup_style/.github/workflows/ci-build.yml