### PR TITLE
Created api commands for mag, pres and temp and volt

### DIFF
--- a/ansys/mapdl/core/inline_functions/inline_functions.py
+++ b/ansys/mapdl/core/inline_functions/inline_functions.py
@@ -1,8 +1,9 @@
 from .component_queries import (
     _DisplacementComponentQueries,
     _InverseGetComponentQueries,
-    _ComponentQueries,
+    _ComponentQueries
 )
+from .scalar_queries import _ScalarQueries
 from .selection_queries import _SelectionStatusQueries, _NextSelectedEntityQueries
 from .line_queries import _LineFractionCoordinateQueries, _LineFractionSlopeQueries
 from .normals_queries import _NodeNormalQueries, _KeypointNormalQueries
@@ -26,6 +27,7 @@ class Query(
     _AngleQueries,
     _AreaQueries,
     _DistanceQueries,
+    _ScalarQueries
 ):
     """Class containing all the inline functions of APDL.
 

--- a/ansys/mapdl/core/inline_functions/scalar_queries.py
+++ b/ansys/mapdl/core/inline_functions/scalar_queries.py
@@ -1,0 +1,101 @@
+from .core import _QueryExecution
+
+
+class _ScalarQueries(_QueryExecution):
+    _mapdl = None
+
+    def temp(self, n: int) -> float:
+        """Returns temperature at node ``n``.
+
+        Temperature at node ``n``.
+
+        Parameters
+        ----------
+        n : int
+            Node number
+
+        Returns
+        -------
+        float
+            Temperature
+
+        Examples
+        --------
+        This example has been adapted from the example script
+        :ref:`_ref_3d_plate_thermal`. We create a block
+        of solid material, and apply a temperature to one end
+        of the block, and then solve.
+
+        Then we can use ``queries.temp`` to get the temperature
+        at the first node on the deformed.
+
+        >>> from ansys.mapdl.core import launch_mapdl
+        >>> mapdl = launch_mapdl()
+        >>> mapdl.clear()
+        >>> mapdl.prep7()
+        >>> mapdl.mp("kxx", 1, 45)
+        >>> mapdl.et(1, 'SOLID70')
+        >>> mapdl.block(-0.3, 0.3, -0.46, 1.34, -0.2, -0.2 + 0.02)
+        >>> mapdl.esize(0.01)
+        >>> mapdl.vmesh(1)
+        >>> mapdl.asel("S", vmin=3)
+        >>> mapdl.nsla()
+        >>> mapdl.d("all", "temp", 5)
+        >>> mapdl.nsel('ALL')
+        >>> mapdl.run("/SOLU")
+        >>> mapdl.solve()
+        >>> mapdl.queries.temp(1)
+        4.99999994201101
+        """
+        return self._run_query(f"TEMP({n})", integer=False)
+
+    def pres(self, n: int) -> float:
+        """Returns pressure at node ``n``.
+
+        Pressure at node ``n``.
+
+        Parameters
+        ----------
+        n : int
+            Node number
+
+        Returns
+        -------
+        float
+            Pressure
+        """
+        return self._run_query(f"PRES({n})", integer=False)
+
+    def volt(self, n: int) -> float:
+        """Returns electric potential at node ``n``.
+
+        Electric potential at node ``n``.
+
+        Parameters
+        ----------
+        n : int
+            Node number
+
+        Returns
+        -------
+        float
+            Electric potential
+        """
+        return self._run_query(f"VOLT({n})", integer=False)
+
+    def mag(self, n: int) -> float:
+        """Returns magnetic scalar potential at node ``n``.
+
+        Magnetic scalar potential at node ``n``.
+
+        Parameters
+        ----------
+        n : int
+            Node number
+
+        Returns
+        -------
+        float
+            Magnetic scalar potential
+        """
+        return self._run_query(f"VOLT({n})", integer=False)

--- a/ansys/mapdl/core/inline_functions/scalar_queries.py
+++ b/ansys/mapdl/core/inline_functions/scalar_queries.py
@@ -21,13 +21,11 @@ class _ScalarQueries(_QueryExecution):
 
         Examples
         --------
-        This example has been adapted from the example script
-        :ref:`_ref_3d_plate_thermal`. We create a block
-        of solid material, and apply a temperature to one end
-        of the block, and then solve.
+        We create a block of solid material, and constrain the
+        temperature DOF of all its nodes to a uniform value, and then solve.
 
         Then we can use ``queries.temp`` to get the temperature
-        at the first node on the deformed.
+        at the first node of the solved model.
 
         >>> from ansys.mapdl.core import launch_mapdl
         >>> mapdl = launch_mapdl()
@@ -35,17 +33,14 @@ class _ScalarQueries(_QueryExecution):
         >>> mapdl.prep7()
         >>> mapdl.mp("kxx", 1, 45)
         >>> mapdl.et(1, 'SOLID70')
-        >>> mapdl.block(-0.3, 0.3, -0.46, 1.34, -0.2, -0.2 + 0.02)
-        >>> mapdl.esize(0.01)
+        >>> mapdl.block(0, 1, 0, 1, 0, 1)
+        >>> mapdl.esize(0.5)
         >>> mapdl.vmesh(1)
-        >>> mapdl.asel("S", vmin=3)
-        >>> mapdl.nsla()
         >>> mapdl.d("all", "temp", 5)
-        >>> mapdl.nsel('ALL')
-        >>> mapdl.run("/SOLU")
+        >>> mapdl.slashsolu()
         >>> mapdl.solve()
         >>> mapdl.queries.temp(1)
-        4.99999994201101
+        5.0
         """
         return self._run_query(f"TEMP({n})", integer=False)
 
