### PR TITLE
Additional flake8 standards

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 exclude = venv, __init__.py, build
-# To be added after refactoring code to be compliant: E501, F401, W191, W291, W293
-select = W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, F403
+# To be added after refactoring code to be compliant: E501 
+select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, F401, F403
 count = True
 max-complexity = 10
 max-line-length = 100

--- a/ansys/mapdl/core/_commands/database/selecting.py
+++ b/ansys/mapdl/core/_commands/database/selecting.py
@@ -3,7 +3,8 @@ entities for further operations.
 """
 
 from typing import Optional, Union
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+
+from ansys.mapdl.core.mapdl_types import MapdlInt
 
 
 class Selecting:

--- a/ansys/mapdl/core/_commands/graphics_/style.py
+++ b/ansys/mapdl/core/_commands/graphics_/style.py
@@ -1,7 +1,7 @@
 import warnings
-
 from typing import Optional, Union
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+
+from ansys.mapdl.core.mapdl_types import MapdlInt
 
 
 class Style:

--- a/ansys/mapdl/core/_commands/post1_/element_table.py
+++ b/ansys/mapdl/core/_commands/post1_/element_table.py
@@ -1,5 +1,6 @@
-from typing import Optional, Union
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+from typing import Optional
+
+from ansys.mapdl.core.mapdl_types import MapdlInt
 
 
 class ElementTable:

--- a/ansys/mapdl/core/_commands/post26_/setup.py
+++ b/ansys/mapdl/core/_commands/post26_/setup.py
@@ -1,5 +1,6 @@
-from typing import Optional, Union
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+from typing import Optional
+
+from ansys.mapdl.core.mapdl_types import MapdlInt
 
 
 class Setup:

--- a/ansys/mapdl/core/_commands/preproc/element_type.py
+++ b/ansys/mapdl/core/_commands/preproc/element_type.py
@@ -3,8 +3,8 @@ These PREP7 commands define the type of elements to be used in the model.
 """
 from typing import Optional, Union
 
-from ansys.mapdl.core._commands.parse import parse_e, parse_et
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+from ansys.mapdl.core._commands.parse import parse_et
+from ansys.mapdl.core.mapdl_types import MapdlInt
 
 
 class ElementType:

--- a/ansys/mapdl/core/_commands/preproc/explicit_dynamics.py
+++ b/ansys/mapdl/core/_commands/preproc/explicit_dynamics.py
@@ -1,6 +1,6 @@
-from typing import Optional, Union
+from typing import Optional
 
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+from ansys.mapdl.core.mapdl_types import MapdlFloat, MapdlInt
 
 
 class ExplicitDynamics:

--- a/ansys/mapdl/core/_commands/preproc/status.py
+++ b/ansys/mapdl/core/_commands/preproc/status.py
@@ -1,6 +1,4 @@
-from typing import Optional, Union
-
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+from typing import Optional
 
 
 class Status:

--- a/ansys/mapdl/core/_commands/preproc/volumes.py
+++ b/ansys/mapdl/core/_commands/preproc/volumes.py
@@ -1,7 +1,7 @@
 from typing import Optional, Union
 
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
 from ansys.mapdl.core._commands import parse
+from ansys.mapdl.core.mapdl_types import MapdlInt
 
 
 class Volumes:

--- a/ansys/mapdl/core/_commands/solution/analysis_options.py
+++ b/ansys/mapdl/core/_commands/solution/analysis_options.py
@@ -1,5 +1,6 @@
-from typing import Optional, Union
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+from typing import Optional
+
+from ansys.mapdl.core.mapdl_types import MapdlInt
 
 
 class AnalysisOptions:

--- a/ansys/mapdl/core/_commands/solution/birth_and_death.py
+++ b/ansys/mapdl/core/_commands/solution/birth_and_death.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union
-from ansys.mapdl.core.mapdl_types import MapdlInt, MapdlFloat
+
+from ansys.mapdl.core.mapdl_types import MapdlFloat
 
 
 class BirthAndDeath:

--- a/ansys/mapdl/core/examples/examples.py
+++ b/ansys/mapdl/core/examples/examples.py
@@ -11,6 +11,3 @@ wing_model = os.path.join(dir_path, "wing.dat")
 # This way, files can be loaded with:
 # from ansys.mapdl.core import examples
 # examples.wing_model
