### PR TITLE
implement logger in convert_script

### DIFF
--- a/ansys/mapdl/core/convert.py
+++ b/ansys/mapdl/core/convert.py
@@ -1,5 +1,6 @@
 import os
 from warnings import warn
+from logging import Logger, StreamHandler
 
 from ansys.mapdl.core import __version__
 from ansys.mapdl.core.misc import is_float
@@ -21,6 +22,7 @@ def convert_script(
     exec_file=None,
     macros_as_functions=True,
     use_function_names=True,
+    show_log = False
 ):
     """Converts an ANSYS input file to a python PyMAPDL script.
 
@@ -51,6 +53,10 @@ def convert_script(
         converted to ``mapdl.k``.  When ``False``, it will be
         converted to ``mapdl.run('k')``.
 
+    show_log : bool, optional
+        Print the converted commands using a logger (from ``logging``
+        Python module).
+
     Returns
     -------
     list
@@ -71,7 +77,8 @@ def convert_script(
                                 line_ending=line_ending,
                                 exec_file=exec_file,
                                 macros_as_functions=macros_as_functions,
-                                use_function_names=use_function_names
+                                use_function_names=use_function_names,
+                                show_log=show_log
                           )
 
     translator.save(filename_out)
@@ -79,13 +86,13 @@ def convert_script(
 
 
 def convert_apdl_block(apdl_strings,
-    loglevel="WARNING",
-    auto_exit=True,
-    line_ending=None,
-    exec_file=None,
-    macros_as_functions=True,
-    use_function_names=True,
-                       ):
+        loglevel="WARNING",
+        auto_exit=True,
+        line_ending=None,
+        exec_file=None,
+        macros_as_functions=True,
+        use_function_names=True,
+        show_log = False):
     """Converts an ANSYS input string to a python PyMAPDL string.
 
     Parameters
@@ -115,6 +122,10 @@ def convert_apdl_block(apdl_strings,
         converted to ``mapdl.k``.  When ``False``, it will be
         converted to ``mapdl.run('k')``.
 
+    show_log : bool, optional
+        Print the converted commands using a logger (from ``logging``
+        Python module).
+
     Returns
     -------
     list
@@ -128,7 +139,8 @@ def convert_apdl_block(apdl_strings,
     line_ending=line_ending,
     exec_file=exec_file,
     macros_as_functions=macros_as_functions,
-    use_function_names=use_function_names)
+    use_function_names=use_function_names,
+    show_log=show_log)
 
     if isinstance(apdl_strings, str):
         return translator.line_ending.join(translator.lines)
@@ -142,6 +154,7 @@ def _convert(apdl_strings,
     exec_file=None,
     macros_as_functions=True,
     use_function_names=True,
+    show_log = False
              ):
 
     translator = FileTranslator(
@@ -150,6 +163,7 @@ def _convert(apdl_strings,
         exec_file=exec_file,
         macros_as_functions=macros_as_functions,
         use_function_names=use_function_names,
+        show_log=show_log
     )
 
     if isinstance(apdl_strings, str):
@@ -161,6 +175,27 @@ def _convert(apdl_strings,
     if auto_exit:
         translator.write_exit()
     return translator
+
+
+class Lines(list):
+    def __init__(self, mute):
+        self._log = Logger('convert_logger')
+        self._setup_logger()
+        self._mute = mute
+        super().__init__()
+
+    def append(self, item, mute=True):
+        # append the item to itself (the list)
+        if not self._mute:
+            self._log.info(msg=f"Converted: '{item}'")
+        super(Lines, self).append(item)
+
+    def _setup_logger(self):
+        stdhdl = StreamHandler()
+        stdhdl.setLevel(10)
+        stdhdl.set_name('stdout')
+        self._log.addHandler(stdhdl)
+        self._log.propagate = True
 
 
 class FileTranslator:
@@ -175,9 +210,10 @@ class FileTranslator:
         exec_file=None,
         macros_as_functions=True,
         use_function_names=True,
+        show_log = False
     ):
         self._non_interactive_level = 0
-        self.lines = []
+        self.lines = Lines(mute=not show_log)
         self._functions = []
         if line_ending:
             self.line_ending = line_ending

--- a/ansys/mapdl/core/convert.py
+++ b/ansys/mapdl/core/convert.py
@@ -92,7 +92,7 @@ def convert_apdl_block(apdl_strings,
         exec_file=None,
         macros_as_functions=True,
         use_function_names=True,
-        show_log = False):
+        show_log=False):
     """Converts an ANSYS input string to a python PyMAPDL string.
 
     Parameters
@@ -154,7 +154,7 @@ def _convert(apdl_strings,
     exec_file=None,
     macros_as_functions=True,
     use_function_names=True,
-    show_log = False
+    show_log=False
              ):
 
     translator = FileTranslator(
@@ -210,7 +210,7 @@ class FileTranslator:
         exec_file=None,
         macros_as_functions=True,
         use_function_names=True,
-        show_log = False
+        show_log=False
     ):
         self._non_interactive_level = 0
         self.lines = Lines(mute=not show_log)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -98,9 +98,6 @@ def test_convert_block_commands(tmpdir, cmd):
 
 
 def test_logger(capsys):
-    # I could not find a way to test the logging output. It seems that `caplog`
-    # does not work well. Hence we just run the code with `show_log` equal `True`
-    # to show it does not fail.
 
     apdl_ = """FINISH
     /PREP7

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -97,7 +97,7 @@ def test_convert_block_commands(tmpdir, cmd):
     assert pymapdl_output[cmd] in pyblock
 
 
