### PR TITLE
Fix mixed argument types in ``log_apdl`` argument.

### DIFF
--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -750,7 +750,7 @@ def launch_mapdl(
     start_instance=True,
     ip=LOCALHOST,
     clear_on_connect=True,
-    log_apdl=False,
+    log_apdl=None,
     verbose_mapdl=False,
     license_server_check=True,
     license_type=None,
@@ -856,6 +856,7 @@ def launch_mapdl(
         can be used to "record" all the commands that are sent to
         MAPDL via PyMAPDL so a script can be run within MAPDL without
         PyMAPDL. The input string should be the output file path.
+        Defaults is disable (``log_apdl=None``). 
 
     remove_temp_files : bool, optional
         Removes temporary files on exit.  Default ``False``.

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -855,7 +855,7 @@ def launch_mapdl(
         Enables logging every APDL command to the local disk.  This
         can be used to "record" all the commands that are sent to
         MAPDL via PyMAPDL so a script can be run within MAPDL without
-        PyMAPDL. This string is the path of the output file (e.g. 
+        PyMAPDL. This string is the path of the output file (e.g.
         ``log_apdl='pymapdl_log.txt'``). By default this is disabled.
 
     remove_temp_files : bool, optional

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -855,8 +855,7 @@ def launch_mapdl(
         Enables logging every APDL command to the local disk.  This
         can be used to "record" all the commands that are sent to
         MAPDL via PyMAPDL so a script can be run within MAPDL without
-        PyMAPDL. The input string should be the output file path.
-        Defaults is disable (``log_apdl=None``).
+        PyMAPDL. By default this is disabled.
 
     remove_temp_files : bool, optional
         Removes temporary files on exit.  Default ``False``.

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -856,7 +856,7 @@ def launch_mapdl(
         can be used to "record" all the commands that are sent to
         MAPDL via PyMAPDL so a script can be run within MAPDL without
         PyMAPDL. The input string should be the output file path.
-        Defaults is disable (``log_apdl=None``). 
+        Defaults is disable (``log_apdl=None``).
 
     remove_temp_files : bool, optional
         Removes temporary files on exit.  Default ``False``.

--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -855,7 +855,8 @@ def launch_mapdl(
         Enables logging every APDL command to the local disk.  This
         can be used to "record" all the commands that are sent to
         MAPDL via PyMAPDL so a script can be run within MAPDL without
-        PyMAPDL. By default this is disabled.
+        PyMAPDL. This string is the path of the output file (e.g. 
+        ``log_apdl='pymapdl_log.txt'``). By default this is disabled.
 
     remove_temp_files : bool, optional
         Removes temporary files on exit.  Default ``False``.

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -123,7 +123,7 @@ def setup_logger(loglevel='INFO', log_file=True, mapdl_instance=None):
 class _MapdlCore(Commands):
     """Contains methods in common between all Mapdl subclasses"""
 
-    def __init__(self, loglevel='DEBUG', use_vtk=True, log_apdl=False,
+    def __init__(self, loglevel='DEBUG', use_vtk=True, log_apdl=None,
                 log_file=True, local=True, **start_parm):
         """Initialize connection with MAPDL."""
         self._show_matplotlib_figures = True  # for testing

--- a/ansys/mapdl/core/mapdl_console.py
+++ b/ansys/mapdl/core/mapdl_console.py
@@ -78,7 +78,7 @@ class MapdlConsole(_MapdlCore):
     Only works on Linux.
     """
 
-    def __init__(self, loglevel="INFO", log_apdl="w", use_vtk=True, **start_parm):
+    def __init__(self, loglevel="INFO", log_apdl=None, use_vtk=True, **start_parm):
         """Opens an ANSYS process using pexpect"""
         self._auto_continue = True
         self._continue_on_error = False

--- a/ansys/mapdl/core/mapdl_corba.py
+++ b/ansys/mapdl/core/mapdl_corba.py
@@ -164,7 +164,7 @@ class MapdlCorba(_MapdlCore):
 
     """
 
-    def __init__(self, loglevel='INFO', log_apdl='w', use_vtk=True,
+    def __init__(self, loglevel='INFO', log_apdl=None, use_vtk=True,
                 log_file = True,
                  log_broadcast=False, verbose=False, **start_parm):
         """Open a connection to MAPDL via a CORBA interface"""

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -203,7 +203,7 @@ class MapdlGrpc(_MapdlCore):
     _port = None
 
     def __init__(self, ip='127.0.0.1', port=None, timeout=15, loglevel='WARNING',
-                log_file=True, cleanup_on_exit=False, log_apdl=False,
+                log_file=True, cleanup_on_exit=False, log_apdl=None,
                 set_no_abort=True, remove_temp_files=False, **kwargs):
         """Initialize connection to the mapdl server"""
         # port and ip are needed to setup the log


### PR DESCRIPTION
The argument type wasn't consistent across documentation and code, mixing file mode and Booleans.

Now that parameter will accept strings, which will be the name of the file (located then in the python working directory) or the full path of it. 


Fix #742 
Closes #742 