-
-# downloadable files
-from .downloads import download_bracket

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1137,7 +1137,7 @@ class _MapdlCore(Commands):
     @property
     def _has_matplotlib(self):
         try:
-            import matplotlib # noqa: F401
+            import matplotlib  # noqa: F401
 
             return True
         except ImportError:

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1137,7 +1137,7 @@ class _MapdlCore(Commands):
     @property
     def _has_matplotlib(self):
         try:
-            import matplotlib
+            import matplotlib # noqa: F401
 
             return True
         except ImportError:

--- a/ansys/mapdl/core/mapdl_types.py
+++ b/ansys/mapdl/core/mapdl_types.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Union
 
 MapdlInt = Union[
     str, int

--- a/ansys/mapdl/core/parameters.py
+++ b/ansys/mapdl/core/parameters.py
@@ -1,14 +1,11 @@
+import os
 import tempfile
 import weakref
 
-import os
 import numpy as np
-
-from ansys.mapdl.reader._reader import write_array
-
-from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core.mapdl import _MapdlCore
 from ansys.mapdl.core.misc import supress_logging
+from ansys.mapdl.reader._reader import write_array
 
 ROUTINE_MAP = {
     0: "Begin level",

--- a/docker/mapdl/reduce_mapdl.py
+++ b/docker/mapdl/reduce_mapdl.py
@@ -25,11 +25,9 @@ This misses some files that will be needed by different architectures, like:
 /ansys_inc/v211/tp/IntelMKL/2020.0.166/linx64/lib/intel64/libmkl_def.so
 
 """
-import shutil
 import math
-import stat
-import time
 import os
+import stat
 
 import numpy as np
 

--- a/examples/02-geometry/04-primitives.py
+++ b/examples/02-geometry/04-primitives.py
@@ -8,9 +8,6 @@ using Pythonic PREP7 volume commands.
 
 """
 
-import pyvista
-import numpy as np
-
 from ansys.mapdl.core import launch_mapdl
 
 # start MAPDL and enter the pre-processing routine

--- a/examples/03-tips-n-tricks/03-using_inline_functions_and_Query.py
+++ b/examples/03-tips-n-tricks/03-using_inline_functions_and_Query.py
@@ -108,6 +108,6 @@ for node in [node1, node2]:
     X | {x_displacement}
     Y | {y_displacement}
     Z | {z_displacement}
-    
+
     """
     print(message)

--- a/examples/03-tips-n-tricks/03-using_inline_functions_and_Query.py
+++ b/examples/03-tips-n-tricks/03-using_inline_functions_and_Query.py
@@ -16,7 +16,6 @@ First, get an instance of
 """
 
 from ansys.mapdl.core import launch_mapdl
-from ansys.mapdl.core.inline_functions import Query
 
 mapdl = launch_mapdl()
 

--- a/examples/03-tips-n-tricks/04-rotational-displacement.py
+++ b/examples/03-tips-n-tricks/04-rotational-displacement.py
@@ -113,7 +113,7 @@ A | {rotations[0][0]:11.6f},{rotations[0][1]:11.6f},{rotations[0][2]:11.6f}
 B | {rotations[1][0]:11.6f},{rotations[1][1]:11.6f},{rotations[1][2]:11.6f}
 C | {rotations[2][0]:11.6f},{rotations[2][1]:11.6f},{rotations[2][2]:11.6f}
 D | {rotations[3][0]:11.6f},{rotations[3][1]:11.6f},{rotations[3][2]:11.6f}
- 
+
 """
 
 print(message)

--- a/examples/03-tips-n-tricks/04-rotational-displacement.py
+++ b/examples/03-tips-n-tricks/04-rotational-displacement.py
@@ -17,7 +17,6 @@ of our square.
 
 # start MAPDL and enter the pre-processing routine
 from ansys.mapdl.core import launch_mapdl
-from ansys.mapdl.core.inline_functions import Query
 
 mapdl = launch_mapdl()
 mapdl.prep7()

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,6 @@
 """Shared testing module"""
-from typing import Dict, Tuple
 from collections import namedtuple
-
+from typing import Dict
 
 Node = namedtuple("Node", ["number", "x", "y", "z", "thx", "thy", "thz"])
 Element = namedtuple(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -3,20 +3,17 @@
 This has been copied from test_mapdl.py
 
 """
-import time
 import os
+import time
 
-import pytest
 import numpy as np
+import pytest
 import pyvista
-from pyvista.plotting.renderer import CameraPosition
-from pyvista.plotting import system_supports_plotting
-
-from ansys.mapdl.reader import examples
-
-from ansys.mapdl.core.misc import random_string
-from ansys.mapdl.core.errors import MapdlRuntimeError
 from ansys.mapdl import core as pymapdl
+from ansys.mapdl.core.errors import MapdlRuntimeError
+from ansys.mapdl.reader import examples
+from pyvista.plotting import system_supports_plotting
+from pyvista.plotting.renderer import CameraPosition
 
 skip_no_xserver = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires active X Server"

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -3,20 +3,17 @@
 This has been copied from test_mapdl.py
 
 """
-import time
 import os
+import time
 
-import pytest
 import numpy as np
+import pytest
 import pyvista
-from pyvista.plotting.renderer import CameraPosition
-from pyvista.plotting import system_supports_plotting
-
-from ansys.mapdl.reader import examples
-
-from ansys.mapdl.core.misc import random_string
-from ansys.mapdl.core.errors import MapdlRuntimeError
 from ansys.mapdl import core as pymapdl
+from ansys.mapdl.core.errors import MapdlRuntimeError
+from ansys.mapdl.reader import examples
+from pyvista.plotting import system_supports_plotting
+from pyvista.plotting.renderer import CameraPosition
 
 skip_no_xserver = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires active X Server"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -9,6 +9,7 @@ from ansys.mapdl.core.misc import get_ansys_bin
 
 try:
     import ansys_corba  # noqa: F401
+
     HAS_CORBA = True
 except:
     HAS_CORBA = False

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,15 +1,14 @@
 """Test the mapdl launcher"""
-import weakref
 import os
-import pytest
+import weakref
 
+import pytest
 from ansys.mapdl import core as pymapdl
+from ansys.mapdl.core.launcher import _version_from_path, get_start_instance
 from ansys.mapdl.core.misc import get_ansys_bin
-from ansys.mapdl.core.launcher import get_start_instance, _version_from_path
 
 try:
-    import ansys_corba
-
+    import ansys_corba  # noqa: F401
     HAS_CORBA = True
 except:
     HAS_CORBA = False

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1,19 +1,16 @@
 """Test MAPDL interface"""
-import time
 import os
+import time
 
-import pytest
 import numpy as np
-import pyvista
-from pyvista.plotting.renderer import CameraPosition
-from pyvista.plotting import system_supports_plotting
-from ansys.mapdl.reader import examples
-
-from ansys.mapdl.core.misc import random_string
-from ansys.mapdl.core.errors import MapdlRuntimeError
+import pytest
 from ansys.mapdl import core as pymapdl
-
-from conftest import ON_CI
+from ansys.mapdl.core.errors import MapdlRuntimeError
+from ansys.mapdl.core.misc import random_string
+from ansys.mapdl.reader import examples
+from pyvista import PolyData
+from pyvista.plotting import system_supports_plotting
+from pyvista.plotting.renderer import CameraPosition
 
 skip_no_xserver = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires active X Server"
@@ -279,7 +276,7 @@ def test_lines(cleared, mapdl):
     l3 = mapdl.l(k3, k0)
 
     lines = mapdl.geometry.lines
-    assert isinstance(lines, pyvista.PolyData)
+    assert isinstance(lines, PolyData)
     assert np.allclose(mapdl.geometry.lnum, [l0, l1, l2, l3])
     assert mapdl.geometry.n_line == 4
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,11 +1,6 @@
 """Small or misc tests that don't fit in other test modules"""
-import numpy as np
-import pyvista as pv
-
-import pytest
-from pyvista.plotting import system_supports_plotting
-
 from ansys.mapdl import core as pymapdl
+from pyvista.plotting import system_supports_plotting
 
 
 def test_report():

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1,13 +1,9 @@
 """Test post-processing module for ansys.mapdl"""
-import os
-
-from pyvista.plotting.renderer import CameraPosition
-import pytest
 import numpy as np
-
-from ansys.mapdl.core.errors import MapdlRuntimeError
+import pytest
 from ansys.mapdl.core import examples
 from ansys.mapdl.core.post import COMPONENT_STRESS_TYPE, PRINCIPAL_TYPE
+from pyvista.plotting.renderer import CameraPosition
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Organizes imports and removes any unused module imports. Adds extra directives to flake8 config after black formatting. 