### PR TITLE
convert path to string in CWD

### DIFF
--- a/ansys/mapdl/core/_commands/session/run_controls.py
+++ b/ansys/mapdl/core/_commands/session/run_controls.py
@@ -128,11 +128,23 @@ class RunControls:
         After issuing the /CWD command, all new files opened with no default
         directory specified (via the FILE, /COPY, or RESUME commands, for
         example) default to the new ``dirpath`` directory.
+
+        Examples
+        --------
+        Change MAPDL's working directory to ``"C:/temp"``.  This
+        assumes that MAPDL running on Windows.
+
+        >>> mapdl.cwd("C:/temp")
+
+        MAPDL on Linux example:
+
+        >>> mapdl.cwd("/tmp/")
+
         """
+        dirpath = str(dirpath)
         if not (dirpath.startswith('\'') and dirpath.endswith('\'')) and "'" in dirpath:
             raise RuntimeError('The CWD command does not accept paths that contain singular quotes "'"")
-        command = f"/CWD,'{dirpath}'"
-        return self.run(command, **kwargs)
+        return self.run(f"/CWD,'{dirpath}'", **kwargs)
 
     def filname(self, fname="", key="", **kwargs):
         """Changes the Jobname for the analysis.


### PR DESCRIPTION
Encountered a minor issue with local testing with `Mapdl.cwd`: When passed a `Pathlib.Path`, the test fails outright.  A simple fix is to always convert to string before executing the path when checking the string.

Also added a minor example.
