### PR TITLE
WIP - Feat/ main logger

### DIFF
--- a/ansys/mapdl/core/errors.py
+++ b/ansys/mapdl/core/errors.py
@@ -1,5 +1,7 @@
 """pymapdl specific errors"""
-import logging
+from ansys.mapdl.core.log import getLogger
+logger = getLogger(__name__)
+
 import threading
 import signal
 from functools import wraps
@@ -7,8 +9,6 @@ from functools import wraps
 from grpc._channel import _InactiveRpcError, _MultiThreadedRendezvous
 
 SIGINT_TRACKER = []
-
-logger = logging.getLogger(__name__)
 
 
 LOCKFILE_MSG = """

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -1,6 +1,6 @@
 """Module for launching MAPDL locally or connecting to a remote instance with gRPC."""
 from ansys.mapdl.core import log
-logger = log.getLogger(__name__)
+logger = log.getLogger(__name__, loglevel='DEBUG')
 
 import platform
 from glob import glob
@@ -122,7 +122,7 @@ def close_all_local_instances(port_range=None):
         port_range = range(50000, 50200)
 
     @threaded
-    def close_mapdl(port):
+    def close_mapdl(port, name='Closing mapdl thread.'):
         try:
             mapdl = MapdlGrpc(port=port, set_no_abort=False)
             mapdl.exit()

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -1,6 +1,6 @@
 """Module for launching MAPDL locally or connecting to a remote instance with gRPC."""
 from ansys.mapdl.core import log
-logger = log.getLogger('launcher')
+logger = log.getLogger(__name__)
 
 import platform
 from glob import glob

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -1,4 +1,9 @@
 """Module for launching MAPDL locally or connecting to a remote instance with gRPC."""
+import logging
+from ansys.mapdl.core import log
+
+logger = log.getLogger('launcher')
+
 import platform
 from glob import glob
 import re
@@ -32,14 +37,14 @@ ALLOWABLE_MODES = ["corba", "console", "grpc"]
 LOCALHOST = "127.0.0.1"
 MAPDL_DEFAULT_PORT = 50052
 
-INTEL_MSG = """Due to incompatibilites between 'DMP', Windows and VPN connections,
+INTEL_MSG = """Due to incompatibilities between 'DMP', Windows and VPN connections,
 the flat '-mpi INTELMPI' is overwritten by '-mpi msmpi'.
 
 If you still want to use 'INTEL', set:
 
 launch_mapdl(..., force_intel=True, additional_switches='-mpi INTELMPI')
 
-Be aware of possible errors or unexpected behaviour with this configuration.
+Be aware of possible errors or unexpected behavior with this configuration.
 """
 
 

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -1,7 +1,5 @@
 """Module for launching MAPDL locally or connecting to a remote instance with gRPC."""
-import logging
 from ansys.mapdl.core import log
-
 logger = log.getLogger('launcher')
 
 import platform

--- a/ansys/mapdl/core/log.py
+++ b/ansys/mapdl/core/log.py
@@ -22,7 +22,8 @@ LOG_LEVEL = logging.DEBUG
 FILE_NAME = 'pyansys.log'
 
 ## Single configuration
