### PR TITLE
add pressure vessle example

### DIFF
--- a/ansys/mapdl/core/_commands/parse.py
+++ b/ansys/mapdl/core/_commands/parse.py
@@ -44,6 +44,7 @@ def parse_e(msg: Optional[str]) -> Optional[int]:
 
 
 def parse_kpoint(msg):
+    """Parse create keypoint message and return keypoint number."""
     if msg:
         res = re.search(r"kpoint=\s+(\d+)\s+", msg)
         if res is not None:
@@ -51,15 +52,18 @@ def parse_kpoint(msg):
 
 
 def parse_output_areas(msg):
-    """Parse create area message and return area number"""
+    """Parse create area message and return area number."""
     if msg:
         res = re.search(r"(OUTPUT AREAS =\s*)([0-9]+)", msg)
+        if res is not None:
+            return int(res.group(2))
+        res = re.search(r"(OUTPUT AREA\(S\) =\s*)([0-9]+)", msg)
         if res is not None:
             return int(res.group(2))
 
 
 def parse_a(msg):
-    """Parse create area message and return area number"""
+    """Parse create area message and return area number."""
     if msg:
         res = re.search(r"(AREA NUMBER =\s*)([0-9]+)", msg)
         if res is not None:
@@ -67,7 +71,7 @@ def parse_a(msg):
 
 
 def parse_line_no(msg):
-    """Parse create area message and return area number"""
+    """Parse create line message and return line number."""
     if msg:
         res = re.search(r"LINE NO[.]=\s+(\d+)", msg)
         if res is not None:

--- a/ansys/mapdl/core/_commands/preproc/booleans.py
+++ b/ansys/mapdl/core/_commands/preproc/booleans.py
@@ -36,9 +36,20 @@ class Booleans:
         conditions assigned to the original entities will not be
         transferred to the new entities generated.  Concatenated entities
         are not valid with this command.
+
+        Examples
+        --------
+        Generate two areas and combine them.
+
+        >>> a1 = mapdl.rectng(2.5, 3.5, 0, 10)
+        >>> a2 = mapdl.cyl4(0, 10, 2.5, 0, 3.5, 90)
+        >>> a_comb = mapdl.aadd(a1, a2)
+        >>> a_comb
+        3
+
         """
         command = f"AADD,{na1},{na2},{na3},{na4},{na5},{na6},{na7},{na8},{na9}"
-        return self.run(command, **kwargs)
+        return parse.parse_output_areas(self.run(command, **kwargs))
 
     def aglue(
         self,

--- a/ansys/mapdl/core/_commands/preproc/volumes.py
+++ b/ansys/mapdl/core/_commands/preproc/volumes.py
@@ -862,10 +862,9 @@ class Volumes:
         nseg="",
         **kwargs,
     ) -> str:
-        """Generate cylindrical volumes by rotating an area pattern about
+        """Generate cylindrical volumes by rotating an area pattern about an axis.
 
         APDL Command: VROTAT
-        an axis.
 
         Generates cylindrical volumes (and their corresponding
         keypoints, lines, and areas) by rotating an area pattern (and

--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -1690,7 +1690,7 @@ class PostProcessing:
 
         """
         scalars = self.nodal_eqv_stress
