### PR TITLE
Fix nplot parameters

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -782,7 +782,7 @@ class _MapdlCore(Commands):
             self._apdl_log.close()
         self._apdl_log = None
 
-    def nplot(self, knum="", vtk=None, **kwargs):
+    def nplot(self, nnum="", vtk=None, show_node_numbering=False, **kwargs):
         """APDL Command: NPLOT
 
         Displays nodes.
@@ -793,11 +793,14 @@ class _MapdlCore(Commands):
 
         Parameters
         ----------
-        knum : bool, int, optional
+        nnum : bool, int, optional
             Node number key:
 
             - ``False`` : No node numbers on display (default).
             - ``True`` : Include node numbers on display.
+
+            .. note::
+               This parameter is only valid when ``vtk==True``
 
         vtk : bool, optional
             Plot the currently selected nodes using ``pyvista``.
@@ -812,7 +815,7 @@ class _MapdlCore(Commands):
         >>> mapdl.n(1, 0, 0, 0)
         >>> mapdl.n(11, 10, 0, 0)
         >>> mapdl.fill(1, 11, 9)
-        >>> mapdl.nplot(knum=True, vtk=True, background='w', color='k',
+        >>> mapdl.nplot(nnum=True, vtk=True, background='w', color='k',
                         show_bounds=True)
 
         Plot without using VTK
@@ -833,6 +836,9 @@ class _MapdlCore(Commands):
 
         if vtk is None:
             vtk = self._use_vtk
+
+        if 'knum' in kwargs:
+            raise ValueError('`knum` keyword depricated.  Please use `nnum` instead.')
 
         if vtk:
             kwargs.setdefault('title', 'MAPDL Node Plot')

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -847,7 +847,7 @@ class _MapdlCore(Commands):
                 return general_plotter([], [], [], **kwargs)
 
             labels = []
-            if knum:
+            if nnum:
                 # must eliminate duplicate points or labeling fails miserably.
                 pcloud = pv.PolyData(self.mesh.nodes)
                 pcloud['labels'] = self.mesh.nnum
@@ -858,11 +858,11 @@ class _MapdlCore(Commands):
             return general_plotter([], points, labels, **kwargs)
 
         # otherwise, use the built-in nplot
-        if isinstance(knum, bool):
-            knum = int(knum)
+        if isinstance(nnum, bool):
+            nnum = int(nnum)
 
         self._enable_interactive_plotting()
-        return super().nplot(knum, **kwargs)
+        return super().nplot(nnum, **kwargs)
 
     def vplot(self, nv1="", nv2="", ninc="", degen="", scale="",
               vtk=None, quality=4, show_area_numbering=False,

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -782,7 +782,7 @@ class _MapdlCore(Commands):
             self._apdl_log.close()
         self._apdl_log = None
 
-    def nplot(self, nnum="", vtk=None, show_node_numbering=False, **kwargs):
+    def nplot(self, nnum="", vtk=None, **kwargs):
         """APDL Command: NPLOT
 
         Displays nodes.

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -838,7 +838,7 @@ class _MapdlCore(Commands):
             vtk = self._use_vtk
 
         if 'knum' in kwargs:
-            raise ValueError('`knum` keyword depricated.  Please use `nnum` instead.')
+            raise ValueError('`knum` keyword deprecated.  Please use `nnum` instead.')
 
         if vtk:
             kwargs.setdefault('title', 'MAPDL Node Plot')

--- a/doc/source/user_guide/mesh_geometry.rst
+++ b/doc/source/user_guide/mesh_geometry.rst
@@ -69,5 +69,5 @@ commands for creating geometries.
 
 API Reference
 ~~~~~~~~~~~~~
-For a full descrption of the ``Mesh`` and ``Geometry`` classes, please
+For a full description of the ``Mesh`` and ``Geometry`` classes, please
 see :ref:`ref_mesh_api` and :ref:`ref_geometry_api`.

--- a/examples/00-mapdl-examples/mapdl_beam.py
+++ b/examples/00-mapdl-examples/mapdl_beam.py
@@ -44,7 +44,7 @@ print(mapdl.mesh.nodes)
 print(mapdl.mesh.nnum)
 
 # plot the nodes using VTK
-mapdl.nplot(vtk=True, knum=True, cpos='xy', show_bounds=True, point_size=10)
+mapdl.nplot(vtk=True, nnum=True, cpos='xy', show_bounds=True, point_size=10)
 
 ###############################################################################
 # create elements between the nodes

--- a/examples/00-mapdl-examples/statically_indeterminate_reaction_force_analysis.py
+++ b/examples/00-mapdl-examples/statically_indeterminate_reaction_force_analysis.py
@@ -3,7 +3,7 @@ r"""
 
 Statically Indeterminate Reaction Force Analysis
 ------------------------------------------------
-Problem Descrption:
+Problem Description:
  - A prismatical bar with built-in ends is loaded axially at two
    intermediate cross sections.  Determine the reactions :math:`R_1`
    and :math:`R_2`.

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -18,3 +18,4 @@ sord
 struc
 emiss
 vise
+sur

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,3 +1,3 @@
-codespell==2.0.0
+codespell==2.1.0
 
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -360,13 +360,13 @@ def test_enum(mapdl, make_block):
     assert np.allclose(mapdl.mesh.enum, range(1, mapdl.mesh.n_elem + 1))
 
 
-@pytest.mark.parametrize('knum', [True, False])
+@pytest.mark.parametrize('nnum', [True, False])
 @skip_no_xserver
-def test_nplot_vtk(cleared, mapdl, knum):
+def test_nplot_vtk(cleared, mapdl, nnum):
     mapdl.n(1, 0, 0, 0)
     mapdl.n(11, 10, 0, 0)
     mapdl.fill(1, 11, 9)
-    mapdl.nplot(vtk=True, knum=knum, background='w', color='k')
+    mapdl.nplot(vtk=True, nnum=nnum, background='w', color='k')
 
 
 @skip_no_xserver


### PR DESCRIPTION
The `nplot` method uses the `knum` rather than the nnum parameter when plotting nodes.  Changed to ``nnum``.
