### PR TITLE
Fix parsing time values in `post_processing` module

### DIFF
--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -171,11 +171,14 @@ class PostProcessing:
          75.03939292229019,
          75.20949687626468]
         """
-        list_rsp = self._mapdl.set("LIST")
-        groups = re.findall(r"([-+]?\d*\.\d+|\d+)", list_rsp)
+        self._mapdl.post1()
+        self._mapdl.header('OFF', 'OFF', 'OFF', 'OFF', 'OFF', 'OFF')
+        nsigfig = 10
+        self._mapdl.format('', 'E', nsigfig + 9, nsigfig)
+        self._mapdl.page(1E9, '', -1, 240)
 
-        # values will always be the second set
-        return np.array([float(item) for item in (groups[1::5])])
+        list_rsp = self._mapdl.set("LIST")
+        return np.genfromtxt(list_rsp.splitlines(), skip_header=3)
 
     def _reset_cache(self):
         """Reset local cache"""

--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -170,7 +170,7 @@ class PostProcessing:
          75.03939292229019,
          75.20949687626468]
         """
-        self._mapdl.post1()
+        self._mapdl.post1(mute=True)
         list_rsp = self._mapdl.set("LIST")
         return np.genfromtxt(list_rsp.splitlines(), skip_header=3)[:, 1]
 

--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -171,13 +171,8 @@ class PostProcessing:
          75.20949687626468]
         """
         self._mapdl.post1()
-        self._mapdl.header('OFF', 'OFF', 'OFF', 'OFF', 'OFF', 'OFF')
-        nsigfig = 10
-        self._mapdl.format('', 'E', nsigfig + 9, nsigfig)
-        self._mapdl.page(1E9, '', -1, 240)
-
         list_rsp = self._mapdl.set("LIST")
-        return np.genfromtxt(list_rsp.splitlines(), skip_header=3)
+        return np.genfromtxt(list_rsp.splitlines(), skip_header=3)[:, 1]
 
     def _reset_cache(self):
         """Reset local cache"""

--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -1,5 +1,4 @@
 """Post-processing module using MAPDL interface"""
-import re
 import weakref
 
 import numpy as np


### PR DESCRIPTION
Fix #723 by improving the parsing of the output string in `mapdl.post_processing.time_values()`.

Now all the heavy lifting is done by `np.genfromtxt` and no format issued. However, for this specific case, the format is fixed using `mapdl.header` and `mapdl.format`.