-CONSOLE_MSG_FORMAT = '%(funcName)-15s - %(message)s'
+LAUNCHER_LOGGER = 'launcher'
+CONSOLE_MSG_FORMAT = '%(module)-15s - %(funcName)-15s - %(message)s'
 FILE_MSG_FORMAT = '%(asctime)-15s | %(module)-15s | %(funcName)-15s | %(message)s'
 DEFAULT_FILE_HEADER = """
 Date Time               | Module          | Function        | Message
@@ -41,13 +42,18 @@ Date Time               | Thread          | Module          | Function        | 
 
 def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=LOG_LEVEL):
 
-    default_file_header = DEFAULT_FILE_HEADER_POOL if name == 'pool' else DEFAULT_FILE_HEADER
+    default_file_header = DEFAULT_FILE_HEADER_POOL if name == POOL_LOGGER else DEFAULT_FILE_HEADER
 
     previous_loggers = logging.root.manager.__dict__['loggerDict']
-    if previous_loggers:
+    loggers = [each_logger for each_logger in previous_loggers.keys() if LAUNCHER_LOGGER in each_logger or POOL_LOGGER in each_logger]
+
+    if loggers:
         # is not empty
-        parent_logger = list(previous_loggers.values())[-1]  #
-        logger = parent_logger.getChild(name)
+        # parent_logger = list(previous_loggers.values())[-1]  #
+        # logger = parent_logger.getChild(name)
+        hierarchy_len = [len(each.split('.')) for each in loggers]
+        logger_name = [value for index, value in enumerate(loggers) if hierarchy_len[index] == max(hierarchy_len)][0]
+        logger = previous_loggers[logger_name].getChild(name)
 
         if file_msg is None and console_msg is None and logger.parent.name != POOL_LOGGER:
             # We are not going to change the message output, hence we can reuse the whole logger.

--- a/ansys/mapdl/core/log.py
+++ b/ansys/mapdl/core/log.py
@@ -17,46 +17,74 @@
 # >
 
 import logging
-
+## General configuration
 LOG_LEVEL = logging.DEBUG
-CONSOLE_MSG_FORMAT = '%(funcName)s - %(message)s'
-FILE_MSG_FORMAT = '%(asctime)s - %(module)s:%(funcName)s- %(message)s'
 FILE_NAME = 'pyansys.log'
 
-CONSOLE_MSG_POOL_FORMAT = '%(threadName)s: %(module)s: %(funcName)s - %(message)s'
-FILE_MSG_POOL_FORMAT = '%(asctime)s - %(threadName)s: %(module)s: %(funcName)s - %(message)s'
+## Single configuration
+CONSOLE_MSG_FORMAT = '%(funcName)-15s - %(message)s'
+FILE_MSG_FORMAT = '%(asctime)-15s | %(module)-15s | %(funcName)-15s | %(message)s'
+DEFAULT_FILE_HEADER = """
+Date Time               | Module          | Function        | Message
+------------------------|-----------------|-----------------|---------
+"""
+
+## Pool configuration
+POOL_LOGGER = 'pool'
+CONSOLE_MSG_POOL_FORMAT = '%(threadName)-15s - %(module)-15s - %(funcName)-15s - %(message)s'
+FILE_MSG_POOL_FORMAT = '%(asctime)-15s | %(threadName)-15s | %(module)-15s | %(funcName)-15s | %(message)s'
+DEFAULT_FILE_HEADER_POOL = """
+Date Time               | Thread          | Module          | Function        | Message
+------------------------|-----------------|-----------------|-----------------|---------------------------
+"""
 
 
 def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=LOG_LEVEL):
-    logger = logging.getLogger(name)
 
-    if logger.parent.hasHandlers():
+    default_file_header = DEFAULT_FILE_HEADER_POOL if name == 'pool' else DEFAULT_FILE_HEADER
 
-        if file_msg is None and console_msg is None and logger.parent.name != 'pool':
+    previous_loggers = logging.root.manager.__dict__['loggerDict']
+    if previous_loggers:
+        # is not empty
+        parent_logger = list(previous_loggers.values())[-1]  #
+        logger = parent_logger.getChild(name)
+
+        if file_msg is None and console_msg is None and logger.parent.name != POOL_LOGGER:
             # We are not going to change the message output, hence we can reuse the whole logger.
             return logger
 
-        ## There is a previous logger used
+        def instance_but_not_subclass(obj, klass):
+            return type(obj) is klass
+
+        # There is a previous logger used
         # Since there is no easy way to modify the format at a given logger, we just create a new one (logger)
         # and pass the same file and stream handlers as the parent one, giving the option for change the format.
-        fh = [each_handler for each_handler in logger.parent.handlers if isinstance(each_handler, logging.FileHandler)][0]
-        ch = [each_handler for each_handler in logger.parent.handlers if isinstance(each_handler, logging.StreamHandler)][0]
+        fh = [each_handler for each_handler in logger.parent.handlers if instance_but_not_subclass(
+            each_handler, FileHandlerWithHeader)][0]
+        ch = [each_handler for each_handler in logger.parent.handlers if instance_but_not_subclass(
+            each_handler, logging.StreamHandler)][0]
 
-        if logger.parent.name == 'pool':
-            fh.setFormatter(logging.Formatter(file_msg or FILE_MSG_POOL_FORMAT))
-            ch.setFormatter(logging.Formatter(console_msg or CONSOLE_MSG_POOL_FORMAT))
+        if logger.parent.name == POOL_LOGGER:
+            fh.setFormatter(logging.Formatter(
+                file_msg or FILE_MSG_POOL_FORMAT))
+            ch.setFormatter(logging.Formatter(
+                console_msg or CONSOLE_MSG_POOL_FORMAT))
 
         else:
             fh.setFormatter(logging.Formatter(file_msg or fh.formatter._fmt))
-            ch.setFormatter(logging.Formatter(console_msg or ch.formatter._fmt))
+            ch.setFormatter(logging.Formatter(
+                console_msg or ch.formatter._fmt))
 
+        logger.setLevel(logger.parent.level)
         logger.propagate = False
 
     else:
         # There is no parent logger, so we create it.
+        logger = logging.getLogger(name)
         logger.setLevel(loglevel)
-        fh = logging.StreamHandler()
-        ch = logging.FileHandler(fname or FILE_NAME)
+        ch = logging.StreamHandler()
+        fh = FileHandlerWithHeader(
+            fname or FILE_NAME, header=default_file_header)
 
         fh.setFormatter(logging.Formatter(file_msg or FILE_MSG_FORMAT))
         ch.setFormatter(logging.Formatter(console_msg or CONSOLE_MSG_FORMAT))
@@ -66,3 +94,19 @@ def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=L
     logger.addHandler(fh)
 
     return logger
+
+
+# Create a class that extends the FileHandler class from logging.FileHandler
+class FileHandlerWithHeader(logging.FileHandler):
+
+    # Pass the file name and header string to the constructor.
+    def __init__(self, *args, **kwargs):
+        # self._builtin_open = super()._builtin_open
+
+        # Store the header information.
+        self.header = kwargs.pop('header', DEFAULT_FILE_HEADER)
+
+        # Call the parent __init__
+        super().__init__(*args, **kwargs)
+
+        self.stream.write('\n' + self.header)

--- a/ansys/mapdl/core/log.py
+++ b/ansys/mapdl/core/log.py
@@ -3,22 +3,23 @@
 # The approach is to call ``Getlogger``` at the beginning of each module.
 # Functions in several ways:
 # * If ``GetLogger`` gets called before any other logger has been initialized, it will create
-# the default logger which parameters are a constant in this module.
+# the default logger which parameters are constants in this module.
 # * If ``GetLogger`` gets called after another logger has been created, there are two options:
-#    * If we do not intend changes in the messages format, it will return a child logger with
-# the default name. This child logger will redirect all the output to the main.
+#    * If we do not intend changes in the messages format or the caller is not the pool library, 
+#      it will return a child logger. This child logger will redirect all the output to the main.
 #    * If we do intend changes in the message format because maybe we want to account for
-# different context, a new child logger is created with the same handlers as the parent and
-# using the providen message format or the parent message format.
-#
+# different context (for example when using the ``pool`` module), a new child logger is created
+#  with the same handlers as the parent and using the providen message format or the parent message format.
+# You can change both, the file message format or the console message format. 
+# But you cannot change the present handlers or the file where the log is being written.
+
 # In cases we want to change the format according to different contexts, for example when the
 # module launcher is called by the pool module:
-#
+
 # >
 
 import logging
 import sys, os
-import threading
 
 
 ## General configuration
@@ -44,93 +45,33 @@ Date Time               | Level name   | Thread          | Module          | Fun
 """
 
 
