### PR TITLE
depricate usage of chain_commands

### DIFF
--- a/ansys/mapdl/core/check_version.py
+++ b/ansys/mapdl/core/check_version.py
@@ -110,8 +110,8 @@ def version_requires(min_version):
     class Client():
 
         def __init__(self):
-        '''Connects to a fake server'''
-        self._server = FakeServer()
+            '''Connects to a fake server'''
+            self._server = FakeServer()
 
         @version_requires((0, 1, 3))  # require 0.1.3
         def meth_a(self):

--- a/ansys/mapdl/core/mapdl_geometry.py
+++ b/ansys/mapdl/core/mapdl_geometry.py
@@ -241,7 +241,7 @@ class Geometry:
             Steps to between amin and amax.
         """
         # store initially selected areas and elements
-        with self._mapdl.chain_commands:
+        with self._mapdl.non_interactive:
             self._mapdl.cm("__tmp_elem__", "ELEM")
             self._mapdl.cm("__tmp_area__", "AREA")
         orig_anum = self.anum
@@ -261,14 +261,13 @@ class Geometry:
 
         # duplicate areas to avoid affecting existing areas
         a_num = int(self._mapdl.get(entity="AREA", item1="NUM", it1num="MAXD"))
-        with self._mapdl.chain_commands:
-            self._mapdl.numstr("AREA", a_num)
-            self._mapdl.agen(2, "ALL", noelem=1)
+        self._mapdl.numstr("AREA", a_num, mute=True)
+        self._mapdl.agen(2, "ALL", noelem=1, mute=True)
         a_max = int(self._mapdl.get(entity="AREA", item1="NUM", it1num="MAXD"))
 
-        with self._mapdl.chain_commands:
-            self._mapdl.asel("S", "AREA", vmin=a_num + 1, vmax=a_max)
-            self._mapdl.aatt()  # necessary to reset element/area meshing association
+        self._mapdl.asel("S", "AREA", vmin=a_num + 1, vmax=a_max, mute=True)
+        # necessary to reset element/area meshing association
+        self._mapdl.aatt(mute=True)
 
         # create a temporary etype
         etype_max = int(self._mapdl.get(entity="ETYP", item1="NUM", it1num="MAX"))
@@ -277,14 +276,13 @@ class Geometry:
 
         old_routine = self._mapdl.parameters.routine
 
-        with self._mapdl.chain_commands:
-            self._mapdl.et(etype_tmp, "MESH200", 6)
-            self._mapdl.shpp("off")
-            self._mapdl.smrtsize(density)
-            self._mapdl.type(etype_tmp)
+        self._mapdl.et(etype_tmp, "MESH200", 6, mute=True)
+        self._mapdl.shpp("off", mute=True)
+        self._mapdl.smrtsize(density, mute=True)
+        self._mapdl.type(etype_tmp, mute=True)
 
-            if old_routine != "PREP7":
-                self._mapdl.prep7()
+        if old_routine != "PREP7":
+            self._mapdl.prep7(mute=True)
 
         # Mesh and get the number of elements per area
         resp = self._mapdl.amesh("all")
@@ -299,16 +297,15 @@ class Geometry:
         # pd.clean(inplace=True)  # OPTIONAL
 
         # delete all temporary meshes and clean up settings
-        with self._mapdl.chain_commands:
-            self._mapdl.aclear("ALL")
-            self._mapdl.adele("ALL", kswp=1)
-            self._mapdl.numstr("AREA", 1)
-            self._mapdl.type(etype_old)
-            self._mapdl.etdele(etype_tmp)
-            self._mapdl.shpp("ON")
-            self._mapdl.smrtsize("OFF")
-            self._mapdl.cmsel("S", "__tmp_area__", "AREA")
-            self._mapdl.cmsel("S", "__tmp_elem__", "ELEM")
+        self._mapdl.aclear("ALL", mute=True)
+        self._mapdl.adele("ALL", kswp=1, mute=True)
+        self._mapdl.numstr("AREA", 1, mute=True)
+        self._mapdl.type(etype_old, mute=True)
+        self._mapdl.etdele(etype_tmp, mute=True)
+        self._mapdl.shpp("ON", mute=True)
+        self._mapdl.smrtsize("OFF", mute=True)
+        self._mapdl.cmsel("S", "__tmp_area__", "AREA", mute=True)
+        self._mapdl.cmsel("S", "__tmp_elem__", "ELEM", mute=True)
 
         # store the area number used for each element
         entity_num = np.empty(grid.n_cells, dtype=np.int32)
@@ -431,23 +428,21 @@ class Geometry:
     def _load_lines(self):
         """Load lines from MAPDL using IGES"""
         # ignore volumes
-        with self._mapdl.chain_commands:
-            self._mapdl.cm("__tmp_volu__", "VOLU")
-            self._mapdl.cm("__tmp_line__", "LINE")
-            self._mapdl.cm("__tmp_area__", "AREA")
-            self._mapdl.cm("__tmp_keyp__", "KP")
-            self._mapdl.ksel("ALL")
-            self._mapdl.lsel("ALL")
-            self._mapdl.asel("ALL")
-            self._mapdl.vsel("NONE")
+        self._mapdl.cm("__tmp_volu__", "VOLU", mute=True)
+        self._mapdl.cm("__tmp_line__", "LINE", mute=True)
+        self._mapdl.cm("__tmp_area__", "AREA", mute=True)
+        self._mapdl.cm("__tmp_keyp__", "KP", mute=True)
+        self._mapdl.ksel("ALL", mute=True)
+        self._mapdl.lsel("ALL", mute=True)
+        self._mapdl.asel("ALL", mute=True)
+        self._mapdl.vsel("NONE", mute=True)
 
         iges = self._load_iges()
 
-        with self._mapdl.chain_commands:
-            self._mapdl.cmsel("S", "__tmp_volu__", "VOLU")
-            self._mapdl.cmsel("S", "__tmp_area__", "AREA")
-            self._mapdl.cmsel("S", "__tmp_line__", "LINE")
-            self._mapdl.cmsel("S", "__tmp_keyp__", "KP")
+        self._mapdl.cmsel("S", "__tmp_volu__", "VOLU", mute=True)
+        self._mapdl.cmsel("S", "__tmp_area__", "AREA", mute=True)
+        self._mapdl.cmsel("S", "__tmp_line__", "LINE", mute=True)
+        self._mapdl.cmsel("S", "__tmp_keyp__", "KP", mute=True)
 
         selected_lnum = self.lnum
         lines = []
@@ -483,20 +478,18 @@ class Geometry:
     def _load_keypoints(self):
         """Load keypoints from MAPDL using IGES"""
         # write only keypoints
-        with self._mapdl.chain_commands:
-            self._mapdl.cm("__tmp_volu__", "VOLU")
-            self._mapdl.cm("__tmp_area__", "AREA")
-            self._mapdl.cm("__tmp_line__", "LINE")
-            self._mapdl.vsel("NONE")
-            self._mapdl.asel("NONE")
-            self._mapdl.lsel("NONE")
+        self._mapdl.cm("__tmp_volu__", "VOLU", mute=True)
+        self._mapdl.cm("__tmp_area__", "AREA", mute=True)
+        self._mapdl.cm("__tmp_line__", "LINE", mute=True)
+        self._mapdl.vsel("NONE", mute=True)
+        self._mapdl.asel("NONE", mute=True)
+        self._mapdl.lsel("NONE", mute=True)
 
         iges = self._load_iges()
 
-        with self._mapdl.chain_commands:
-            self._mapdl.cmsel("S", "__tmp_volu__", "VOLU")
-            self._mapdl.cmsel("S", "__tmp_area__", "AREA")
-            self._mapdl.cmsel("S", "__tmp_line__", "LINE")
+        self._mapdl.cmsel("S", "__tmp_volu__", "VOLU", mute=True)
+        self._mapdl.cmsel("S", "__tmp_area__", "AREA", mute=True)
+        self._mapdl.cmsel("S", "__tmp_line__", "LINE", mute=True)
 
         keypoints = []
         kp_num = []
@@ -881,7 +874,7 @@ class Geometry:
         # LSEL, , , ,P51X
 
         # unordered option
-        with self._mapdl.chain_commands:
+        with self._mapdl.non_interactive:
             self._mapdl.flst(5, items.size, FLST_LOOKUP[item_type])
             for item in items:
                 self._mapdl.fitem(5, item)

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -206,6 +206,8 @@ class MapdlGrpc(_MapdlCore):
                 log_file=True, cleanup_on_exit=False, log_apdl=None,
                 set_no_abort=True, remove_temp_files=False, **kwargs):
         """Initialize connection to the mapdl server"""
+        self.__distributed = None
+
         # port and ip are needed to setup the log
         self._port = port
         self._ip = ip
@@ -1808,3 +1810,10 @@ class MapdlGrpc(_MapdlCore):
 
     def get_name(self):
         return self._name
+
+    @property
+    def _distributed(self) -> bool:
+        """MAPDL is running in distributed mode."""
+        if self.__distributed is None:
+            self.__distributed = self.parameters.numcpu > 1
+        return self.__distributed

--- a/ansys/mapdl/core/mesh_grpc.py
+++ b/ansys/mapdl/core/mesh_grpc.py
@@ -77,9 +77,8 @@ class MeshGrpc(Mesh):
         """
         # elements must have their underlying nodes selected to avoid
         # VTK segfault
