### PR TITLE
Feat/post processing consistency properties

### DIFF
--- a/ansys/mapdl/core/post.py
+++ b/ansys/mapdl/core/post.py
@@ -1246,7 +1246,6 @@ class PostProcessing:
         """Element degree of freedom result"""
         return self._mapdl.get_array("ELEM", item1=item, it1num=it1num)
 
-    @property
     def nodal_temperature(self) -> np.ndarray:
         """The nodal temperature of the current result.
 
@@ -1265,7 +1264,7 @@ class PostProcessing:
 
         Examples
         --------
-        >>> mapdl.post_processing.temperature
+        >>> mapdl.post_processing.temperature()
         array([0., 0., 0., ..., 0., 0., 0.])
 
         """
@@ -1310,10 +1309,9 @@ class PostProcessing:
         """
         kwargs.setdefault("scalar_bar_args", {'title': "Nodal\nTemperature"})
         return self._plot_point_scalars(
-            self.nodal_temperature, show_node_numbering=show_node_numbering, **kwargs
+            self.nodal_temperature(), show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_pressure(self) -> np.ndarray:
         """The nodal pressure of the current result.
 
@@ -1332,7 +1330,7 @@ class PostProcessing:
 
         Examples
         --------
-        >>> mapdl.post_processing.pressure
+        >>> mapdl.post_processing.pressure()
         array([0., 0., 0., ..., 0., 0., 0.])
 
         """
@@ -1377,10 +1375,9 @@ class PostProcessing:
         """
         kwargs.setdefault("scalar_bar_args", {'title': "Nodal\nPressure"})
         return self._plot_point_scalars(
-            self.nodal_pressure, show_node_numbering=show_node_numbering, **kwargs
+            self.nodal_pressure(), show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_voltage(self) -> np.ndarray:
         """The nodal voltage of the current result.
 
@@ -1408,7 +1405,7 @@ class PostProcessing:
         --------
         Return the voltage of the current result.
 
-        >>> mapdl.post_processing.voltage
+        >>> mapdl.post_processing.voltage()
         array([0., 0., 0., ..., 0., 0., 0.])
         """
         return self._ndof_rst("VOLT")
@@ -1451,7 +1448,7 @@ class PostProcessing:
         """
         kwargs.setdefault("scalar_bar_args", {'title': "Nodal\nVoltage"})
         return self._plot_point_scalars(
-            self.nodal_voltage, show_node_numbering=show_node_numbering, **kwargs
+            self.nodal_voltage(), show_node_numbering=show_node_numbering, **kwargs
         )
 
     def nodal_component_stress(self, component) -> np.ndarray:
@@ -1621,7 +1618,6 @@ class PostProcessing:
             disp, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_stress_intensity(self) -> np.ndarray:
         """The nodal stress intensity of the current result.
 
@@ -1643,7 +1639,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_stress_intensity
+        >>> mapdl.post_processing.nodal_stress_intensity()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -1688,13 +1684,12 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_stress_intensity(smooth_shading=True)
 
         """
-        scalars = self.nodal_stress_intensity
+        scalars = self.nodal_stress_intensity()
         kwargs.setdefault("scalar_bar_args", {'title': "Nodal Stress\nIntensity"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_eqv_stress(self) -> np.ndarray:
         """The nodal equivalent stress of the current result.
 
@@ -1718,7 +1713,7 @@ class PostProcessing:
 
         Examples
         --------
-        >>> mapdl.post_processing.nodal_eqv_stress
+        >>> mapdl.post_processing.nodal_eqv_stress()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -1726,7 +1721,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_eqv_stress
+        >>> mapdl.post_processing.nodal_eqv_stress()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -1771,7 +1766,7 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_eqv_stress(smooth_shading=True)
 
         """
-        scalars = self.nodal_eqv_stress
+        scalars = self.nodal_eqv_stress()
         kwargs.setdefault("scalar_bar_args", {'title': "Nodal Equivalent\nStress"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
@@ -1952,7 +1947,6 @@ class PostProcessing:
             disp, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_total_strain_intensity(self) -> np.ndarray:
         """The total nodal strain intensity of the current result.
 
@@ -1976,7 +1970,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_total_strain_intensity
+        >>> mapdl.post_processing.nodal_total_strain_intensity()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2019,13 +2013,12 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_total_strain_intensity()
 
         """
-        scalars = self.nodal_total_strain_intensity
+        scalars = self.nodal_total_strain_intensity()
         kwargs.setdefault("scalar_bar_args", {'title': "Total Nodal\nStrain Intensity"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_total_eqv_strain(self) -> np.ndarray:
         """The total nodal equivalent strain of the current result.
 
@@ -2047,7 +2040,7 @@ class PostProcessing:
         --------
         Total quivalent strain for the current result.
 
-        >>> mapdl.post_processing.nodal_total_eqv_strain
+        >>> mapdl.post_processing.nodal_total_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2055,7 +2048,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_total_eqv_strain
+        >>> mapdl.post_processing.nodal_total_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2099,7 +2092,7 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_total_eqv_strain(smooth_shading=True)
 
         """
-        scalars = self.nodal_total_eqv_strain
+        scalars = self.nodal_total_eqv_strain()
         kwargs.setdefault("scalar_bar_args", {'title': "Total Nodal\nEquivalent Strain"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
@@ -2265,7 +2258,6 @@ class PostProcessing:
             disp, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_elastic_strain_intensity(self) -> np.ndarray:
         """The elastic nodal strain intensity of the current result.
 
@@ -2294,7 +2286,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_elastic_strain_intensity
+        >>> mapdl.post_processing.nodal_elastic_strain_intensity()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2338,13 +2330,12 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_elastic_strain_intensity()
 
         """
-        scalars = self.nodal_elastic_strain_intensity
+        scalars = self.nodal_elastic_strain_intensity()
         kwargs.setdefault("scalar_bar_args", {'title': "Elastic Nodal\nStrain Intensity"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_elastic_eqv_strain(self) -> np.ndarray:
         """The elastic nodal equivalent strain of the current result.
 
@@ -2365,7 +2356,7 @@ class PostProcessing:
         --------
         Elastic quivalent strain for the current result.
 
-        >>> mapdl.post_processing.nodal_elastic_eqv_strain
+        >>> mapdl.post_processing.nodal_elastic_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2373,7 +2364,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_elastic_eqv_strain
+        >>> mapdl.post_processing.nodal_elastic_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2417,7 +2408,7 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_elastic_eqv_strain(smooth_shading=True)
 
         """
-        scalars = self.nodal_elastic_eqv_strain
+        scalars = self.nodal_elastic_eqv_strain()
         kwargs.setdefault("scalar_bar_args", {'title': "Elastic Nodal\n Equivalent Strain"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
@@ -2582,7 +2573,6 @@ class PostProcessing:
             disp, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_plastic_strain_intensity(self) -> np.ndarray:
         """The plastic nodal strain intensity of the current result.
 
@@ -2612,7 +2602,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_plastic_strain_intensity
+        >>> mapdl.post_processing.nodal_plastic_strain_intensity()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2656,13 +2646,12 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_plastic_strain_intensity()
 
         """
-        scalars = self.nodal_plastic_strain_intensity
+        scalars = self.nodal_plastic_strain_intensity()
         kwargs.setdefault("scalar_bar_args", {'title': "Plastic Nodal\nStrain Intensity"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_plastic_eqv_strain(self) -> np.ndarray:
         """The plastic nodal equivalent strain of the current result.
 
@@ -2690,7 +2679,7 @@ class PostProcessing:
         --------
         Plastic quivalent strain for the current result
 
-        >>> mapdl.post_processing.nodal_plastic_eqv_strain
+        >>> mapdl.post_processing.nodal_plastic_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2698,7 +2687,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_plastic_eqv_strain
+        >>> mapdl.post_processing.nodal_plastic_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2742,7 +2731,7 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_plastic_eqv_strain(smooth_shading=True)
 
         """
-        scalars = self.nodal_plastic_eqv_strain
+        scalars = self.nodal_plastic_eqv_strain()
         kwargs.setdefault("scalar_bar_args", {'title': "Plastic Nodal\n Equivalent Strain"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
@@ -2914,7 +2903,6 @@ class PostProcessing:
             disp, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_thermal_strain_intensity(self) -> np.ndarray:
         """The thermal nodal strain intensity of the current result.
 
@@ -2944,7 +2932,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_thermal_strain_intensity
+        >>> mapdl.post_processing.nodal_thermal_strain_intensity()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -2985,13 +2973,12 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_thermal_strain_intensity()
 
         """
-        scalars = self.nodal_thermal_strain_intensity
+        scalars = self.nodal_thermal_strain_intensity()
         kwargs.setdefault("scalar_bar_args", {'title': "Thermal Nodal\nStrain Intensity"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_thermal_eqv_strain(self) -> np.ndarray:
         """The thermal nodal equivalent strain of the current result.
 
@@ -3019,7 +3006,7 @@ class PostProcessing:
         --------
         Thermal quivalent strain for the current result.
 
-        >>> mapdl.post_processing.nodal_thermal_eqv_strain
+        >>> mapdl.post_processing.nodal_thermal_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -3027,7 +3014,7 @@ class PostProcessing:
 
         >>> mapdl.post1()
         >>> mapdl.set(1, 2)
-        >>> mapdl.post_processing.nodal_thermal_eqv_strain
+        >>> mapdl.post_processing.nodal_thermal_eqv_strain()
         array([15488.84357602, 16434.95432337, 15683.2334295 , ...,
                    0.        ,     0.        ,     0.        ])
 
@@ -3071,13 +3058,12 @@ class PostProcessing:
         >>> mapdl.post_processing.plot_nodal_thermal_eqv_strain(smooth_shading=True)
 
         """
-        scalars = self.nodal_thermal_eqv_strain
+        scalars = self.nodal_thermal_eqv_strain()
         kwargs.setdefault("scalar_bar_args", {'title': "Thermal Nodal\n Equivalent Strain"})
         return self._plot_point_scalars(
             scalars, show_node_numbering=show_node_numbering, **kwargs
         )
 
-    @property
     def nodal_contact_friction_stress(self) -> np.ndarray:
         """Nodal contact friction stress of the current result.
 
@@ -3149,5 +3135,5 @@ class PostProcessing:
         """
         kwargs.setdefault("scalar_bar_args", {'title': "Nodal Contact\n Friction Stress"})
         return self._plot_point_scalars(
-            self.nodal_contact_friction_stress, show_node_numbering=show_node_numbering, **kwargs
+            self.nodal_contact_friction_stress(), show_node_numbering=show_node_numbering, **kwargs
         )

--- a/examples/00-mapdl-examples/pressure_vessel.py
+++ b/examples/00-mapdl-examples/pressure_vessel.py
@@ -101,7 +101,7 @@ mapdl.set(1, 1)
 # results directly from MAPDL's VGET command
 # *VGET, __VAR__, NODE, , S, EQV
 nnum = mapdl.mesh.nnum
-von_mises_mapdl = mapdl.post_processing.nodal_eqv_stress
+von_mises_mapdl = mapdl.post_processing.nodal_eqv_stress()
 
 # we could print out the solution for each node with:
 

--- a/examples/00-mapdl-examples/transient_thermal.py
+++ b/examples/00-mapdl-examples/transient_thermal.py
@@ -187,7 +187,7 @@ mapdl.post1()
 
 # get the temperature of the 30th result set
 mapdl.set(1, 30)
-temp = mapdl.post_processing.nodal_temperature
+temp = mapdl.post_processing.nodal_temperature()
 
 # Load this result into the underlying VTK grid
 grid = mapdl.mesh._grid
@@ -205,7 +205,7 @@ single_slice.plot(scalars="temperature")
 
 # get the temperature of a different result set
 mapdl.set(1, 120)
-temp = mapdl.post_processing.nodal_temperature
+temp = mapdl.post_processing.nodal_temperature()
 
 # Load this result into the underlying VTK grid
 grid = mapdl.mesh._grid
@@ -255,7 +255,7 @@ idx = np.nonzero(mapdl.mesh.nnum == 12)[0][0]
 node_temp_from_post = []
 for i in range(1, 1 + nsets):
     mapdl.set(1, i)
-    node_temp_from_post.append(mapdl.post_processing.nodal_temperature[idx])
+    node_temp_from_post.append(mapdl.post_processing.nodal_temperature()[idx])
 
 # Again, the first 10 temperatures
 node_temp_from_post[:10]

--- a/examples/06-verif-manual/vm-004-deflection_of_a_hinged_support.py
+++ b/examples/06-verif-manual/vm-004-deflection_of_a_hinged_support.py
@@ -157,7 +157,7 @@ mapdl.post_processing.plot_nodal_displacement(
 #    text, it returns a numpy array.
 
 
-seqv = mapdl.post_processing.nodal_eqv_stress
+seqv = mapdl.post_processing.nodal_eqv_stress()
 
 # print out the nodes
 for i, nnum in enumerate(mapdl.mesh.nnum):

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -472,7 +472,7 @@ def test_nodal_eqv_stress(mapdl, static_solve):
     data = np.genfromtxt(mapdl.prnsol("S", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     seqv_ans = data[:, -1]
-    seqv = mapdl.post_processing.nodal_eqv_stress
+    seqv = mapdl.post_processing.nodal_eqv_stress()
 
     seqv_aligned = seqv[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(seqv_ans, seqv_aligned)
@@ -523,7 +523,7 @@ def test_plot_rot(mapdl, static_solve, comp):
 
 # TODO: add valid result
 def test_temperature(mapdl, static_solve):
-    from_grpc = mapdl.post_processing.nodal_temperature
+    from_grpc = mapdl.post_processing.nodal_temperature()
     assert np.allclose(from_grpc, 0)
 
 
@@ -548,7 +548,7 @@ def test_plot_temperature(mapdl, static_solve):
 
 # TODO: add valid result
 def test_pressure(mapdl, static_solve):
-    from_grpc = mapdl.post_processing.nodal_pressure
+    from_grpc = mapdl.post_processing.nodal_pressure()
     assert np.allclose(from_grpc, 0)
 
 
@@ -559,7 +559,7 @@ def test_plot_pressure(mapdl, static_solve):
 
 # TODO: add valid result
 def test_voltage(mapdl, static_solve):
-    from_grpc = mapdl.post_processing.nodal_voltage
+    from_grpc = mapdl.post_processing.nodal_voltage()
     assert np.allclose(from_grpc, 0)
 
 
@@ -683,7 +683,7 @@ def test_nodal_total_strain_intensity(mapdl, static_solve):
     data = np.genfromtxt(mapdl.prnsol("EPTO", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     sint_ans = data[:, -2]
-    sint = mapdl.post_processing.nodal_total_strain_intensity
+    sint = mapdl.post_processing.nodal_total_strain_intensity()
 
     sint_aligned = sint[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(sint_ans, sint_aligned)
@@ -702,7 +702,7 @@ def test_nodal_total_eqv_strain(mapdl, static_solve):
     data = np.genfromtxt(mapdl.prnsol("EPTO", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     seqv_ans = data[:, -1]
-    seqv = mapdl.post_processing.nodal_total_eqv_strain
+    seqv = mapdl.post_processing.nodal_total_eqv_strain()
 
     seqv_aligned = seqv[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(seqv_ans, seqv_aligned)
@@ -828,7 +828,7 @@ def test_nodal_elastic_strain_intensity(mapdl, static_solve):
     data = np.genfromtxt(mapdl.prnsol("EPEL", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     sint_ans = data[:, -2]
-    sint = mapdl.post_processing.nodal_elastic_strain_intensity
+    sint = mapdl.post_processing.nodal_elastic_strain_intensity()
 
     sint_aligned = sint[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(sint_ans, sint_aligned)
@@ -847,7 +847,7 @@ def test_nodal_elastic_eqv_strain(mapdl, static_solve):
     data = np.genfromtxt(mapdl.prnsol("EPEL", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     seqv_ans = data[:, -1]
-    seqv = mapdl.post_processing.nodal_elastic_eqv_strain
+    seqv = mapdl.post_processing.nodal_elastic_eqv_strain()
 
     seqv_aligned = seqv[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(seqv_ans, seqv_aligned)
@@ -990,7 +990,7 @@ def test_nodal_plastic_strain_intensity(mapdl, plastic_solve):
     data = np.genfromtxt(mapdl.prnsol("EPPL", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     sint_ans = data[:, -2]
-    sint = mapdl.post_processing.nodal_plastic_strain_intensity
+    sint = mapdl.post_processing.nodal_plastic_strain_intensity()
 
     sint_aligned = sint[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(sint_ans, sint_aligned)
@@ -1006,7 +1006,7 @@ def test_nodal_plastic_eqv_strain(mapdl, plastic_solve):
     data = np.genfromtxt(mapdl.prnsol("EPPL", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     seqv_ans = data[:, -1]
-    seqv = mapdl.post_processing.nodal_plastic_eqv_strain
+    seqv = mapdl.post_processing.nodal_plastic_eqv_strain()
 
     seqv_aligned = seqv[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(seqv_ans, seqv_aligned)
@@ -1031,7 +1031,7 @@ def test_nodal_contact_friction_stress(mapdl, contact_solve):
     nodes = array[:, 0]
 
     index = nodes.astype(int) - 1  # -1 to convert apdl node number to python index.
-    sfric_nod = mapdl.post_processing.nodal_contact_friction_stress[index]
+    sfric_nod = mapdl.post_processing.nodal_contact_friction_stress()[index]
 
     assert np.allclose(sfric_prn, sfric_nod)
 
@@ -1087,7 +1087,7 @@ def test_plot_nodal_contact_friction_stress(mapdl, contact_solve):
 #     data = np.genfromtxt(mapdl.prnsol('EPPL', 'PRIN').splitlines()[1:])
 #     nnum_ans = data[:, 0].astype(np.int32)
 #     sint_ans = data[:, -2]
-#     sint = mapdl.post_processing.nodal_thermal_strain_intensity
+#     sint = mapdl.post_processing.nodal_thermal_strain_intensity()
 
 #     sint_aligned = sint[np.in1d(mapdl.mesh.nnum, nnum_ans)]
 #     assert np.allclose(sint_ans, sint_aligned)
@@ -1103,7 +1103,7 @@ def test_plot_nodal_contact_friction_stress(mapdl, contact_solve):
 #     data = np.genfromtxt(mapdl.prnsol('EPPL', 'PRIN').splitlines()[1:])
 #     nnum_ans = data[:, 0].astype(np.int32)
 #     seqv_ans = data[:, -1]
-#     seqv = mapdl.post_processing.nodal_thermal_eqv_strain
+#     seqv = mapdl.post_processing.nodal_thermal_eqv_strain()
 
 #     seqv_aligned = seqv[np.in1d(mapdl.mesh.nnum, nnum_ans)]
 #     assert np.allclose(seqv_ans, seqv_aligned)

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -765,7 +765,7 @@ def test_nodal_stress_intensity(mapdl, static_solve):
     data = np.genfromtxt(mapdl.prnsol("S", "PRIN").splitlines()[1:])
     nnum_ans = data[:, 0].astype(np.int32)
     sint_ans = data[:, -2]
-    sint = mapdl.post_processing.nodal_stress_intensity
+    sint = mapdl.post_processing.nodal_stress_intensity()
 
     sint_aligned = sint[np.in1d(mapdl.mesh.nnum, nnum_ans)]
     assert np.allclose(sint_ans, sint_aligned)


### PR DESCRIPTION
Close #775 by implementing some API changes.

Now all the nodal and elements "getter" results methods need to be called. No `@property` is used for them.






