### PR TITLE
Fix/ ``log_file`` keyword was not being used in ``_Mapdl``

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -144,8 +144,14 @@ class _MapdlCore(Commands):
         self._path = start_parm.get("run_location", None)
         self._ignore_errors = False
 
-        # Setting up logger
-        self._log = logger.add_instance_logger(self._name, self, level=loglevel)
+        # Setting up loggers
+        self._log = logger.add_instance_logger(self._name, self, level=loglevel) # instance logger
+        # adding a file handler to the logger
+        if log_file:
+            if not isinstance(log_file, str):
+                log_file = 'log.log'
+            self._log.log_to_file(filename=log_file, level=loglevel)
+
         self._log.debug('Logging set to %s', loglevel)
 
         from ansys.mapdl.core.parameters import Parameters

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -123,7 +123,7 @@ class _MapdlCore(Commands):
     """Contains methods in common between all Mapdl subclasses"""
 
     def __init__(self, loglevel='DEBUG', use_vtk=True, log_apdl=None,
-                log_file=True, local=True, **start_parm):
+                log_file=False, local=True, **start_parm):
         """Initialize connection with MAPDL."""
         self._show_matplotlib_figures = True  # for testing
         self._query = None
@@ -149,7 +149,7 @@ class _MapdlCore(Commands):
         # adding a file handler to the logger
         if log_file:
             if not isinstance(log_file, str):
-                log_file = 'log.log'
+                log_file = 'instance.log'
             self._log.log_to_file(filename=log_file, level=loglevel)
 
         self._log.debug('Logging set to %s', loglevel)

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -229,7 +229,7 @@ class MapdlGrpc(_MapdlCore):
     _port = None
 
     def __init__(self, ip='127.0.0.1', port=None, timeout=15, loglevel='WARNING',
-                log_file=True, cleanup_on_exit=False, log_apdl=None,
+                log_file=False, cleanup_on_exit=False, log_apdl=None,
                 set_no_abort=True, remove_temp_files=False, **kwargs):
         """Initialize connection to the mapdl server"""
         self.__distributed = None


### PR DESCRIPTION
Close #794 by using ``log_file`` keyword argument to add a file handler.