@@ -63,6 +58,29 @@ class _ScalarQueries(_QueryExecution):
         -------
         float
             Pressure
+
+        Examples
+        --------
+        We create a block of solid material, and constrain the
+        pressure DOF of all its nodes to a uniform value, and then solve.
+
+        Then we can use ``queries.pres`` to get the pressure
+        at the first node of the solved model.
+
+        >>> mapdl.clear()
+        >>> mapdl.prep7()
+        >>> mapdl.mp("ex", 1, 1)
+        >>> mapdl.et(1, 'CPT215')
+        >>> mapdl.keyopt(1, 12, 1)
+        >>> mapdl.block(0, 1, 0, 1, 0, 1)
+        >>> mapdl.esize(0.5)
+        >>> mapdl.vmesh(1)
+        >>> mapdl.d("all", "pres", 5)
+        >>> mapdl.d("all", "ux", 0, lab2="uy", lab3="uz")
+        >>> mapdl.run("/SOLU")
+        >>> mapdl.solve()
+        >>> mapdl.queries.pres(1)
+        5.0
         """
         return self._run_query(f"PRES({n})", integer=False)
 
@@ -80,6 +98,27 @@ class _ScalarQueries(_QueryExecution):
         -------
         float
             Electric potential
+
+        Examples
+        --------
+        We create a block of solid material, and constrain the
+        volt DOF of all its nodes to a uniform value, and then solve.
+
+        Then we can use ``queries.volt`` to get the Electric Potential
+        at the first node of the solved model.
+
+        >>> mapdl.clear()
+        >>> mapdl.prep7()
+        >>> mapdl.mp("perx", 1, 1)
+        >>> mapdl.et(1, 'SOLID122')
+        >>> mapdl.block(0, 1, 0, 1, 0, 1)
+        >>> mapdl.esize(0.5)
+        >>> mapdl.vmesh(1)
+        >>> mapdl.d("all", "volt", 5)
+        >>> mapdl.run("/SOLU")
+        >>> mapdl.solve()
+        >>> mapdl.queries.volt(1)
+        5.0
         """
         return self._run_query(f"VOLT({n})", integer=False)
 
@@ -97,5 +136,26 @@ class _ScalarQueries(_QueryExecution):
         -------
         float
             Magnetic scalar potential
