### PR TITLE
Fix missing logo

### DIFF
--- a/doc/source/api/post.rst
+++ b/doc/source/api/post.rst
@@ -1,4 +1,4 @@
-.. _ref_post_processing_api:
+.. _post_processing_api:
 
 
 Post-Processing

--- a/doc/source/user_guide/post.rst
+++ b/doc/source/user_guide/post.rst
@@ -98,4 +98,4 @@ a mask of the currently selected nodes.
 Post Processing Object Methods
 ------------------------------
 For a full list of all available post-processing methods, see
-:ref:`ref_post_processing`.
+:ref:`post_processing_api`.

--- a/examples/00-mapdl-examples/contact_elements.py
+++ b/examples/00-mapdl-examples/contact_elements.py
@@ -1,6 +1,9 @@
 """
 .. _ref_contact_example:
 
+Contact Element Example
+~~~~~~~~~~~~~~~~~~~~~~~
+
 This example demonstrates how to create contact elements for general
 contact.
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -2,7 +2,7 @@ pypandoc>=1.5.0
 matplotlib
 imageio>=2.5.0
 imageio-ffmpeg
-Sphinx>=4.0.0
+Sphinx==4.0.3
 sphinx-autobuild
 sphinxcontrib-napoleon
 sphinxcontrib-websupport


### PR DESCRIPTION
This PR fixes the version of sphinx for the docbuild to `sphinx==4.0.3` to fix the missing logo.  As of `sphinx==4.1.2` this has not been fixed.

Also:
- [x] Fixes broken link to post-processing API.
- [x] Fixes missing title on contact element example.