-def test_logger(caplog):
+def test_logger(capsys):
     # I could not find a way to test the logging output. It seems that `caplog`
     # does not work well. Hence we just run the code with `show_log` equal `True`
     # to show it does not fail.
@@ -105,9 +105,9 @@ def test_logger(caplog):
     apdl_ = """FINISH
     /PREP7
     """.split('\n')
-    # caplog.clear()
+
     translator = FileTranslator(line_ending='\n', show_log=True)
     for line in apdl_:
         translator.translate_line(line)
-
-    # assert any(['Convert' in each for each in caplog.messages]) # This should work.
+    std = capsys.readouterr()
+    assert all(['Converted' in each for each in std.err.split('\n')[:-1]]) # last one is an empty line.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,8 +1,10 @@
 import os
 import pytest
+import logging
+
 from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core import examples
-from ansys.mapdl.core.convert import convert_apdl_block
+from ansys.mapdl.core.convert import convert_apdl_block, FileTranslator
 
 nblock = """nblock,3,,326253
 (1i9,3e20.9e3)
@@ -94,3 +96,19 @@ def test_convert_block_commands(tmpdir, cmd):
     pyblock = convert_apdl_block(apdl_strings=apdl_block.split('\n'))
     pyblock = '\n'.join(pyblock)
     assert pymapdl_output[cmd] in pyblock
+
+
+def test_logger(caplog):
+    # I could not find a way to test the logging output. It seems that `caplog`
+    # does not work well. Hence we just run the code with `show_log` equal `True`
+    # to show it does not fail.
+
+    apdl_ = """FINISH
+    /PREP7
+    """.split('\n')
+    # caplog.clear()
+    translator = FileTranslator(line_ending='\n', show_log=True)
+    for line in apdl_:
+        translator.translate_line(line)
+
+    # assert any(['Convert' in each for each in caplog.messages]) # This should work.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import logging
 
 from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core import examples


### PR DESCRIPTION
## Request
Implement a logger on the converter script. 

## Implementation
The logger is quite simple. Basic stdout output. No format. Uses the standard ``logging`` module.

The logging is made when we append the line to ``FileTranslator.lines`` through an overloaded ``append`` method in a custom ``List`` class.

## Use:
If the optional keyword ``show_log`` is ``True`` in ``FileTranslator``, the resulting converted PyMAPDL is printed to the stdout.

## Example:

```python
>>> from ansys.mapdl.core.convert import convert_apdl_block, FileTranslator
>>> apdl_ = """FINISH
... /PREP7
... """
>>>
>>>_ = convert_apdl_block(apdl_strings=apdl_, line_ending='\n', show_log=True)
Converted: '"""Script generated by ansys-mapdl-core version 0.60.dev0"""'
Converted: 'from ansys.mapdl.core import launch_mapdl'
Converted: 'mapdl = launch_mapdl(loglevel="WARNING")'
Converted: 'mapdl.finish()'
Converted: 'mapdl.prep7()'
Converted: 'mapdl.exit()'
```

Closes #698 
