### PR TITLE
licensing and tmp file fixes

### DIFF
--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -117,15 +117,11 @@ def test_check_license_file_fail():
 def test_license_checker(tmpdir):
     # validate license checker (this will only checkout the license)
     checker = licensing.LicenseChecker()
-    checker.start(license_file=False)
+    checker.start(license_file=False, checkout_license=True)
+    assert checker.check() is False
+    assert checker._license_checkout_success is None
     checker.wait()
     assert checker.check()
-
-    checker = licensing.LicenseChecker(timeout=0.1)
-    checker.start(checkout_license=False)
-    checker.wait()
-    with pytest.raises(errors.LicenseServerConnectionError):
-        checker.check()
 
 
 @skip_launch_mapdl

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -739,8 +739,6 @@ def test_cdread_in_python_directory(mapdl, cleared, tmpdir):
         clearing_cdread_cdwrite_tests(mapdl)
         mapdl.cdread('db', 'model')
         assert asserting_cdread_cdwrite_tests(mapdl)
-    except:
-        raise
     finally:
         # always change back to the previous directory
         os.chdir(old_cwd)


### PR DESCRIPTION
This PR fixes the following tests:
- Unit tests were failing on linux due to changed defaults on the license checker.  Simple patch.
- `test_cdread_in_python_directory` was creating a temporary file `model.cdb` in the current working directory. Test behavior has been fixed.

#### Temporary File Test Strategy

Pinging @german89

When creating files, avoid assuming anything regarding paths and always use the `tmpdir` fixture.  This fixture creates temporary directories and provides a convenient way of creating files on the fly without modifying the user's environment.

In the case of `test_cdread...`, we were testing if a file within the current working directory of Python would be seen by pymapdl and then copied over (or used directly if local).  Rather than creating the file in the current working directory (which would have to be cleaned up), the best approach is to:

```py
old_cwd = os.getcwd()

try:
    os.chdir(tmpdir)
    # test something
finally:
    os.chdir(old_cwd)
```

With this approach, the current working directory is always changed back as `finally` is always executed.  Moreover, because we're don't have a `except` block, don't ignore any exceptions that occur within our `try` block.  This way we can "fake" execution in the current working directory without creating files in the actual current working directory.