-def getLogger(name=None, record_file=True, console_output=True, file_msg=None, console_msg=None, fname=None, loglevel=LOG_LEVEL, record_uncaught_exceptions=True):
+def getLogger(name=None, record_file=True, console_output=True, file_msg=None, console_msg=None, fname=FILE_NAME, loglevel=LOG_LEVEL, record_uncaught_exceptions=True):
+    """"""
+    log_last_name = name.split('.')[-1] 
+    # if we are creating a logger for the pool class:
+    default_file_header = DEFAULT_FILE_HEADER_POOL if POOL_LOGGER in name else DEFAULT_FILE_HEADER
 
-    default_file_header = DEFAULT_FILE_HEADER_POOL if name == POOL_LOGGER else DEFAULT_FILE_HEADER
-    log_name = name.split('.')[-1]
+    if not hasattr(logging.root, '_last_logger'):
+        # There is no parent logger, so we create it.
+        logger = logging.getLogger(log_last_name)
+        logger = _configure_default_logger(logger, loglevel, record_file, console_output, file_msg, console_msg, fname, default_file_header)
 
-    previous_loggers = logging.root.manager.__dict__['loggerDict']
-    loggers = [each_logger for each_logger in previous_loggers.keys() if LAUNCHER_LOGGER in each_logger or POOL_LOGGER in each_logger]
-
-    if loggers:
-        # is not empty
-        # parent_logger = list(previous_loggers.values())[-1]  #
-        # logger = parent_logger.getChild(name)
-        # hierarchy_len = [len(each.split('.')) for each in loggers]
-        # logger_name = [value for index, value in enumerate(loggers) if hierarchy_len[index] == max(hierarchy_len)][0]
-        # logger_name = loggers[]
-        logger_name = logging.root.last_logger
-        logger = previous_loggers[logger_name].getChild(log_name)
-        logging.root.last_logger = logger.name
-
-        if file_msg is None and console_msg is None and logger.parent.name != POOL_LOGGER:
-            # We are not going to change the message output, hence we can reuse the whole logger.
-            return logger
-
-        def instance_but_not_subclass(obj, klass):
-            return type(obj) is klass
+    else:
+        # there are previous loggers defined.
+        logger = _get_logger_child(name, record_file, console_output, file_msg, console_msg) 
 
         # There is a previous logger used
         # Since there is no easy way to modify the format at a given logger, we just create a new one (logger)
         # and pass the same file and stream handlers as the parent one, giving the option for change the format.
-        first_logger = previous_loggers[logging.root.first_logger]
 
-        file_handlers = [each_handler for each_handler in first_logger.handlers if instance_but_not_subclass(
-            each_handler, FileHandlerWithHeader)]
-        console_handlers = [each_handler for each_handler in first_logger.handlers if instance_but_not_subclass(
-            each_handler, logging.StreamHandler)]
-
-        if file_handlers:
-            fh = file_handlers[0]
-            if logger.parent.name == POOL_LOGGER:
-                fh.setFormatter(logging.Formatter(file_msg or FILE_MSG_POOL_FORMAT))
-            else:
-                fh.setFormatter(logging.Formatter(file_msg or fh.formatter._fmt))
-
-        if console_handlers:
-            ch = console_handlers[0]
-            if logger.parent.name == POOL_LOGGER:
-                ch.setFormatter(logging.Formatter(console_msg or CONSOLE_MSG_POOL_FORMAT))
-            else:
-                ch.setFormatter(logging.Formatter(console_msg or ch.formatter._fmt))
-
-        logger.setLevel(logger.parent.level)
-        logger.propagate = False  # This is important to avoid duplicated logs.
-
-    else:
-        # There is no parent logger, so we create it.
-        logger = logging.getLogger(log_name)
-        logging.root.last_logger = logger.name
-        logging.root.first_logger = logger.name
-        logger.setLevel(loglevel)
-        if record_file:
-            fh = FileHandlerWithHeader(
-                fname or FILE_NAME, header=default_file_header)
-            fh.setFormatter(logging.Formatter(file_msg or FILE_MSG_FORMAT))
-
-        if console_output:
-            ch = logging.StreamHandler()
-            ch.setFormatter(logging.Formatter(console_msg or CONSOLE_MSG_FORMAT))
-
-        logger.propagate = True  # Probably this is irrelevant.
-
-    if record_file:
-        logger.addHandler(fh)
-    if console_output:
-        logger.addHandler(ch)
-
+        if POOL_LOGGER == logger.parent.name or POOL_LOGGER == log_last_name:
+            # Adding header again.
+            with open(fname, 'a') as fid:
+                fid.write(DEFAULT_FILE_HEADER_POOL)
 
     ## Using logger to record unhandled exceptions
-
     if record_uncaught_exceptions:
