### PR TITLE
naviage to main page on clicking logo

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -163,6 +163,7 @@ html_logo = os.path.join("_static", "pyansys-logo-black-cropped.png")
 html_theme_options = {
     "github_url": "https://github.com/pyansys/pymapdl",
     "show_prev_next": False,
+    "logo_link": "https://docs.pyansys.com/",  # navigate to the main page
 }
 
 # -- Options for HTMLHelp output ---------------------------------------------


### PR DESCRIPTION
Simple change to navigate to the main pyansys documentation page when clicking the logo.
