### PR TITLE
disable default license checkout on LicenseChecker

### DIFF
--- a/ansys/mapdl/core/licensing.py
+++ b/ansys/mapdl/core/licensing.py
@@ -391,7 +391,7 @@ class LicenseChecker:
         else:
             self._license_checkout_success = True
 
-    def start(self, license_file=True, checkout_license=True):
+    def start(self, license_file=True, checkout_license=False):
         """Start monitoring the license file and attempt a license checkout.
 
         Parameters
@@ -399,7 +399,8 @@ class LicenseChecker:
         license_file : bool, optional
             Start the license file thread.
         checkout_license : bool, optional
-            Start the checkout license thread.
+            Start the checkout license thread.  By default this is
+            disabled.
 
         """
         if license_file:


### PR DESCRIPTION
Some testing on a recent install with AEDT revealed that the Ansys license utility in `ansysli_util_path` in ``checkout_license`` may or may not be installed in `shared_files` (or `Shared Files` on Windows).

This PR disables the check by default to avoid a false negative if unable to locate the license utility and MAPDL fails to start.  License file appears unaffected.