-        with self._mapdl.chain_commands:
-            self._mapdl.cm(TMP_NODE_CM, "NODE")
-            self._mapdl.nsle("S")
+        self._mapdl.cm(TMP_NODE_CM, "NODE", mute=True)
+        self._mapdl.nsle("S", mute=True)
 
         threads = [
             self._update_cache_elem(),

--- a/ansys/mapdl/core/parameters.py
+++ b/ansys/mapdl/core/parameters.py
@@ -37,7 +37,7 @@ class Parameters:
 
     Examples
     --------
-    Simply list all parameters except for MAPDL MATH parameters
+    Simply list all parameters except for MAPDL MATH parameters.
 
     >>> mapdl.parameters
     ARR                              : ARRAY DIM (3, 1, 1)
@@ -75,6 +75,22 @@ class Parameters:
     @property
     def _log(self):
         return self._mapdl._log
+
+    @property
+    def numcpu(self) -> int:
+        """Number of Distributed MAPDL processes being used.
+
+        Notes
+        -----
+        This will always return ``1`` when using shared memory parallel.
+
+        Examples
+        --------
+        >>> mapdl.parameters.numcpu
+        2
+
+        """
+        return int(self._mapdl.get_value("ACTIVE", item1="NUMCPU"))
 
     @property
     def routine(self) -> str:
@@ -447,7 +463,7 @@ class Parameters:
             old_mute = self._mapdl.mute
             self._mapdl.mute = True
 
-        with self._mapdl.chain_commands:
+        with self._mapdl.non_interactive:
             self._mapdl.dim(name, imax=idim, jmax=jdim, kmax=kdim)
             for i in range(idim):
                 for j in range(jdim):

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -592,6 +592,11 @@ each command individually.  You can then view the final response of
 the chained commands with :attr:`Mapdl.last_response
 <ansys.mapdl.core.Mapdl.last_response>`.
 
+.. note::
+   Command chaining is not supported in distributed MAPDL.  To improve
+   performances, use ``mute=True`` or :attr:`Mapdl.non_interactive
+   <ansys.mapdl.core.Mapdl.non_interactive>`.
+
 
 Sending Arrays to MAPDL
 -----------------------

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -262,13 +262,19 @@ def test_allow_ignore(mapdl):
 
 
 def test_chaining(mapdl, cleared):
-    mapdl.prep7()
-    n_kp = 1000
-    with mapdl.chain_commands:
-        for i in range(1, 1 + n_kp):
-            mapdl.k(i, i, i, i)
+    # test chaining with distributed only
+    if mapdl._distributed:
+        with pytest.raises(RuntimeError):
+            with mapdl.chain_commands:
+                mapdl.prep7()
+    else:
+        mapdl.prep7()
+        n_kp = 1000
+        with mapdl.chain_commands:
+            for i in range(1, 1 + n_kp):
+                mapdl.k(i, i, i, i)
 
-    assert mapdl.geometry.n_keypoint == 1000
+        assert mapdl.geometry.n_keypoint == 1000
 
 
 def test_error(mapdl):
@@ -558,7 +564,7 @@ def test_elements(cleared, mapdl):
         [0, 1, 3],
     ]
 
-    with mapdl.chain_commands:
+    with mapdl.non_interactive:
         for cell in [cell1, cell2]:
             for x, y, z in cell:
                 mapdl.n(x=x, y=y, z=z)


### PR DESCRIPTION
Chained commands are fully supported by MAPDL, especially in distributed mode:

> Multiple commands entered in an input file can be condensed into a single line if the commands are separated by the $ character (see Condensed Data Input in the Command Reference). Distributed Ansys cannot properly handle condensed data input. Each command must be placed on its own line in the input file for a Distributed Ansys run.

This PR depricates the usage of ``chain_commands`` internally, but still leaves the method available for those who wish to use it in shared memory parallel.
