### PR TITLE
account for edge case with hidden nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,15 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Style
-        run: |
-          pip install -r requirements_style.txt --disable-pip-version-check
-          make
+      - name: Install requirements
+        run: pip install -r requirements_style.txt --disable-pip-version-check
+
+      - name: Spelling
+        run: make codespell
 
       - name: flake8
         if: always()
-        run: |
-          make flake8
+        run: make flake8
 
   testimport:
     name: Smoke Tests

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1494,7 +1494,7 @@ class _MapdlCore(Commands):
 
     def _get(self, *args, **kwargs):
         """Simply use the default get method"""
-        return self.get(*args, **kwargs)
+        return float(self.get(*args, **kwargs))
 
     def add_file_handler(self, filepath, append=False, level="DEBUG"):
         """Add a file handler to the mapdl log.  This allows you to

--- a/ansys/mapdl/core/mesh_grpc.py
+++ b/ansys/mapdl/core/mesh_grpc.py
@@ -173,7 +173,7 @@ class MeshGrpc(Mesh):
         >>> mapdl.mesh.n_node
         7217
         """
-        return int(self._mapdl.get(entity="NODE", item1="COUNT"))
+        return int(self._mapdl.get_value(entity="NODE", item1="COUNT"))
 
     @property
     @supress_logging
@@ -185,7 +185,7 @@ class MeshGrpc(Mesh):
         >>> mapdl.mesh.n_elem
         1520
         """
-        return int(self._mapdl.get(entity="ELEM", item1="COUNT"))
+        return int(self._mapdl.get_value(entity="ELEM", item1="COUNT"))
 
     @property
     def node_angles(self):
@@ -288,18 +288,18 @@ class MeshGrpc(Mesh):
         return self._node_coord
 
     def _load_nodes(self, chunk_size=DEFAULT_CHUNKSIZE):
-        """Loads nodes from server.
+        """Loads nodes from server using the gRPC backend.
 
         Parameters
         ----------
-        chunk_size : int
+        chunk_size : int, optional
             Size of the chunks to request from the server.  Default
-            256 kB
+            256 kB.
 
         Returns
         -------
         nodes : np.ndarray
-            Numpy array of nodes
+            Numpy array of nodes.
         """
         if self._chunk_size:
             chunk_size = self._chunk_size
@@ -307,6 +307,14 @@ class MeshGrpc(Mesh):
         request = anskernel.StreamRequest(chunk_size=chunk_size)
         chunks = self._mapdl._stub.Nodes(request)
         nodes = parse_chunks(chunks, np.double).reshape(-1, 3)
+
+        # Sometimes, MAPDL will return virtual, or hidden nodes.
+        # These appear to be at the beginning of the of the
+        # array. This behavior was identified in
+        # https://github.com/pyansys/pymapdl/issues/751
+        n_nodes = self.n_node
+        if n_nodes != nodes.shape[0]:
+            nodes = nodes[:n_nodes]
         return nodes
 
     @threaded

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -140,6 +140,55 @@ def make_block(mapdl, cleared):
     mapdl.vmesh("ALL")
 
 
+@pytest.fixture(scope="function")
+def beam188_solve(mapdl, cleared):
+    # run non-interactive for speed
+    with mapdl.non_interactive:
+        mapdl.antype("STATIC")
+        mapdl.et(1, "BEAM188")
+        mapdl.keyopt(1, 3, 3)  # Cubic shape function
+        mapdl.keyopt(1, 9, 3)
+
+        # define material
+        mapdl.mp("EX", 1, 30E6)
+        mapdl.mp("PRXY", 1, 0.3)
+
+        # define section
+        w_f = 1.048394965
+        w_w = 0.6856481
+        sec_num = 1
+        mapdl.sectype(sec_num, "BEAM", "I", "ISection")
+        mapdl.secdata(15, 15, 28 + (2 * w_f), w_f, w_f, w_w)
+
+        # define geometry
+        for node_num in range(1, 6):
+            mapdl.n(node_num, (node_num - 1) * 120, 0, 0)
+
+        # define one node for the orientation of the beam cross-section
+        mapdl.n(6, 60, 1)
+
+        # define elements
+        for elem_num in range(1, 5):
+            mapdl.e(elem_num, elem_num + 1, 6)
+
+        # boundary conditions
+        mapdl.d(2, "UX", lab2="UY")
+        mapdl.d(4, "UY")
+        mapdl.nsel("S", "LOC", "Y", 0)
+        mapdl.d("ALL", "UZ")
+        mapdl.d("ALL", "ROTX")
+        mapdl.d("ALL", "ROTY")
+        mapdl.nsel("ALL")
+
+        # application of the surface load to the beam element
+        w = 10000 / 12
+        mapdl.sfbeam(1, 1, "PRES", w)
+        mapdl.sfbeam(4, 1, "PRES", w)
+
+        mapdl.run("/SOLU")
+        mapdl.solve()
+
+
 @pytest.mark.skip_grpc
 def test_internal_name_grpc(mapdl):
     assert str(mapdl._ip) in mapdl._name
@@ -957,3 +1006,13 @@ def test_cwd_directory(mapdl, tmpdir):
         mapdl.directory = wrong_path
         assert 'The working directory specified' in record.list[-1].message.args[0]
         assert 'is not a directory on' in record.list[-1].message.args[0]
+
+
+def test_handle_hidden_nodes(mapdl, beam188_solve):
+    # Sometimes, MAPDL will return virtual, or hidden nodes.
+    # These appear to be at the beginning of the of the
+    # array. This behavior was identified in
+    # https://github.com/pyansys/pymapdl/issues/751
+
+    # this should just run without error. Add in a trivial assert as best-practice
+    assert mapdl.mesh.grid.n_points == mapdl.mesh.n_node


### PR DESCRIPTION
Resolves #751 by adding in an additional check within `MeshGrpc` to ensure that hidden nodes are not added to the internal `mapdl.mesh.grid` object when pulling the nodes from the server.  For reference, these hidden nodes are created for BEAM188 elements when running `SOLVE`. Oddly enough, MAPDL will mention that these nodes exist in `CDWRITE`, but not actually write them, nor list them when running `mapdl.nlist`.
 
---
#### Bonus change
Our style check was running the spell check twice. This has been split up into two separate tasks, and the requirements are also installed in a previous step so it's easier to read the logs.