-        def handle_exception(exc_type, exc_value, exc_traceback):
-            if issubclass(exc_type, KeyboardInterrupt):
-                sys.__excepthook__(exc_type, exc_value, exc_traceback)
-                return
-
-            logger.critical("\nUncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
-
-        sys.excepthook = handle_exception
+        add_handling_uncaught_expections(logger)
 
     return logger
 
@@ -148,5 +89,97 @@ class FileHandlerWithHeader(logging.FileHandler):
         # Call the parent __init__
         super().__init__(*args, **kwargs)
 
-        if os.stat(self.stream.name).st_size < 2: # <0 should be alright.
+        # Checking if the file is empty
+        if os.stat(self.stream.name).st_size < 2: # <0 should be alright too.
             self.stream.write(self.header)
+
+
+def add_handling_uncaught_expections(logger):
+
+    def handle_exception(exc_type, exc_value, exc_traceback):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_traceback)
+            return
+        logger.critical("\nUncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+    sys.excepthook = handle_exception
+
+
+def _configure_default_logger(logger, loglevel, record_file, console_output, file_msg, console_msg, fname, default_file_header):
+    # There is no parent logger, so we create it.
+    logging.root._last_logger = logger.name
+    logging.root._first_logger = logger.name
+
+    logger.setLevel(loglevel)
+    if record_file:
+        fh = FileHandlerWithHeader(fname, header=default_file_header)
+        fh.setFormatter(logging.Formatter(file_msg or FILE_MSG_FORMAT))
+        logger.addHandler(fh)
+
+    if console_output:
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter(console_msg or CONSOLE_MSG_FORMAT))
+        logger.addHandler(ch)
+
+    logger.propagate = True  # Probably this is irrelevant.
+
+
+def get_logger_parent():
+    logger_name = logging.root._last_logger
+    return previous_loggers()[logger_name]
+
+
+def _instance_but_not_subclass(obj, _class):
+    return type(obj) is _class
+
+
+def previous_loggers():
+    return logging.root.manager.__dict__['loggerDict']
+
+
+def _get_logger_child(name, record_file, console_output, file_msg, console_msg):
+    # is not empty
+    log_last_name = name.split('.')[-1]
+    logger = get_logger_parent().getChild(log_last_name)
+    logging.root._last_logger = logger.name # Updating
+
+    # Case that we are logging on pool.
+    if POOL_LOGGER == log_last_name or POOL_LOGGER == logger.parent.name:
+        if file_msg is None:
+            file_msg = FILE_MSG_POOL_FORMAT
+        if console_msg is None:
+            console_msg = CONSOLE_MSG_POOL_FORMAT
+
+    if file_msg is None and console_msg is None:
+        # We are not going to change the message output, hence we can reuse the whole logger.
+        return logger
+
+    # There is a previous defined logger
+    # Since there is no easy way to modify the format at a given logger, we just create a new one (logger)
+    # and pass the same file and stream handlers as the parent one, giving the option for change the format.
+
+    return _configure_child_logger(logger, record_file, console_output, file_msg, console_msg) 
+
+
+def _configure_child_logger(logger, record_file, console_output, file_msg, console_msg):
+    first_logger = previous_loggers()[logging.root._first_logger]
+
+    file_handlers = [each_handler for each_handler in first_logger.handlers if _instance_but_not_subclass(
+        each_handler, FileHandlerWithHeader)]
+    console_handlers = [each_handler for each_handler in first_logger.handlers if _instance_but_not_subclass(
+        each_handler, logging.StreamHandler)]
+
+    if file_handlers:
+        fh = file_handlers[0]
+        fh.setFormatter(logging.Formatter(file_msg or fh.formatter._fmt))
+
+    if console_handlers:
+        ch = console_handlers[0]
+        ch.setFormatter(logging.Formatter(console_msg or ch.formatter._fmt))
+
+    logger.setLevel(first_logger.level)
+    logger.propagate = False  # This is important to avoid duplicated logs.
+    if record_file:
+        logger.addHandler(fh)
+    if console_output:
+        logger.addHandler(ch)
+    return logger

--- a/ansys/mapdl/core/log.py
+++ b/ansys/mapdl/core/log.py
@@ -23,20 +23,20 @@ FILE_NAME = 'pyansys.log'
 
 ## Single configuration
 LAUNCHER_LOGGER = 'launcher'
-CONSOLE_MSG_FORMAT = '%(module)-15s - %(funcName)-15s - %(message)s'
-FILE_MSG_FORMAT = '%(asctime)-15s | %(module)-15s | %(funcName)-15s | %(message)s'
+CONSOLE_MSG_FORMAT = '%(levelname)-10s - %(module)-15s - %(funcName)-15s - %(message)s'
+FILE_MSG_FORMAT = '%(asctime)-15s | %(levelname)-12s | %(module)-15s | %(funcName)-15s | %(message)s'
 DEFAULT_FILE_HEADER = """
-Date Time               | Module          | Function        | Message
-------------------------|-----------------|-----------------|---------
+Date Time               | Level name   | Module          | Function        | Message
+------------------------|--------------|-----------------|-----------------|---------------------------
 """
 
 ## Pool configuration
 POOL_LOGGER = 'pool'
-CONSOLE_MSG_POOL_FORMAT = '%(threadName)-15s - %(module)-15s - %(funcName)-15s - %(message)s'
-FILE_MSG_POOL_FORMAT = '%(asctime)-15s | %(threadName)-15s | %(module)-15s | %(funcName)-15s | %(message)s'
+CONSOLE_MSG_POOL_FORMAT = '%(levelname)-10s | %(threadName)-15s - %(module)-15s - %(funcName)-15s - %(message)s'
+FILE_MSG_POOL_FORMAT = '%(asctime)-15s | %(levelname)-12s | %(threadName)-15s | %(module)-15s | %(funcName)-15s | %(message)s'
 DEFAULT_FILE_HEADER_POOL = """
-Date Time               | Thread          | Module          | Function        | Message
-------------------------|-----------------|-----------------|-----------------|---------------------------
+Date Time               | Level name   | Thread          | Module          | Function        | Message
+------------------------|--------------|-----------------|-----------------|-----------------|---------------------------
 """
 
 
@@ -51,8 +51,10 @@ def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=L
         # is not empty
         # parent_logger = list(previous_loggers.values())[-1]  #
         # logger = parent_logger.getChild(name)
-        hierarchy_len = [len(each.split('.')) for each in loggers]
-        logger_name = [value for index, value in enumerate(loggers) if hierarchy_len[index] == max(hierarchy_len)][0]
+        # hierarchy_len = [len(each.split('.')) for each in loggers]
+        # logger_name = [value for index, value in enumerate(loggers) if hierarchy_len[index] == max(hierarchy_len)][0]
+        # logger_name = loggers[]
+        logger_name = logging.root.last_logger
         logger = previous_loggers[logger_name].getChild(name)
         logger.last_logger = logger.name
 
@@ -88,7 +90,7 @@ def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=L
     else:
         # There is no parent logger, so we create it.
         logger = logging.getLogger(name)
