### PR TITLE
Feat/adding license selection to launcher

### DIFF
--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -868,11 +868,12 @@ def launch_mapdl(
         start.  Only available on ``mode='grpc'``. Defaults ``True``.
 
     license_type : str, optional
-        Enable license type selection. You can input a license name as
-        string (for example 'meba' or 'ansys'). You could also use
-        legacy licenses (for example 'aa_t_a') but it will also raise a
-        warning. If it is not used (None), no specific license will be
-        requested, being up to the license server to provide a specific
+        Enable license type selection. You can input a string for its
+        license name (for example 'meba' or 'ansys') or its description
+        ("enterprise solver" or "enterprise" respectively).
+        You can also use legacy licenses (for example 'aa_t_a') but it will
+        also raise a warning. If it is not used (None), no specific license
+        will be requested, being up to the license server to provide a specific
         license typ. Default is ``None``.
 
     Notes
@@ -1062,7 +1063,19 @@ def launch_mapdl(
         # In older versions probably it might raise an error. But not sure.
         license_type = license_type.lower().strip()
 
-        if license_type not in ALLOWABLE_LICENSES:
+        if 'enterprise' in license_type and 'solver' not in license_type:
+            license_type = 'ansys'
+
+        elif 'enterprise' in license_type and 'solver' in license_type:
+            license_type = 'meba'
+
+        elif 'premium' in license_type:
+            license_type = 'mech_2'
+
+        elif 'pro' in license_type:
+            license_type = 'mech_1'
+
+        elif license_type not in ALLOWABLE_LICENSES:
             allow_lics = [f"'{each}'" for each in ALLOWABLE_LICENSES]
             warn_text = \
                 f"The keyword argument 'license_type' value ('{license_type}') is not a recognized license name or has been deprecated.\n" + \

--- a/ansys/mapdl/core/licensing.py
+++ b/ansys/mapdl/core/licensing.py
@@ -14,7 +14,14 @@ LIC_PATH_ENVAR = "ANSYSLIC_DIR"
 LIC_FILE_ENVAR = "ANSYSLMD_LICENSE_FILE"
 APP_NAME = "FEAT_ANSYS"  # TODO: We need to make sure this is the type of feature we need to checkout.
 LIC_TO_CHECK =  ["mech_1"]
-ALLOWABLE_LICENSES = ["ansys", "meba", "mech_2", "mech_1"]
+
+LICENSES = {
+    "ansys": "Ansys Mechanical Enterprise",
+    "meba" : "Ansys Mechanical Enterprise Solver",
+    "mech_2" : "Ansys Mechanical Premium",
+    "mech_1" : "Ansys Mechanical Pro"
+}
+ALLOWABLE_LICENSES = list(LICENSES.keys())
 
 ## Regarding license checking.
 # The available licenses we can check against are (in order of

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -4,6 +4,7 @@ import weakref
 
 import pytest
 from ansys.mapdl import core as pymapdl
+from ansys.mapdl.core._commands.preproc import keypoints
 from ansys.mapdl.core.launcher import _version_from_path, get_start_instance, _validate_add_sw, launch_mapdl
 from ansys.mapdl.core.misc import get_ansys_bin
 from ansys.mapdl.core.licensing import LICENSES
@@ -148,6 +149,22 @@ def test_license_type_keyword():
         # regardless the license specification, it should lunch.
         assert mapdl.is_alive
     mapdl.exit()
+
+
+def test_license_type_keyword_names():
+    # This test might became a way to check available licenses, which is not the purpose.
+    keywords = ['ENTERPRISE', 'enterprise      solver', 'pRemIum', 'PrO']
+
+    successful_check = False
+    for license_description, each_keyword in zip(LICENSES.values(), keywords):
+        mapdl = launch_mapdl(license_type=each_keyword)
+
+        #Using first line to ensure not picking up other stuff.
+        successful_check = license_description in mapdl.__str__().split('\n')[0] or successful_check
+        assert license_description in mapdl.__str__().split('\n')[0]
+        mapdl.exit()
+
+    assert successful_check # if at least one license is ok, this should be true.
 
 
 def test_license_type_additional_switch():


### PR DESCRIPTION
# Description

As requested in #462, an optional keyword has been included to select the license_type.

# Approach
If this keyword is used:
1. It will check if it include some matching words of the licenses descriptions (see licensing.py > LICENSES), and select the correspondent license.
2. If not found by description, it will check by license name. 
3. If not found a valid license name, it will proceed with the provided name but a warning will be raised.

# Notes
- The matching license description words are based on the four available licenses at the moment: enterprise, enterprise solver, premium and pro.

# Tags
Fix #462 
Resolves #462 
Closes #462 