### PR TITLE
Fixing ``pydata-sphinx-theme`` version to avoid issue with docs build…

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -17,4 +17,3 @@ sphinx-gallery>=0.8.1
 sphinx-notfound-page>=0.3.0
 sphinxcontrib-websupport
 vtk<9.1.0
-pydata-sphinx-theme==0.7.1 # See issue #707

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -17,3 +17,4 @@ sphinx-gallery>=0.8.1
 sphinx-notfound-page>=0.3.0
 sphinxcontrib-websupport
 vtk<9.1.0
+pydata-sphinx-theme==0.7.1 # See issue #707


### PR DESCRIPTION
Last ``pydata-sphinx-theme`` update broke our documentation building.

An issue has been already posted in the correspondent repo (https://github.com/pydata/pydata-sphinx-theme/issues/515). 
In the meantime, fixing the ``pydata-sphinx-theme`` version.

Fix #707 
Close #707 
