### PR TITLE
remove file logging

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -107,14 +107,6 @@ def setup_logger(loglevel='INFO', log_file=True):
     # add ch to logger
     log.addHandler(ch)
 
-    if log_file:
-        file_handler = logging.FileHandler('PyMAPDL.log')
-        file_handler.setLevel(loglevel)
-        file_handler.setFormatter(formatter)
-
-    # creating a file handler
-    log.addHandler(file_handler)
-
     # make persistent
     setup_logger.log = log
 


### PR DESCRIPTION
An unintended (or unintentional) side effect of the file logger is that the log file is created for each and every run of pymapdl.  While I appreciate the log, it's often unneeded and we can't control its location.

Removing this for now and requesting that we instead either add it to the launcher, or better, add it as a method to the `Mapdl` class to control both the level of the handler and the location of the file. 
