### PR TITLE
add get_value guard when using non_interactive

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1,7 +1,5 @@
 """Module to control interaction with MAPDL through Python"""
 
-from ansys.mapdl.core import LOG as logger
-
 import time
 import glob
 import re
@@ -29,6 +27,7 @@ from ansys.mapdl.core.plotting import general_plotter
 from ansys.mapdl.core.post import PostProcessing
 from ansys.mapdl.core.commands import Commands
 from ansys.mapdl.core.inline_functions import Query
+from ansys.mapdl.core import LOG as logger
 
 
 _PERMITTED_ERRORS = [
@@ -1581,37 +1580,46 @@ class _MapdlCore(Commands):
     def get_value(
         self, entity="", entnum="", item1="", it1num="", item2="", it2num="", **kwargs
     ):
-        """Runs the GET command and returns a Python value.
+        """Runs the MAPDL GET command and returns a Python value.
 
-        This method uses :func:`_MapdlCore.get`.
+        This method uses :func:`Mapdl.get`.
 
         See the full MADPL command documentation at `*GET
         <https://www.mm.bme.hu/~gyebro/files/ans_help_v182/ans_cmd/Hlp_C_GET.html>`_
 
+        .. note::
+           This method is not available when within the
+           :func:`Mapdl.non_interactive`
+           context manager.
+
         Parameters
         ----------
-        entity
-            Entity keyword. Valid keywords are NODE, ELEM, KP, LINE, AREA,
-            VOLU, PDS, etc.
+        entity : str
+            Entity keyword. Valid keywords are ``"NODE"``, ``"ELEM"``,
+            ``"KP"``, ``"LINE"``, ``"AREA"``, ``"VOLU"``, ``"PDS"``,
+            etc.
 
-        entnum
-            The number or label for the entity (as shown for ENTNUM = in the
-            tables below). In some cases, a zero (or blank) ENTNUM represents
-            all entities of the set.
+        entnum : str, int, optional
+            The number or label for the entity. In some cases, a zero
+            (or blank ``""``) ``entnum`` represents all entities of
+            the set.
 
-        item1
-            The name of a particular item for the given entity. Valid items are
-            as shown in the Item1 columns of the tables below.
+        item1 : str, optional
+            The name of a particular item for the given entity.
 
-        it1num
-            The number (or label) for the specified Item1 (if any). Valid
-            IT1NUM values are as shown in the IT1NUM columns of the tables
-            below. Some Item1 labels do not require an IT1NUM value.
+        it1num : str, int, optional
+            The number (or label) for the specified Item1 (if
+            any). Some Item1 labels do not require an IT1NUM value.
 
-        item2, it2num
+        item2 : str, optional
             A second set of item labels and numbers to further qualify the item
             for which data are to be retrieved. Most items do not require this
             level of information.
+
+        it2num : str, int, optional
+            The number (or label) for the specified ``item2`` (if
+            any). Some ``item2`` labels do not require an ``it2num``
+            value.
 
         Returns
         -------

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1226,9 +1226,16 @@ class MapdlGrpc(_MapdlCore):
     def _get(self, entity, entnum, item1, it1num, item2, it2num):
         """Sends gRPC *Get request.
 
-        WARNING: Not thread SAFE.  Uses _get_lock to ensure multiple
-        request aren't evaluated simultaneously.
+        .. warning::
+           Not thread safe.  Uses ``_get_lock`` to ensure multiple
+           request are not evaluated simultaneously.
         """
+        if self._store_commands:
+            raise RuntimeError(
+                "Cannot use gRPC enabled ``GET`` when in non_interactive mode. "
+                "Exit non_interactive mode before using this method."
+            )
+
         cmd = f"{entity},{entnum},{item1},{it1num},{item2},{it2num}"
 
         # not threadsafe; don't allow multiple get commands

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ filterwarnings =
 markers =
     skip_grpc: skip tests using grpc
     corba: skip tests using the CORBA interface
+testpaths = tests

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -205,3 +205,9 @@ def test_read_input_file(mapdl, file_name):
     mapdl.clear()
     response = mapdl.input(test_file)
     assert "*****  ANSYS SOLUTION ROUTINE  *****" in response
+
+
+def test_no_get_value_non_interactive(mapdl):
+    with pytest.raises(RuntimeError, match="Cannot use gRPC enabled ``GET``"):
+        with mapdl.non_interactive:
+            mapdl.get_value("ACTIVE", item1="CSYS")


### PR DESCRIPTION
Resolve #748 by implementing a basic guard when using ``non_interactive`` to avoid simultaneous querying the gRPC server.
