### PR TITLE
Introduce flake8 style guidelines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+exclude = venv, __init__.py
+# To be added after refactoring code to be compliant: E501, F401, W191, W291, W293
+select = W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, F403
+count = True
+max-complexity = 10
+max-line-length = 100
+statistics = True

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -20,3 +20,7 @@ jobs:
         run: |
           pip install -r requirements_style.txt --disable-pip-version-check
           make
+
+      - name: flake8
+        run: |
+          make flake8

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ docker/mapdl/_old
 
 # temp testing
 tmp.out
+
+# virtual environment
+venv/
+
+# Visual studio code local settings
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ coverage-xml:
 coverage-html:
 	@echo "Reporting HTML coverage"
 	@pytest -v --cov ansys.mapdl --cov-report html
+
+flake8:
+	@echo "Running flake8"
+	@flake8 .

--- a/ansys/mapdl/core/inline_functions/nearest_queries.py
+++ b/ansys/mapdl/core/inline_functions/nearest_queries.py
@@ -113,4 +113,3 @@ class _EntityNearestEntityQueries(_ParameterParsing):
         response = self._mapdl.run(f'_=ENEARN({n})')
         integer = self._parse_parameter_integer_response(response)
         return integer
-

--- a/ansys/mapdl/core/inline_functions/normals_queries.py
+++ b/ansys/mapdl/core/inline_functions/normals_queries.py
@@ -268,4 +268,3 @@ class _KeypointNormalQueries(_ParameterParsing):
         response = self._mapdl.run(f'_=NORMKZ({k1}, {k2}, {k3})')
         float_ = self._parse_parameter_float_response(response)
         return float_
-

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -385,7 +385,6 @@ def launch_grpc(exec_file='', jobname='file', nproc=2, ram=None,
                          stdout=subprocess.DEVNULL,
                          stderr=subprocess.DEVNULL)
 
-
     # watch for the creation of temporary files at the run_directory.
     # This lets us know that the MAPDL process has at least started
     sleep_time = 0.1

--- a/ansys/mapdl/core/mapdl_geometry.py
+++ b/ansys/mapdl/core/mapdl_geometry.py
@@ -12,14 +12,15 @@ VALID_TYPE_MSG = """- 'S' : Select a new set (default)
 - 'U' : Unselect a set from the current set.
 """
 
