### PR TITLE
allow HAS_GRPC when running on devops

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,4 @@
+"""Shared testing module"""
 from typing import Dict, Tuple
 from collections import namedtuple
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,10 +32,9 @@ for rver in valid_rver:
 # Cache if gRPC MAPDL is installed.
 #
 # minimum version on linux.  Windows is v202, but using v211 for consistency
-# override this if running on Azure
-HAS_GRPC = int(rver) >= 211
-if 'PYMAPDL_PORT' in os.environ:
-    HAS_GRPC = True
+# Override this if running on CI/CD and PYMAPDL_PORT has been specified
+ON_CI = 'PYMAPDL_START_INSTANCE' in os.environ and 'PYMAPDL_PORT' in os.environ
+HAS_GRPC = int(rver) >= 211 or ON_CI
 
 
 # determine if we can launch an instance of MAPDL locally

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,25 +12,31 @@ from ansys.mapdl.core.launcher import (get_start_instance,
                                        MAPDL_DEFAULT_PORT,
                                        _get_available_base_ansys)
 from ansys.mapdl.core.inline_functions import Query
-from common import get_details_of_nodes, get_details_of_elements, \
-    Node, Element
+from common import (get_details_of_nodes, get_details_of_elements,
+                    Node, Element)
 
 
 # Necessary for CI plotting
 pyvista.OFF_SCREEN = True
 
 
-# check for a valid MAPDL install with gRPC
-# NOTE: checks in this order
-valid_rver = ['212', '211', '202', '201', '195', '194', '193', '192', '191']
+# Check if MAPDL is installed
+# NOTE: checks in this order to get the newest installed version
+valid_rver = ['221', '212', '211', '202', '201', '195', '194', '193', '192', '191']
 EXEC_FILE = None
 for rver in valid_rver:
     if os.path.isfile(get_ansys_bin(rver)):
         EXEC_FILE = get_ansys_bin(rver)
         break
 
+# Cache if gRPC MAPDL is installed.
+#
 # minimum version on linux.  Windows is v202, but using v211 for consistency
+# override this if running on Azure
 HAS_GRPC = int(rver) >= 211
+if 'PYMAPDL_PORT' in os.environ:
+    HAS_GRPC = True
+
 
 # determine if we can launch an instance of MAPDL locally
 local = [False]

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -100,7 +100,7 @@ def test_allow_ignore(mapdl_console):
     mapdl_console.allow_ignore = True
     assert mapdl_console.allow_ignore is True
     mapdl_console.k()
-    assert mapdl_console.geometry.n_keypoint is 0
+    assert mapdl_console.geometry.n_keypoint == 0
 
 
 def test_chaining(mapdl_console, cleared):

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -89,7 +89,7 @@ def test_allow_ignore(mapdl_corba):
     mapdl_corba.allow_ignore = True
     assert mapdl_corba.allow_ignore is True
     mapdl_corba.k()
-    assert mapdl_corba.geometry.n_keypoint is 0
+    assert mapdl_corba.geometry.n_keypoint == 0
 
 
 def test_chaining(mapdl_corba, cleared):

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -7,7 +7,7 @@ from ansys.mapdl.core import examples
 
 PATH = os.path.dirname(os.path.abspath(__file__))
 
-# skip entire module unless HAS_GRPC
+# skip entire module unless HAS_GRPC installed or connecting to server
 pytestmark = pytest.mark.skip_grpc
 
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -7,12 +7,13 @@ import numpy as np
 import pyvista
 from pyvista.plotting.renderer import CameraPosition
 from pyvista.plotting import system_supports_plotting
-
 from ansys.mapdl.reader import examples
 
 from ansys.mapdl.core.misc import random_string
 from ansys.mapdl.core.errors import MapdlRuntimeError
 from ansys.mapdl import core as pymapdl
+
+from conftest import ON_CI
 
 skip_no_xserver = pytest.mark.skipif(not system_supports_plotting(),
                                      reason="Requires active X Server")
@@ -537,6 +538,7 @@ def test_load_table(mapdl):
     assert np.allclose(mapdl.parameters['my_conv'], my_conv[:, -1])
 
 
+@pytest.mark.xfail(ON_CI, reason="Bug in docker 2021R1 release candidate image")
 @pytest.mark.skip_grpc
 def test_lssolve(mapdl, cleared):
     mapdl.mute = True

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -152,7 +152,7 @@ def test_allow_ignore(mapdl):
     mapdl.allow_ignore = True
     assert mapdl.allow_ignore is True
     mapdl.k()
-    assert mapdl.geometry.n_keypoint is 0
+    assert mapdl.geometry.n_keypoint == 0
     mapdl.allow_ignore = False
 
 


### PR DESCRIPTION
This PR fixes our CI/CD where `test_grpc.py` was being skipped because MAPDL wasn't installed.  We now override that flag by also checking if gRPC specific environment variables have been setup.
