### PR TITLE
fix use gRPC functionality

### DIFF
--- a/ansys/mapdl/core/inline_functions/component_queries.py
+++ b/ansys/mapdl/core/inline_functions/component_queries.py
@@ -27,7 +27,6 @@ class _ComponentQueries(_ParameterParsing):
         and ``(1, 2, 3)`` then find the centroid x-coordinate of this
         element.
 
-        >>> from ansys.mapdl.core.inline_functions import Query
         >>> from ansys.mapdl.core import launch_mapdl
         >>> mapdl = launch_mapdl()
         >>> mapdl.prep7()
@@ -35,12 +34,10 @@ class _ComponentQueries(_ParameterParsing):
         >>> n1 = mapdl.n(2, 1, 2, 3)
         >>> mapdl.et(1, 'LINK11')
         >>> e0 = mapdl.e(n0, n1)
-        >>> q = Query(mapdl)
-        >>> q.centrx(e0)
+        >>> mapdl.queries.centrx(e0)
         0.5
         """
-        response = self._mapdl.run(f"_=CENTRX({e})")
-        return self._parse_parameter_float_response(response)
+        return self._run_query(f"CENTRX({e})")
 
     def centry(self, e: int) -> float:
         """Return the y coordinate of the element centroid.
@@ -408,12 +405,10 @@ class _InverseGetComponentQueries(_ParameterParsing):
         >>> mapdl.k(1, 0, 1, 2)
         >>> mapdl.k(2, 1, 2, 0)
         >>> mapdl.k(3, 2, 0, 1)
-        >>> q = Query(mapdl)
-        >>> q.kp(1., 1., 1.)
+        >>> mapdl.queries.kp(1., 1., 1.)
         1
         """
-        response = self._mapdl.run(f"_=KP({x},{y},{z})")
-        return self._parse_parameter_integer_response(response)
+        return self._run_query(f"KP({x},{y},{z})", integer=True)
 
 
 class _DisplacementComponentQueries(_ParameterParsing):


### PR DESCRIPTION
This PR proposes that we use the gRPC functionality `scalar_param` "under the hood" when querying using our inline functions.

Advantage of this approach is we no longer have to rely on parsing text of the response, but rather can query the variable directly using a lower level gRPC method.  Ideally, we would use `get_value` and completely skip the "middle-man" of generating a query and obtaining the value of the temporary parameter, but that would require rewriting our existing commands to instead use the `*GET` command pattern (non-trivial work).

Only two commands were refactored, I'm leaving the rest for you @jgd10.
