### PR TITLE
remove Jinja2 ver req

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -12,5 +12,4 @@ sphinx-copybutton
 sphinx-gallery>=0.8.1
 sphinx-autodoc-typehints
 pyansys_sphinx_theme
-Jinja2==2.11.3  # due to An error happened in rendering the page genindex. with v3
 ansys-mapdl-reader<=0.51.3  # 0.51.4-0.51.5 breaks doc build


### PR DESCRIPTION
Minor change to the doc build req to remove the `Jinja2` version.
