### PR TITLE
Use consistent tests

### DIFF
--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -700,15 +700,15 @@ def test_cyclic_solve(mapdl, cleared):
 
 
 def test_load_table(mapdl):
-    dimx = np.random.randint(3, 15)
-    dimy = np.random.randint(3, 15)
+    dimx = 5
+    dimy = 8
 
     my_conv = np.random.rand(dimx, dimy)
     my_conv[:, 0] = np.arange(dimx)
     my_conv[0, :] = np.arange(dimy)
 
     mapdl.load_table("my_conv", my_conv)
-    assert np.allclose(mapdl.parameters["my_conv"], my_conv[1:, 1:], rtol=0.0001)
+    assert np.allclose(mapdl.parameters["my_conv"], my_conv[1:, 1:], 1E-7)
 
     with pytest.raises(ValueError, match='requires that the axis 0 is in ascending order.'):
         my_conv1 = my_conv.copy()
@@ -721,14 +721,16 @@ def test_load_table(mapdl):
         mapdl.load_table("my_conv", my_conv1)
 
 
-def test_load_array(mapdl):
-
-    dimx = np.random.randint(1, 15)
-    dimy = np.random.randint(1, 15)
+@pytest.mark.parametrize("dimx", [1, 3, 10])
+@pytest.mark.parametrize("dimy", [1, 3, 10])
+def test_load_array(mapdl, dimx, dimy):
     my_conv = np.random.rand(dimx, dimy)
-
     mapdl.load_array("my_conv", my_conv)
-    assert np.allclose(mapdl.parameters["my_conv"], my_conv, rtol=0.0001)
+
+    # flatten as MAPDL returns flat arrays when second dimension is 1.
+    if dimy == 1:
+        my_conv = my_conv.ravel()
+    assert np.allclose(mapdl.parameters["my_conv"], my_conv, rtol=1E-7)
 
 
 @pytest.mark.skip_grpc


### PR DESCRIPTION
Ping @germa89:

Looks like #758 didn't quite resolve our issues. We're still seeing intermittent failures in `test_load_array`. You can validate this locally with:

```
pytest tests/test_mapdl.py -k test_load_array --count 100 -x
```

This fails because when our input array is shaped `(10, 1)`, MAPDL will output a flat array `(10,)`. Since numpy outputs flat arrays when the second dimension is 1, (e.g. `numpy.arange`), this PR changes the test to account for this edge case.

### Lessons learned

If we want to test for a variety of edge cases, use parameterized inputs:

```py
@pytest.mark.parametrize("dimx", [1, 3, 10])
@pytest.mark.parametrize("dimy", [1, 3, 10])
def test_load_array(mapdl, dimx, dimy):
    my_conv = np.random.rand(dimx, dimy)
    mapdl.load_array("my_conv", my_conv)

    # flatten as MAPDL returns flat arrays when second dimension is 1.
    if dimy == 1:
        my_conv = my_conv.ravel()
    assert np.allclose(mapdl.parameters["my_conv"], my_conv, rtol=0.0001)
```

This way, we test a variety of edge cases without resorting to random integers. Tracking down flaky tests is a nightmare. Let's avoid it by making tests consistent.  If we want complete testing, let's focus on parameterized tests, not randomized tests. If we really want to do randomized tests correctly, checkout the [hypothesis](https://hypothesis.readthedocs.io/en/latest/details.html) library.  Disclaimer: it's going to make our tests longer and harder to maintain.