-        kwargs.setdefault("scalar_bar_args", {'title': "Nodal Equilvanent\nStress"})
+        kwargs.setdefault("scalar_bar_args", {'title': "Nodal Equivalent\nStress"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
         )

--- a/examples/00-mapdl-examples/pressure_vessel.py
+++ b/examples/00-mapdl-examples/pressure_vessel.py
@@ -1,0 +1,159 @@
+"""
+.. _pressure_vessel_example:
+
+Pressure Vessel
+---------------
+This example demonstrates how to create a basic pressure vessel and
+apply a pressure to it.
+
+Also shown here:
+- Various ways of accessing stress results from MAPDL.
+- Comparison between PRNSOL, *VGET (efficient wrapping), and the legacy reader.
+- Notes regarding FULL vs. POWER graphics when using PRNSOL.
+
+"""
+import numpy as np
+from ansys.mapdl.core import launch_mapdl
+
+# start mapdl, enter the preprocessor, and set the units
+mapdl = launch_mapdl()
+
+mapdl.clear()
+mapdl.prep7()
+
+# US Customary system using inches (in, lbf*s2/in, s, °F).
+mapdl.units('BIN')
+
+
+###############################################################################
+# Set the materials and element type
+
+mapdl.et(1, "SOLID285")
+mapdl.mp("EX", 1, 10e6)
+mapdl.mp("PRXY", 1, 0.3)
+mapdl.mp("DENS", 1, 0.1)
+print(mapdl.mplist())
+
+
+###############################################################################
+# Create the Geometry
+
+# area generation
+height = 10
+inner_width = 2.5
+outer_width = 3.5
+mapdl.rectng(inner_width, outer_width, 0, height)
+mapdl.cyl4(0, height, inner_width, 0, outer_width, 90)
+
+# combine areas
+a_comb = mapdl.aadd(1, 2)
+mapdl.aplot(color='grey', background='w', show_area_numbering=True)
+
+# Generate a cylindrical volume by rotating an area pattern about an axis
+mapdl.vrotat(a_comb, pax1=6, arc=90)
+mapdl.vplot(color='grey', background='w', show_area_numbering=True, cpos='zy')
+
+
+###############################################################################
+# Create the mesh
+mapdl.smrtsize(1)
+mapdl.esize(0.25, 0)
+mapdl.mshape(1, "3D")
+mapdl.mshkey(0)
+mapdl.vmesh("ALL")
+mapdl.eplot(color='grey', background='w')
+
+
+###############################################################################
+# Solve
+
+# boundary condition selection
+mapdl.geometry.area_select([3, 5, 7])
+mapdl.da("ALL", "SYMM")
+mapdl.allsel()
+
+# apply pressure
+mapdl.geometry.area_select([1, 6])
+mapdl.sfa("ALL", 1, "PRES", 1000)
+mapdl.allsel()
+
+# solver
+mapdl.run("/SOL")
+mapdl.antype(0)
+mapdl.outres("ALL", "ALL")
+mapdl.run("/STATUS,SOLU")
+sol_output = mapdl.solve()
+mapdl.finish()
+
+
+###############################################################################
+# Post-Processing
+# ~~~~~~~~~~~~~~~
+# Enter the MAPDL post-postprocessing routine (/POST1) and obtain the
+# von-mises stress for the single static solution. Here, we use MAPDL
+# directly to obtain the results using a wrapper around the VGET method to efficiently obtain results without outputing to disk.
+
+# enter the postprocessing routine
+mapdl.post1()
+mapdl.set(1, 1)
+
+# results directly from MAPDL's VGET command
+# *VGET, __VAR__, NODE, , S, EQV
+nnum = mapdl.mesh.nnum
+von_mises_mapdl = mapdl.post_processing.nodal_eqv_stress
+
+# we could print out the solution for each node with:
+
+print(f'\nNode  Stress (psi)')
+for node_num, stress_value in zip(nnum[:5], von_mises_mapdl[:5]):
+    print(f'{node_num:<5d} {stress_value:.3f}')
+print('...')
+
+# or simply get the maximum stress value and corresponding node
+idx = np.argmax(von_mises_mapdl)
+node_num = nnum[idx]
+stress_value = von_mises_mapdl[idx]
+print(f'\nMaximum Stress')
+print(f'Node  Stress (psi)')
+print(f'{node_num:<5d} {stress_value:.3f}')
+
+###############################################################################
+# Plot the results
+
+mapdl.post_processing.plot_nodal_eqv_stress(cpos='zy')
+
+
+###############################################################################
+# We could, alternatively, get the exact same results by directly
+# accessing the result file using the legacy file reader
+# `ansys-mapdl-reader <https://github.com/pyansys/pymapdl-reader>`_.
+
+# access the result
+result = mapdl.result
+
+# Get the von mises stess and show that this is equivalent to the
+# stress obtained from MAPDL.
+nnum, stress = result.principal_nodal_stress(0)
+von_mises = stress[:, -1]  # von-Mises stress is the right most column
+min_von_mises, max_von_mises = np.min(von_mises), np.max(von_mises)
+print('All close:', np.allclose(von_mises, von_mises_mapdl))
+
+###############################################################################
+# That these results are equivalent to results from PRNSOL.
+#
+# .. note::
+#    Enabling POWER GRAPHICS with ``mapdl.graphics('POWER') will
+#    change the averaging scheme.
+
+mapdl.header('OFF', 'OFF', 'OFF', 'OFF', 'OFF', 'OFF')
+table = mapdl.prnsol('S', 'PRIN').splitlines()[1:]
+prnsol_eqv = np.genfromtxt(table)[:, -1]  # eqv is the last column
+
+# show these are equivalent (RTOL due to rounding within PRNSOL)
+print('All close:', np.allclose(von_mises, prnsol_eqv, rtol=1E-4))
+
+print(f'LEGACY Reader and MAPDL VGET Min: {min_von_mises}')
+print(f'PRNSOL MAPDL Min:                 {prnsol_eqv.min()}')
+print()
+print(f'LEGACY Reader and MAPDL VGET Min: {max_von_mises}')
+print(f'PRNSOL MAPDL Min:                 {prnsol_eqv.max()}')

--- a/examples/00-mapdl-examples/pressure_vessel.py
+++ b/examples/00-mapdl-examples/pressure_vessel.py
@@ -91,7 +91,8 @@ mapdl.finish()
 # ~~~~~~~~~~~~~~~
 # Enter the MAPDL post-postprocessing routine (/POST1) and obtain the
 # von-mises stress for the single static solution. Here, we use MAPDL
-# directly to obtain the results using a wrapper around the VGET method to efficiently obtain results without outputing to disk.
+# directly to obtain the results using a wrapper around the VGET
+# method to efficiently obtain results without outputting to disk.
 
 # enter the postprocessing routine
 mapdl.post1()


### PR DESCRIPTION
Fix ``aadd`` method for Windows (currently fails), and now returns the correct int type.

Add pressure example, thanks to @aliirmak in #729.
