### PR TITLE
added method to fetch query class instance to mapdl

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -192,7 +192,7 @@ class _MapdlCore(Commands):
 
         Returns
         -------
-        ansys.mapdl.core.inline_functions.Query
+        :class:`ansys.mapdl.core.inline_functions.Query`
             Instance of the Query class
 
         Examples


### PR DESCRIPTION
Closes #535.

Backwards compatibility maintained, but improved syntax available. I'm not sure if more needs to be done to bring in line with the docs, however.