-        logger.last_logger = logger.name
+        logging.root.last_logger = logger.name
         logger.setLevel(loglevel)
         ch = logging.StreamHandler()
         fh = FileHandlerWithHeader(

--- a/ansys/mapdl/core/log.py
+++ b/ansys/mapdl/core/log.py
@@ -1,0 +1,68 @@
+"""This module provides the tools for logging in PyAnsys"""
+
+# The approach is to call ``Getlogger``` at the beginning of each module.
+# Functions in several ways:
+# * If ``GetLogger`` gets called before any other logger has been initialized, it will create
+# the default logger which parameters are a constant in this module.
+# * If ``GetLogger`` gets called after another logger has been created, there are two options:
+#    * If we do not intend changes in the messages format, it will return a child logger with
+# the default name. This child logger will redirect all the output to the main.
+#    * If we do intend changes in the message format because maybe we want to account for
+# different context, a new child logger is created with the same handlers as the parent and
+# using the providen message format or the parent message format.
+#
+# In cases we want to change the format according to different contexts, for example when the
+# module launcher is called by the pool module:
+#
+# >
+
+import logging
+
+LOG_LEVEL = logging.DEBUG
+CONSOLE_MSG_FORMAT = '%(funcName)s - %(message)s'
+FILE_MSG_FORMAT = '%(asctime)s - %(module)s:%(funcName)s- %(message)s'
+FILE_NAME = 'pyansys.log'
+
+CONSOLE_MSG_POOL_FORMAT = '%(threadName)s: %(module)s: %(funcName)s - %(message)s'
+FILE_MSG_POOL_FORMAT = '%(asctime)s - %(threadName)s: %(module)s: %(funcName)s - %(message)s'
+
+
+def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=LOG_LEVEL):
+    logger = logging.getLogger(name)
+
+    if logger.parent.hasHandlers():
+
+        if file_msg is None and console_msg is None and logger.parent.name != 'pool':
+            # We are not going to change the message output, hence we can reuse the whole logger.
+            return logger
+
+        ## There is a previous logger used
+        # Since there is no easy way to modify the format at a given logger, we just create a new one (logger)
+        # and pass the same file and stream handlers as the parent one, giving the option for change the format.
+        fh = [each_handler for each_handler in logger.parent.handlers if isinstance(each_handler, logging.FileHandler)][0]
+        ch = [each_handler for each_handler in logger.parent.handlers if isinstance(each_handler, logging.StreamHandler)][0]
+
+        if logger.parent.name == 'pool':
+            fh.setFormatter(logging.Formatter(file_msg or FILE_MSG_POOL_FORMAT))
+            ch.setFormatter(logging.Formatter(console_msg or CONSOLE_MSG_POOL_FORMAT))
+
+        else:
+            fh.setFormatter(logging.Formatter(file_msg or fh.formatter._fmt))
+            ch.setFormatter(logging.Formatter(console_msg or ch.formatter._fmt))
+
+        logger.propagate = False
+
+    else:
+        # There is no parent logger, so we create it.
+        logger.setLevel(loglevel)
+        fh = logging.StreamHandler()
+        ch = logging.FileHandler(fname or FILE_NAME)
+
+        fh.setFormatter(logging.Formatter(file_msg or FILE_MSG_FORMAT))
+        ch.setFormatter(logging.Formatter(console_msg or CONSOLE_MSG_FORMAT))
+        logger.propagate = True  # Probably this is irrelevant.
+
+    logger.addHandler(ch)
+    logger.addHandler(fh)
+
+    return logger

--- a/ansys/mapdl/core/log.py
+++ b/ansys/mapdl/core/log.py
@@ -54,6 +54,7 @@ def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=L
         hierarchy_len = [len(each.split('.')) for each in loggers]
         logger_name = [value for index, value in enumerate(loggers) if hierarchy_len[index] == max(hierarchy_len)][0]
         logger = previous_loggers[logger_name].getChild(name)
+        logger.last_logger = logger.name
 
         if file_msg is None and console_msg is None and logger.parent.name != POOL_LOGGER:
             # We are not going to change the message output, hence we can reuse the whole logger.
