### PR TITLE
Fix parameter name in `launcher.py`

### DIFF
--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -726,7 +726,7 @@ def _validate_add_sw(add_sw, exec_path, force_intel=False):
                 add_sw = re.sub(regex, '', add_sw)
                 warnings.warn(INTEL_MSG)
 
-            if _version_from_path(exec_file) >= 210:
+            if _version_from_path(exec_path) >= 210:
                 add_sw += ' -mpi msmpi'
 
     return add_sw


### PR DESCRIPTION
`launch_mapdl` fails outright due to an invalid parameter name.

This is a reminder to self that we need to implement some sort of windows CI.  As much as I don't want to pay for a build machine, we might have to.  I might borrow the one used for AEDT since they're not at 100% usage.