### PR TITLE
Added support for CWD to contain spaces

### DIFF
--- a/ansys/mapdl/core/_commands/session/run_controls.py
+++ b/ansys/mapdl/core/_commands/session/run_controls.py
@@ -113,6 +113,9 @@ class RunControls:
     def cwd(self, dirpath="", **kwargs):
         """Changes the current working directory.
 
+        ``dirpath`` must not contain any singular quotations/apostrophes.
+        These are not supported in APDL.
+
         APDL Command: /CWD
 
         Parameters
@@ -124,9 +127,11 @@ class RunControls:
         -----
         After issuing the /CWD command, all new files opened with no default
         directory specified (via the FILE, /COPY, or RESUME commands, for
-        example) default to the new DIRPATH directory.
+        example) default to the new ``dirpath`` directory.
         """
-        command = "/CWD,%s" % (str(dirpath))
+        if not (dirpath.startswith('\'') and dirpath.endswith('\'')) and "'" in dirpath:
+            raise RuntimeError('The CWD command does not accept paths that contain singular quotes "'"")
+        command = f"/CWD,'{dirpath}'"
         return self.run(command, **kwargs)
 
     def filname(self, fname="", key="", **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from collections import namedtuple
 import os
 import time
 
@@ -18,6 +19,9 @@ from common import get_details_of_nodes, get_details_of_elements, Node, Element
 
 # Necessary for CI plotting
 pyvista.OFF_SCREEN = True
+
+SpacedPaths = namedtuple('SpacedPaths', ['path_without_spaces', 'path_with_spaces',
+                                         'path_with_single_quote'])
 
 
 # Check if MAPDL is installed
@@ -238,6 +242,14 @@ def mapdl(request, tmpdir_factory):
             time.sleep(1)  # takes a second for the processes to shutdown
             for pid in mapdl._pids:
                 assert not check_pid(pid)
+
+
+@pytest.fixture
+def path_tests(tmpdir):
+    p1 = tmpdir.mkdir("./temp/")
+    p2 = tmpdir.mkdir("./t e m p/")
+    p3 = tmpdir.mkdir("./temp'")
+    return SpacedPaths(str(p1), str(p2), str(p3))
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def test_path_without_spaces(mapdl, path_tests):
+    resp = mapdl.cwd(path_tests.path_without_spaces)
+    assert 'WARNING' not in resp
+
+
+def test_path_with_spaces(mapdl, path_tests):
+    resp = mapdl.cwd(path_tests.path_with_spaces)
+    assert 'WARNING' not in resp
+
+
+def test_path_with_single_quote(mapdl, path_tests):
+    with pytest.raises(RuntimeError):
+        resp = mapdl.cwd(path_tests.path_with_single_quote)
+        assert 'WARNING' not in resp
+
+
+


### PR DESCRIPTION
the cwd command accepts directory paths with spaces when enclosed in a
pair of single quotes/apostrophes. However, it seems that it does NOT
support directory path's that otherwise contain single quotes. I have
added a note to this effect to the docstring.

Otherwise this commit enables the supplication of directory paths with
spaces in as well as two tests for this. The methods could (and perhaps
should) be extended to other path-related commands, but I'm not sure
which these are, and would welcome input from other people.

Otherwise, this commit should fix issue #641.