@@ -87,6 +88,7 @@ def getLogger(name=None, file_msg=None, console_msg=None, fname=None, loglevel=L
     else:
         # There is no parent logger, so we create it.
         logger = logging.getLogger(name)
+        logger.last_logger = logger.name
         logger.setLevel(loglevel)
         ch = logging.StreamHandler()
         fh = FileHandlerWithHeader(

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1,4 +1,7 @@
 """Module to control interaction with MAPDL through Python"""
+from ansys.mapdl.core import log
+logger = log.getLogger('launcher')
+
 import time
 import glob
 import re
@@ -107,41 +110,11 @@ def setup_logger(loglevel='INFO', log_file=True):
 
     # return existing log if this function has already been called
     if hasattr(setup_logger, "log"):
-        setup_logger.log.setLevel(loglevel)
-        ch = setup_logger.log.handlers[0]
-        ch.setLevel(loglevel)
         return setup_logger.log
 
-    # create logger
-    log = logging.getLogger(__name__)
-    log.setLevel(loglevel)
+    setup_logger.log = logger
 
-    # create console handler and set level to debug
-    ch = logging.StreamHandler()
-    ch.setLevel(loglevel)
-
-    # create formatter
-    formatstr = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-    formatter = logging.Formatter(formatstr)
-
-    # add formatter to ch
-    ch.setFormatter(formatter)
-
-    # add ch to logger
-    log.addHandler(ch)
-
-    if log_file:
-        file_handler = logging.FileHandler('PyMAPDL.log')
-        file_handler.setLevel(loglevel)
-        file_handler.setFormatter(formatter)
-
-    # creating a file handler
-    log.addHandler(file_handler)
-
-    # make persistent
-    setup_logger.log = log
-
-    return log
+    return logger
 
 
 class _MapdlCore(Commands):

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1,6 +1,6 @@
 """Module to control interaction with MAPDL through Python"""
 from ansys.mapdl.core import log
-logger = log.getLogger('launcher')
+logger = log.getLogger('launcher', loglevel='ERROR')
 
 import time
 import glob

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -45,6 +45,7 @@ with self.non_interactive:
     self.run('(F20.12)')
 """
 
+## Invalid commands in interactive mode. 
 INVAL_COMMANDS = {
     "*VWR": VWRITE_REPLACEMENT,
     "*CFO": "Run CFOPEN as ``non_interactive``",
@@ -53,7 +54,29 @@ INVAL_COMMANDS = {
     "/EOF": "Unsupported command.  Use ``exit`` to stop the server.",
     "*ASK": "Unsupported command.  Use python ``input`` instead.",
     "*IF": "Use a python ``if`` or run as non_interactive",
-    "CMATRIX": "Use as non_interactive",
+    "CMAT": "Use as non_interactive",
+}
+
+## Soft-invalid commands
+# Invalid commands in interactive mode but their execution is just ignored.
+# The correspondent command is replaced by a comment using the command '\COM'
+# and a warning is recorded in the logger
+#
+# This commands can still be executed in ``non_interactive`` mode or using
+# ``Mapdl._run`` method.
+#
+# Format of the message:
+# f"{CMD} is ignored: {INVAL_COMMANDS_SILENT[CMD]}.
+#
+# NOTE
+# Obtain the command from the string supplied using
+#
+#    string.split(',')[0].upper()
+#
+# This way to get the command is different from the one used in ``INVAL_COMMANDS``.
+#
+INVAL_COMMANDS_SILENT = {
+    "/NOPR": "Suppressing console output is not recommended, use ``Mute`` parameter instead. This command is disabled in interactive mode."
 }
 
 PLOT_COMMANDS = ["NPLO", "EPLO", "KPLO", "LPLO", "APLO", "VPLO", "PLNS", "PLES"]
@@ -2053,19 +2076,31 @@ class _MapdlCore(Commands):
             # https://github.com/pyansys/pymapdl/issues/380
             command = "/CLE,NOSTART"
 
+        # Invalid commands silently ignored.
+        cmd_ = command.split(',')[0].upper()
+        # if command[:3].upper() in INVAL_COMMANDS_SILENT or \
+        #         command[:4].upper() in INVAL_COMMANDS_SILENT:
+        if cmd_ in INVAL_COMMANDS_SILENT:
+            msg = f"{cmd_} is ignored: {INVAL_COMMANDS_SILENT[cmd_]}."
+            self._log.info(msg)
+
+            # This very likely won't be recorded anywhere.
+            # But just in case, I'm adding info as /com
+            command = f"/com, PyAnsys: {msg}" # Using '!' makes the output of '_run' empty
+
         if self._store_commands:
             self._stored_commands.append(command)
             return
         elif command[:3].upper() in INVAL_COMMANDS:
             exception = RuntimeError(
                 'Invalid pymapdl command "%s"\n\n%s'
-                % (command, INVAL_COMMANDS[command[:3]])
+                % (command, INVAL_COMMANDS[command[:3].upper()])
             )
             raise exception
         elif command[:4].upper() in INVAL_COMMANDS:
             exception = RuntimeError(
                 'Invalid pymapdl command "%s"\n\n%s'
-                % (command, INVAL_COMMANDS[command[:4]])
+                % (command, INVAL_COMMANDS[command[:4].upper()])
             )
             raise exception
         elif write_to_log and self._apdl_log is not None:

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -45,7 +45,7 @@ with self.non_interactive:
     self.run('(F20.12)')
 """
 
-## Invalid commands in interactive mode. 
+## Invalid commands in interactive mode.
 INVAL_COMMANDS = {
     "*VWR": VWRITE_REPLACEMENT,
     "*CFO": "Run CFOPEN as ``non_interactive``",
@@ -2078,8 +2078,6 @@ class _MapdlCore(Commands):
 
         # Invalid commands silently ignored.
         cmd_ = command.split(',')[0].upper()
-        # if command[:3].upper() in INVAL_COMMANDS_SILENT or \
-        #         command[:4].upper() in INVAL_COMMANDS_SILENT:
         if cmd_ in INVAL_COMMANDS_SILENT:
             msg = f"{cmd_} is ignored: {INVAL_COMMANDS_SILENT[cmd_]}."
             self._log.info(msg)

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1,4 +1,6 @@
 """gRPC specific class and methods for the MAPDL gRPC client """
+from ansys.mapdl.core.log import getLogger
+logger = getLogger(__name__)
 import re
 from warnings import warn
 import shutil
@@ -6,7 +8,6 @@ import threading
 import weakref
 import io
 import time
-import logging
 import os
 import socket
 from functools import wraps
@@ -39,7 +40,6 @@ from ansys.mapdl.core.common_grpc import (
 from ansys.mapdl.core import __version__, _LOCAL_PORTS
 from ansys.mapdl.core import check_version
 
-logger = logging.getLogger(__name__)
 
 VOID_REQUEST = anskernel.EmptyRequest()
 

--- a/ansys/mapdl/core/misc.py
+++ b/ansys/mapdl/core/misc.py
@@ -238,7 +238,7 @@ def threaded_daemon(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        thread = Thread(target=func, args=args, kwargs=kwargs, name=name)
+        thread = Thread(target=func, args=args, kwargs=kwargs)
         thread.daemon = True
         thread.start()
         return thread

--- a/ansys/mapdl/core/misc.py
+++ b/ansys/mapdl/core/misc.py
@@ -238,7 +238,7 @@ def threaded_daemon(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        thread = Thread(target=func, args=args, kwargs=kwargs)
+        thread = Thread(target=func, args=args, kwargs=kwargs, name=name)
         thread.daemon = True
         thread.start()
         return thread

--- a/ansys/mapdl/core/misc.py
+++ b/ansys/mapdl/core/misc.py
@@ -226,7 +226,8 @@ def threaded(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        thread = Thread(target=func, args=args, kwargs=kwargs)
+        name = kwargs.get('name', f'Threaded `{func.__name__}` function')
+        thread = Thread(target=func, name=name, args=args, kwargs=kwargs)
         thread.start()
         return thread
 
@@ -238,7 +239,8 @@ def threaded_daemon(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        thread = Thread(target=func, args=args, kwargs=kwargs)
+        name = kwargs.get('name', f'Threaded (with Daemon) `{func.__name__}` function')
+        thread = Thread(target=func, name=name, args=args, kwargs=kwargs)
         thread.daemon = True
         thread.start()
         return thread

--- a/ansys/mapdl/core/pool.py
+++ b/ansys/mapdl/core/pool.py
@@ -1,9 +1,11 @@
 """This module is for threaded implementations of the mapdl interface"""
+from ansys.mapdl.core import log
+LOG = log.getLogger('pool')
+
 import shutil
 import warnings
 import os
 import time
-import logging
 
 from tqdm import tqdm
 
@@ -16,9 +18,6 @@ from ansys.mapdl.core.launcher import (
     _version_from_path,
 )
 from ansys.mapdl.core.errors import VersionError
-
-LOG = logging.getLogger(__name__)
-LOG.setLevel("DEBUG")
 
 
 def available_ports(n_ports, starting_port=MAPDL_DEFAULT_PORT):
@@ -165,7 +164,7 @@ class LocalMapdlPool:
         self._instances = [None for _ in range(n_instances)]
 
         # threaded spawn
-        threads = [self._spawn_mapdl(i, ports[i], pbar) for i in range(n_instances)]
+        threads = [self._spawn_mapdl(i, ports[i], pbar, name=f'Instance {i}') for i in range(n_instances)]
         if wait:
             [thread.join() for thread in threads]
 
@@ -551,7 +550,7 @@ class LocalMapdlPool:
                 yield instance
 
     @threaded_daemon
-    def _spawn_mapdl(self, index, port=None, pbar=None):
+    def _spawn_mapdl(self, index, port=None, pbar=None, name=''):
         """Spawn a mapdl instance at an index"""
         # create a new temporary directory for each instance
         run_location = create_temp_dir(self._root_dir)

--- a/ansys/mapdl/core/pool.py
+++ b/ansys/mapdl/core/pool.py
@@ -1,6 +1,6 @@
 """This module is for threaded implementations of the mapdl interface"""
-from ansys.mapdl.core import log
-LOG = log.getLogger('pool')
+from ansys.mapdl.core.log import getLogger
+LOG = getLogger('pool')  # This should be import the first.
 
 import shutil
 import warnings

--- a/ansys/mapdl/core/pool.py
+++ b/ansys/mapdl/core/pool.py
@@ -576,7 +576,7 @@ class LocalMapdlPool:
                         port = max(self._ports) + 1
                         self._spawn_mapdl(index, port=port).join()
                     except Exception as e:
-                        logging.error(e, exc_info=True)
+                        LOG.error(e, exc_info=True)
             time.sleep(refresh)
 
     @property

--- a/ansys/mapdl/core/pool.py
+++ b/ansys/mapdl/core/pool.py
@@ -1,6 +1,6 @@
 """This module is for threaded implementations of the mapdl interface"""
 from ansys.mapdl.core.log import getLogger
-LOG = getLogger('pool')  # This should be import the first.
+LOG = getLogger(__name__)  # This should be import the first.
 
 import shutil
 import warnings

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -57,4 +57,3 @@ def test_log_change_in_file_msg(mapdl):
     logger.info('An useful info message')
 
     find_logmsg_in_logfile('THIS IS A TEST', 'An useful info message')
-

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,13 +1,60 @@
 """"Testing of log module"""
-from ansys.mapdl.core.log import FILE_NAME
+from ansys.mapdl.core  import log
 
-def find_string_in_log(string):
-    with(open(FILE_NAME, 'r')) as fid:
-        text = ''.join(fid.readlines())
-    return string in text
+import re
+import pytest
 
 
-def test_log_info(mapdl):
-    string = 'This is an info log'
-    mapdl._log.info('This is an info log')
-    assert find_string_in_log(string)
+LOG_LEVELS =  {'CRITICAL': 50,
+'ERROR': 40,
+'WARNING': 30,
+'INFO': 20,
+'DEBUG': 10}
+
+
+def get_logger_text(fname=log.FILE_NAME):
+    with(open(fname, 'r')) as fid:
+        return ''.join(fid.readlines())
+
+def find_logmsg_in_logfile(prev_string='INFO', string='', text=None):
+    if text is None:
+        text = get_logger_text()
+    if re.findall(f'^.*{prev_string}.*{string}.*$', text, re.MULTILINE):
+        return True
+    else:
+        return False
+
+
+def test_log_levels(mapdl):
+    for each_log_name, each_log_number in LOG_LEVELS.items():
+        string = f'This is an {each_log_name} log'
+        mapdl._log.log(each_log_number, string)
+        assert find_logmsg_in_logfile(each_log_name, string)
+
+
+def test_log_nesting(mapdl):
+    hierarchy = 'this.is.a.hierarchy.which.is.used.for.build.loggers'
+
+    for each in hierarchy.split('.'):
+        logger = log.getLogger(each)
+
+    assert hierarchy in logger.name
+
+
+# def test_log_different_loglevel(mapdl):
+#     logger = log.getLogger(loglevel='ERROR')
+
+
+def test_log_uncaught_exception(mapdl):
+    exception_msg = 'Uncaught exception'
+    with pytest.raises(Exception):
+        raise Exception(exception_msg)
+    assert find_logmsg_in_logfile('', exception_msg)
+
+
+def test_log_change_in_file_msg(mapdl):
+    logger = log.getLogger('test', file_msg='%(asctime)-15s | %(funcName)-25s | THIS IS A TEST %(message)s')
+    logger.info('An useful info message')
+
+    find_logmsg_in_logfile('THIS IS A TEST', 'An useful info message')
+

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,13 @@
+""""Testing of log module"""
+from ansys.mapdl.core.log import FILE_NAME
+
+def find_string_in_log(string):
+    with(open(FILE_NAME, 'r')) as fid:
+        text = ''.join(fid.readlines())
+    return string in text
+
+
+def test_log_info(mapdl):
+    string = 'This is an info log'
+    mapdl._log.info('This is an info log')
+    assert find_string_in_log(string)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -610,3 +610,22 @@ def test_coriolis(mapdl, cleared):
     assert "GYROSCOPIC DAMPING MATRIX WILL BE CALCULATED" in resp
     assert "ROTATING DAMPING MATRIX ACTIVATED" in resp
     assert "PRINT ROTOR MASS SUMMARY ACTIVATED" in resp
+
+
+def test_inval_commands(mapdl, cleared):
+    """Test the output of invalid commands"""
+    cmds = ["*END", "*vwrite", "/eof", "cmatrix"]
+    for each_cmd in cmds:
+        with pytest.raises(RuntimeError):
+            mapdl.run(each_cmd)
+
+
+def test_inval_commands_silent(mapdl, tmpdir, cleared):
+    assert mapdl.run("parm = 'asdf'")  # assert it is not empty
+    mapdl.nopr()
+    assert mapdl.run("parm = 'asdf'")  # assert it is not empty
+
+    assert not mapdl._run('/nopr')  # setting /nopr and assert it is empty
+    assert not mapdl.run("parm = 'asdf'")  # assert it is not empty
+
+    mapdl._run('/gopr') # getting settings back


### PR DESCRIPTION

# ``log`` module

## Objective
This module intends to create a general framework for logging in Pyansys.
This module is built upon ``logging`` library and it does NOT intend to replace it.
This module uses module logging, rather than log specific classes or functions.
This approach is simpler, since you do not need to carry around the logger.
However, for compatibility, the ``Mapdl._log`` has been redirected to the correspondent module logger.

## Usage

The approach is to call ``Getlogger``` at the beginning of each module we want to log.
This function works in several ways:

* If this is the first time that you call it, ``getLogger`` will create a new logger using the provided input or the default logger configuration.
* If ``getLogger`` has been called before, it will generate a child logger from the previously called logger.
    * If you only provide a name, the child logger will have no handlers and it will propagate its log to the parent one.
    * If ``file_msg`` and / or ``console_msg`` are provided in this call, the format of the child logger will be changed in the file stream and / or console stream.
    The parent handlers are copied into the child logger and the propagation from child to parent is disabled (See notes for further explanations).
    However, you can NOT change any other configuration of the logger.
    Attributes such as file name (``fname``), the log level (``loglevel``) or the options to record to file or console (``record_file`` and ``console_output``)
    cannot be changed at this step. This is to maintained the logging framework consistency.

This module detects automatically when the ``pool`` module is called for logging, and it adjust the log format in both cases, file and console streams.
The format is different for file and console output, being the file format a bit more detailed.

This module also write appropriate headers for the default file log handlers.

#### Default file header
```
    Date Time               | Level name   | Module          | Function                  | Message
    ------------------------|--------------|-----------------|---------------------------|---------------------------
```

#### Default pool file header
```
    Date Time               | Level name   | Thread          | Module          | Function                  | Message
    ------------------------|--------------|-----------------|-----------------|---------------------------|---------------------------
```

## Output format

### Default console
```
    '%(levelname)-10s - %(module)-15s - %(funcName)s - %(message)s'
```

### Default file
```
    '%(asctime)-15s | %(levelname)-12s | %(module)-15s | %(funcName)-25s | %(message)s'
```

### Default pool console
```
    '%(levelname)-10s | %(threadName)-15s - %(module)-15s - %(funcName)s - %(message)s'
```

### Default pool file
```
    '%(asctime)-15s | %(levelname)-12s | %(threadName)-15s | %(module)-15s | %(funcName)-25s | %(message)s'
```

## Cases

### Log a module without changes in log format.
```python
    >>> from ansys.mapdl.core.log import getLogger
    >>> logger = getLogger(__name__)  # logger names as the module where it is imported.
    ...
    ...
    >>> logger.info('This is a useful message')
    INFO       |  test            - <module > - This is an useful message
```

### Log a module with changes in log format.
``` python
    >>> from ansys.mapdl.core.log import getLogger
    >>> file_msg = '%(asctime)-15s | %(funcName)-25s | THIS IS A TEST %(message)s'
    >>> logger = getLogger(__name__, file_msg=file_msg)  # logger named as the module where it is imported.
    ...
    ...
    >>> logger.info('This is a useful message')
    INFO       |  test            - <module > - This is an useful message
```

## Notes

* To check if there is logger previously initialized by ``log`` module, we rely upon ``logging.root`` having or not the attribute ``last_logger``.
If this attribute does not exist, it is considered that ``getLogger`` hasn't been called and therefore, ``log`` hasn't been initialized previously.
* The ``propagate`` option is disabled when creating a child with different log format to avoid having the logs repeated from the same loggers since both loggers (child and parent) will share the handlers.
* This module check if ``pool`` module is called by checking the ``name`` parameter provided to ``getLogger``. If the string ``pool`` is found, it will be considered to be called from ``pool`` module.
* To log each thread, this module uses the flag ``% (threadName)s`` (more information on `LogRecord attributes < https: // docs.python.org/3/library/logging.html#logrecord-attributes/>`_) therefore, all the calls to ``Threading.Thread`` have been modified to include a thread name (``name``).
* For compatibility, the ``Mapdl._log`` has been redirected to the module logger, therefore you could do something like this in your script:
```python
    >>> from ansys.mapdl.core import launch_mapdl
    >>> mapdl = launch_mapdl()
    >>> mapdl._log.info('This is an useful message')
    INFO       | test            - <module > - This is an useful message  # Module is not defined since we are at ``__main__``
```

## Logic behind this module

One of the objectives of this module was to provide a flexible tool to log in cases as different as being in a pool resource or running a single instance.
Hence the format of the logs should be flexible and easy to change when logging in those cases but keeping the output streams.
However, the ``logging`` module does not easy allow you to change this format once the logger has been created.
Therefore the solution it is implemented here is to create a child logger which copies the handlers of the parent but it does set a different format.
This way the output is still keep in place, but the format can be changed.