-FLST_LOOKUP = {'NODE': 1,  # node numbers
-               'ELEM': 2,  # element numbers
-               'KP': 3,  # keypoint numbers
-               'LINE': 4,  # line numbers
-               'AREA': 5,  # area numbers
-               'VOLU': 6,  # volume numbers
-               'TRACE': 7,  # trace points
-               'COORD': 8,  # coordinate locations
+FLST_LOOKUP = {
+	'NODE': 1,  # node numbers
+	'ELEM': 2,  # element numbers
+	'KP': 3,  # keypoint numbers
+	'LINE': 4,  # line numbers
+	'AREA': 5,  # area numbers
+	'VOLU': 6,  # volume numbers
+	'TRACE': 7,  # trace points
+	'COORD': 8,  # coordinate locations
 }
 
 def merge_polydata(items):

--- a/ansys/mapdl/core/mapdl_geometry.py
+++ b/ansys/mapdl/core/mapdl_geometry.py
@@ -13,14 +13,14 @@ VALID_TYPE_MSG = """- 'S' : Select a new set (default)
 """
 
 FLST_LOOKUP = {
-	'NODE': 1,  # node numbers
-	'ELEM': 2,  # element numbers
-	'KP': 3,  # keypoint numbers
-	'LINE': 4,  # line numbers
-	'AREA': 5,  # area numbers
-	'VOLU': 6,  # volume numbers
-	'TRACE': 7,  # trace points
-	'COORD': 8,  # coordinate locations
+    'NODE': 1,  # node numbers
+    'ELEM': 2,  # element numbers
+    'KP': 3,  # keypoint numbers
+    'LINE': 4,  # line numbers
+    'AREA': 5,  # area numbers
+    'VOLU': 6,  # volume numbers
+    'TRACE': 7,  # trace points
+    'COORD': 8,  # coordinate locations
 }
 
 def merge_polydata(items):

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -644,7 +644,7 @@ class MapdlGrpc(_MapdlCore):
 
     def _close_process(self):
        """Close all MAPDL processes"""
-		if self._local:
+        if self._local:
             for pid in self._pids:
                 try:
                     os.kill(pid, 9)

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -643,7 +643,7 @@ class MapdlGrpc(_MapdlCore):
         self._exited = True
 
     def _close_process(self):
-       """Close all MAPDL processes"""
+        """Close all MAPDL processes"""
         if self._local:
             for pid in self._pids:
                 try:

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -644,7 +644,7 @@ class MapdlGrpc(_MapdlCore):
 
     def _close_process(self):
        """Close all MAPDL processes"""
-       if self._local:
+		if self._local:
             for pid in self._pids:
                 try:
                     os.kill(pid, 9)

--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -1159,8 +1159,6 @@ class PostProcessing():
         return self._plot_point_scalars(scalars,
                                         show_node_numbering=show_node_numbering,
                                         **kwargs)
-###############################################################################
-
 
     def nodal_elastic_component_strain(self, component) -> np.ndarray:
         """Elastic nodal component strain
@@ -1432,12 +1430,8 @@ class PostProcessing():
         return self._plot_point_scalars(scalars,
                                         show_node_numbering=show_node_numbering,
                                         **kwargs)
-
-
-###############################################################################
-
-
-    def nodal_plastic_component_strain(self, component) -> np.ndarray:
+    
+	def nodal_plastic_component_strain(self, component) -> np.ndarray:
         """Plastic nodal component strain
 
         Equivalent MAPDL command:
@@ -1707,12 +1701,8 @@ class PostProcessing():
         return self._plot_point_scalars(scalars,
                                         show_node_numbering=show_node_numbering,
                                         **kwargs)
-
-
-###############################################################################
-
-
-    def nodal_thermal_component_strain(self, component) -> np.ndarray:
+    
+	def nodal_thermal_component_strain(self, component) -> np.ndarray:
         """Thermal nodal component strain
 
         Equivalent MAPDL command:
@@ -1982,4 +1972,3 @@ class PostProcessing():
         return self._plot_point_scalars(scalars,
                                         show_node_numbering=show_node_numbering,
                                         **kwargs)
-

--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -1431,7 +1431,7 @@ class PostProcessing():
                                         show_node_numbering=show_node_numbering,
                                         **kwargs)
     
-	def nodal_plastic_component_strain(self, component) -> np.ndarray:
+    def nodal_plastic_component_strain(self, component) -> np.ndarray:
         """Plastic nodal component strain
 
         Equivalent MAPDL command:
@@ -1702,7 +1702,7 @@ class PostProcessing():
                                         show_node_numbering=show_node_numbering,
                                         **kwargs)
     
-	def nodal_thermal_component_strain(self, component) -> np.ndarray:
+    def nodal_thermal_component_strain(self, component) -> np.ndarray:
         """Thermal nodal component strain
 
         Equivalent MAPDL command:

--- a/examples/00-mapdl-examples/2d_plate_with_a_hole.py
+++ b/examples/00-mapdl-examples/2d_plate_with_a_hole.py
@@ -306,7 +306,7 @@ def compute_stress_con(ratio):
     mapdl.antype('STATIC')
     mapdl.solve()
 
-	# Post-Processing
+    # Post-Processing
     # ~~~~~~~~~~~~~~~
     # grab the stress from the result
     result = mapdl.result

--- a/examples/00-mapdl-examples/2d_plate_with_a_hole.py
+++ b/examples/00-mapdl-examples/2d_plate_with_a_hole.py
@@ -306,8 +306,7 @@ def compute_stress_con(ratio):
     mapdl.antype('STATIC')
     mapdl.solve()
 
-
-    # Post-Processing
+	# Post-Processing
     # ~~~~~~~~~~~~~~~
     # grab the stress from the result
     result = mapdl.result

--- a/examples/00-mapdl-examples/3d_notch.py
+++ b/examples/00-mapdl-examples/3d_notch.py
@@ -262,8 +262,6 @@ print('Stress Concentration: %.2f' % stress_con)
 # # stress concentration for a variety of hole diameters.  For each
 # # batch, MAPDL is reset and the geometry is generated from scratch.
 
-
-
 # ###############################################################################
 # # Run the batch and record the stress concentration
 # k_t_exp = []

--- a/examples/00-mapdl-examples/mapdl_3d_beam.py
+++ b/examples/00-mapdl-examples/mapdl_3d_beam.py
@@ -65,4 +65,3 @@ result.plot_nodal_displacement(0, show_edges=True)
 # Animate a modal result
 # result.animate_nodal_solution(0, show_edges=True, loop=False, displacement_factor=10,
                               # movie_filename='demo.gif')
-

--- a/examples/00-mapdl-examples/mapdl_beam.py
+++ b/examples/00-mapdl-examples/mapdl_beam.py
@@ -63,8 +63,6 @@ print(mapdl.elist())
 for elem in mapdl.mesh.elem:
     print(elem)
 
-
-
 ###############################################################################
 # Define the boundary conditions
 

--- a/examples/00-mapdl-examples/vm-004-deflection_of_a_hinged_support.py
+++ b/examples/00-mapdl-examples/vm-004-deflection_of_a_hinged_support.py
@@ -142,7 +142,7 @@ mapdl.post_processing.plot_nodal_displacement(
     cmap='magma',
     line_width=5,
     cpos='xy',
-    scalar_bar_args={'title':'Displacement', 'vertical': False},
+    scalar_bar_args={'title': 'Displacement', 'vertical': False},
 )
 
 ###############################################################################

--- a/examples/03-tips-n-tricks/03-using_inline_functions_and_Query.py
+++ b/examples/03-tips-n-tricks/03-using_inline_functions_and_Query.py
@@ -115,4 +115,3 @@ for node in [node1, node2]:
     
     """
     print(message)
