### PR TITLE
Raise max gRPC receive limit to 256MB

### DIFF
--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -36,7 +36,10 @@ from ansys.mapdl.core import check_version
 logger = logging.getLogger(__name__)
 
 VOID_REQUEST = anskernel.EmptyRequest()
-MAX_MESSAGE_LENGTH = 256*1024**2  # 256 MB
+
+# Default 256 MB message length
+MAX_MESSAGE_LENGTH = int(os.environ.get('PYMAPDL_MAX_MESSAGE_LENGTH', 256*1024**2))
+
 
 def chunk_raw(raw, save_as):
     with io.BytesIO(raw) as f:

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -746,3 +746,30 @@ These commands have no direct mapping to MAPDL as they are not
 applicable to a "headless" interactive session.
 
 * ``*DEL``
+
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+There are several PyMAPDL specific environment variables that can be
+used to control the behavior or launching of PyMAPDL and MAPDL.  These
+include:
+
++----------------------------+-------------------------------------------------+
+| ANSYSLMD_LICENSE_FILE      | License file or IP address (e.g. 192.168.0.16). |
+|                            | This is helpful for supplying licencing for     |
+|                            | docker.                                         |
++----------------------------+-------------------------------------------------+
+| PYMAPDL_MAX_MESSAGE_LENGTH | Maximum gRPC message length.  If your           |
+|                            | connection terminates when running              |
+|                            | PRNSOL or NLIST, raise this.  In bytes,         |
+|                            | defaults to 256 MB                              |
++----------------------------+-------------------------------------------------+
+| PYMAPDL_PORT               | Default port to look for when connecting        |
+|                            | PyMAPDL.  Normally used for unit testing.       |
++----------------------------+-------------------------------------------------+
+| PYMAPDL_START_INSTANCE     | Override the behavior of                        |
+|                            | :func:`ansys.mapdl.core.launch_mapdl` to only   |
+|                            | attempt to connect to existing                  |
+|                            | instances of PyMAPDL.  Generally used           |
+|                            | in combination with ``PYMAPDL_PORT``            |
++----------------------------+-------------------------------------------------+

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -87,6 +87,16 @@ def test_input_empty(mapdl):
     assert 'does not exist' in resp
 
 
+def test_large_output(mapdl, cleared):
+    """Verify we can receive messages over the default 4MB limit."""
+    mapdl.block(0, 1, 0, 1, 0, 1)
+    mapdl.et(1, 187)
+    mapdl.esize(0.05)
+    mapdl.vmesh('all')
+    msg = mapdl.nlist()
+    assert len(msg) > 4*1024**2
+
+
 def test_download_missing_file(mapdl, tmpdir):
     target = tmpdir.join('tmp')
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
This PR raises the maximum receive message length to 256 MB based on https://stackoverflow.com/questions/42629047/how-to-increase-message-size-in-grpc-using-python and suggestions from @germa89 in #578.

I figure that 256 MB is a sensible limit, but this can be overridden with ``PYMAPDL_MAX_MESSAGE_LENGTH``.  Docs are also updated.

Resolves #578.
﻿
