### PR TITLE
Support 3.9

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,6 +12,8 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
+    - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -22,4 +24,6 @@ jobs:
         pip install -r requirements_build.txt
         python setup.py sdist
         pip install dist/ansys*
+
+    - name: Test import
         python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,25 @@
+name: Smoke Tests
+# verify we can install on a variety of Python versions and OSes
+
+on: [push, pull_request, workflow_dispatch]
+
+
+jobs:
+  testimport:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install PyMAPDL
+        run: |
+          pip install -r requirements_build.txt
+          python setup.py sdist
+          pip install dist/ansys*
+          python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -3,7 +3,6 @@ name: Smoke Tests
 
 on: [push, pull_request, workflow_dispatch]
 
-
 jobs:
   testimport:
     runs-on: ${{ matrix.os }}
@@ -12,14 +11,15 @@ jobs:
         os: [windows-latest, ubuntu-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9']
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Install PyMAPDL
-        run: |
-          pip install -r requirements_build.txt
-          python setup.py sdist
-          pip install dist/ansys*
-          python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
+    - name: Install PyMAPDL
+      run: |
+        pip install -r requirements_build.txt
+        python setup.py sdist
+        pip install dist/ansys*
+        python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"

--- a/setup.py
+++ b/setup.py
@@ -48,16 +48,6 @@ if not is64:
                        'Please check the version of Python installed at\n'
                        '%s' % sys.executable)
 
-if sys.version_info.minor > 8:
-    try:
-        import vtk
-    except:
-        raise RuntimeError('\n\n``ansys-mapdl-reader`` supports Python 3.6 - 3.8\n'
-                           'Python 3.9 support depends on vtk wheels, which should\n'
-                           'be released by August 2021.\n\n'
-                           'Installed Python:\n'
-                           '%s' % str(sys.version.splitlines()[0]))
-
 
 packages = []
 for package in find_namespace_packages(include='ansys*'):
@@ -83,6 +73,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     url='https://github.com/pyansys/pymapdl',
     python_requires='>=3.6.*',


### PR DESCRIPTION
It's been a long time coming, but Python 3.9 is finally supported as of this PR.

Also adds smoke tests to make sure we can import on the supported versions.  Assumption that server behavior is identical regardless of the environment (which isn't the best assumption and we're working on getting windows agents with MAPDL).