-

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,3 +1,4 @@
 codespell==2.1.0
+flake8==3.9.2
 
 

--- a/tests/test_inline_functions/test_query.py
+++ b/tests/test_inline_functions/test_query.py
@@ -49,5 +49,3 @@ class TestParseParameter:
         input_ = value
         with pytest.raises(TypeError):
             query._parse_parameter_integer_response(input_)
-
-

--- a/tests/test_inline_functions/test_selection_queries.py
+++ b/tests/test_inline_functions/test_selection_queries.py
@@ -272,5 +272,3 @@ class TestVLNEXT:
     def test_non_existing_volumes(self, query):
         next_ = query.vlnext(999)
         assert next_ == 0
-
-

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -43,9 +43,6 @@ if not get_start_instance():
 if not valid_versions:
     pytestmark = pytest.mark.skip("Requires MAPDL")
 
-
-
-
 paths = [('/usr/dir_v2019.1/slv/ansys_inc/v211/ansys/bin/ansys211', 211),
          ('C:/Program Files/ANSYS Inc/v202\\ansys/bin/win64/ANSYS202.exe', 202),
          ('/usr/ansys_inc/v211/ansys/bin/mapdl', 211)]
@@ -54,12 +51,9 @@ def test_version_from_path(path_data):
     exec_file, version = path_data
     assert _version_from_path(exec_file) == version
 
-
 def test_catch_version_from_path():
     with pytest.raises(RuntimeError):
         _version_from_path('abc')
-
-
 
 @pytest.mark.skipif(os.name != 'posix', reason="Requires Linux")
 @pytest.mark.skipif(not versions, reason="Requires ANSYS install")
@@ -76,13 +70,11 @@ def test_invalid_mode():
         exec_file = get_ansys_bin(valid_versions[0])
         pymapdl.launch_mapdl(exec_file, mode='notamode')
 
-
 @pytest.mark.skipif(not os.path.isfile(V150_EXEC), reason="Requires v150")
 def test_old_version():
     exec_file = get_ansys_bin('150')
     with pytest.raises(ValueError):
         pymapdl.launch_mapdl(exec_file, mode='corba')
-
 
 @pytest.mark.skipif(not os.name == 'nt', reason="Requires windows")
 @pytest.mark.console
@@ -91,7 +83,6 @@ def test_failed_console():
     with pytest.raises(ValueError):
         pymapdl.launch_mapdl(exec_file, mode='console')
 
-
 @pytest.mark.parametrize('version', valid_versions)
 @pytest.mark.console
 @pytest.mark.skipif(os.name != 'posix', reason="Only supported on Linux")
@@ -99,7 +90,6 @@ def test_launch_console(version):
     exec_file = get_ansys_bin(version)
     mapdl = pymapdl.launch_mapdl(exec_file, mode='console')
     assert mapdl.version == int(version)/10
-
 
 @pytest.mark.corba
 @pytest.mark.parametrize('version', valid_versions)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -34,8 +34,6 @@ esize,5
 vmesh,all
 """
 
-
-
 @pytest.fixture(scope='function')
 def make_block(mapdl, cleared):
     mapdl.block(0, 1, 0, 1, 0, 1)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -431,5 +431,3 @@ def test_free(mm):
 
 def test_repr(mm):
     assert mm._status == repr(mm)
-
-


### PR DESCRIPTION
This is the first PR to introduce flake8 to enforce PEP8 guidelines. The flake8 configuration is defined in the `.flake8` file. Running flake8 was added as part of the style CI process.

This PR addresses issues with blank lines, indentations, and whitespace corresponding to error codes W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, F403. There are still more error codes to address in following PRs.