+
+        Examples
+        --------
+        We create a block of solid material, and constrain the
+        mag DOF of all its nodes to a uniform value, and then solve.
+
+        Then we can use ``queries.mag`` to get the Magnetic Scalar
+        Potential at the first node of the solved model.
+
+        >>> mapdl.clear()
+        >>> mapdl.prep7()
+        >>> mapdl.mp("murx", 1, 1)
+        >>> mapdl.et(1, 'SOLID96')
+        >>> mapdl.block(0, 1, 0, 1, 0, 1)
+        >>> mapdl.esize(0.5)
+        >>> mapdl.vmesh(1)
+        >>> mapdl.d("all", "mag", 5)
+        >>> mapdl.run("/SOLU")
+        >>> mapdl.solve()
+        >>> mapdl.queries.mag(1)
+        5.0
         """
-        return self._run_query(f"VOLT({n})", integer=False)
+        return self._run_query(f"MAG({n})", integer=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,6 +280,22 @@ def cube_solve(cleared, mapdl):
 
 
 @pytest.fixture
+def box_with_fields(cleared, mapdl):
+    mapdl.prep7()
+    mapdl.mp("kxx", 1, 45)
+    mapdl.mp("ex", 1, 2e10)
+    mapdl.mp("perx", 1, 1)
+    mapdl.mp("murx", 1, 1)
+    mapdl.et(1, 'SOLID70')
+    mapdl.et(2, 'CPT215')
+    mapdl.et(3, 'SOLID122')
+    mapdl.et(4, 'SOLID96')
+    mapdl.block(0, 1, 0, 1, 0, 1)
+    mapdl.esize(0.5)
+    return mapdl
+
+
+@pytest.fixture
 def box_geometry(mapdl, cleared):
     areas, keypoints = create_geometry(mapdl)
     q = mapdl.queries

--- a/tests/test_inline_functions/test_field_component_queries.py
+++ b/tests/test_inline_functions/test_field_component_queries.py
@@ -1,19 +1,6 @@
 class TestFieldComponentValueGetter:
-    def build_setup(self, mapdl):
-        mapdl.prep7()
-        mapdl.mp("kxx", 1, 45)
-        mapdl.mp("ex", 1, 2e10)
-        mapdl.mp("perx", 1, 1)
-        mapdl.mp("murx", 1, 1)
-        mapdl.et(1, 'SOLID70')
-        mapdl.et(2, 'CPT215')
-        mapdl.et(3, 'SOLID122')
-        mapdl.et(4, 'SOLID96')
-        mapdl.block(0, 1, 0, 1, 0, 1)
-        mapdl.esize(0.5)
-
-    def test_temp(self, mapdl):
-        self.build_setup(mapdl)
+    def test_temp(self, box_with_fields):
+        mapdl = box_with_fields
         mapdl.type(1)
         mapdl.vmesh(1)
         mapdl.d("all", "temp", 5.0)
@@ -22,8 +9,8 @@ class TestFieldComponentValueGetter:
         temp_value = mapdl.queries.temp(1)
         assert temp_value is not None
 
-    def test_pressure(self, mapdl):
-        self.build_setup(mapdl)
+    def test_pressure(self, box_with_fields):
+        mapdl = box_with_fields
         mapdl.type(2)
         mapdl.vmesh(1)
         mapdl.d("all", "pres", 5.0)
@@ -33,8 +20,8 @@ class TestFieldComponentValueGetter:
         pres_value = mapdl.queries.pres(1)
         assert pres_value is not None
 
-    def test_volt(self, mapdl):
-        self.build_setup(mapdl)
+    def test_volt(self, box_with_fields):
+        mapdl = box_with_fields
         mapdl.type(3)
         mapdl.vmesh(1)
         mapdl.d("all", "volt", 5.0)
@@ -43,8 +30,8 @@ class TestFieldComponentValueGetter:
         volt_value = mapdl.queries.volt(1)
         assert volt_value is not None
 
-    def test_mag(self, mapdl):
-        self.build_setup(mapdl)
+    def test_mag(self, box_with_fields):
+        mapdl = box_with_fields
         mapdl.type(4)
         mapdl.vmesh(1)
         mapdl.d("all", "mag", 5.0)

--- a/tests/test_inline_functions/test_field_component_queries.py
+++ b/tests/test_inline_functions/test_field_component_queries.py
@@ -1,0 +1,54 @@
+class TestFieldComponentValueGetter:
+    def build_setup(self, mapdl):
+        mapdl.prep7()
+        mapdl.mp("kxx", 1, 45)
+        mapdl.mp("ex", 1, 2e10)
+        mapdl.mp("perx", 1, 1)
+        mapdl.mp("murx", 1, 1)
+        mapdl.et(1, 'SOLID70')
+        mapdl.et(2, 'CPT215')
+        mapdl.et(3, 'SOLID122')
+        mapdl.et(4, 'SOLID96')
+        mapdl.block(0, 1, 0, 1, 0, 1)
+        mapdl.esize(0.5)
+
+    def test_temp(self, mapdl):
+        self.build_setup(mapdl)
+        mapdl.type(1)
+        mapdl.vmesh(1)
+        mapdl.d("all", "temp", 5.0)
+        mapdl.slashsolu()
+        mapdl.solve()
+        temp_value = mapdl.queries.temp(1)
+        assert temp_value is not None
+
+    def test_pressure(self, mapdl):
+        self.build_setup(mapdl)
+        mapdl.type(2)
+        mapdl.vmesh(1)
+        mapdl.d("all", "pres", 5.0)
+        mapdl.d("all", "ux", 0.0, lab2="uy", lab3="uz")
+        mapdl.slashsolu()
+        mapdl.solve()
+        pres_value = mapdl.queries.pres(1)
+        assert pres_value is not None
+
+    def test_volt(self, mapdl):
+        self.build_setup(mapdl)
+        mapdl.type(3)
+        mapdl.vmesh(1)
+        mapdl.d("all", "volt", 5.0)
+        mapdl.slashsolu()
+        mapdl.solve()
+        volt_value = mapdl.queries.volt(1)
+        assert volt_value is not None
+
+    def test_mag(self, mapdl):
+        self.build_setup(mapdl)
+        mapdl.type(4)
+        mapdl.vmesh(1)
+        mapdl.d("all", "mag", 5.0)
+        mapdl.slashsolu()
+        mapdl.solve()
+        mag_value = mapdl.queries.mag(1)
+        assert mag_value is not None


### PR DESCRIPTION
Created equivalent pymapdl commands for the 4 scalar queries: MAG, PRES, VOLT,
and TEMP. Examples have only been added for one of the four and tests
for none of them because my knowledge of APDL is not extensive enough.
Further work will require external input.

@rgpatchi Can you create the examples for the commands without them? In addition we can work on tests for the three new functions together.