### PR TITLE
Fix MAPDL collection

### DIFF
--- a/ansys/mapdl/core/launcher.py
+++ b/ansys/mapdl/core/launcher.py
@@ -62,6 +62,11 @@ def _is_ubuntu():
     if os.name != "posix":
         return False
 
+    # gcc is installed by default
+    proc = subprocess.Popen("gcc --version", shell=True, stdout=subprocess.PIPE)
+    if 'ubuntu' in proc.stdout.read().decode().lower():
+        return True
+
     # try lsb_release as this is more reliable
     try:
         import lsb_release
@@ -69,6 +74,7 @@ def _is_ubuntu():
         if lsb_release.get_distro_information()["ID"].lower() == "ubuntu":
             return True
     except ImportError:
+        # finally, check platform
         return "ubuntu" in platform.platform().lower()
 
 

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2447,7 +2447,9 @@ class _MapdlCore(Commands):
 
     def __del__(self):  # pragma: no cover
         """Clean up when complete"""
+        self._log.debug("Collecting...")
         if self._cleanup:
+            self._log.debug("Exiting MAPDL on collection.")
             try:
                 self.exit()
             except Exception as e:
@@ -2456,6 +2458,10 @@ class _MapdlCore(Commands):
                         self._log.error("exit: %s", str(e))
                 except Exception:
                     pass
+        else:
+            self._log.debug(
+                "Not exiting MAPDL on collection due to ``cleanup_on_exit=False``"
+            )
 
     @supress_logging
     def get_array(

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2447,9 +2447,8 @@ class _MapdlCore(Commands):
 
     def __del__(self):  # pragma: no cover
         """Clean up when complete"""
-        self._log.debug("Collecting...")
         if self._cleanup:
-            self._log.debug("Exiting MAPDL on collection.")
+            logger.debug("Exiting MAPDL %s on collection.", self._name)
             try:
                 self.exit()
             except Exception as e:
@@ -2459,8 +2458,9 @@ class _MapdlCore(Commands):
                 except Exception:
                     pass
         else:
-            self._log.debug(
-                "Not exiting MAPDL on collection due to ``cleanup_on_exit=False``"
+            logger.debug(
+                "Not exiting MAPDL %s on collection due to ``cleanup_on_exit=False``",
+                self._name
             )
 
     @supress_logging

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2448,7 +2448,6 @@ class _MapdlCore(Commands):
     def __del__(self):  # pragma: no cover
         """Clean up when complete"""
         if self._cleanup:
-            logger.debug("Exiting MAPDL %s on collection.", self._name)
             try:
                 self.exit()
             except Exception as e:
@@ -2457,11 +2456,6 @@ class _MapdlCore(Commands):
                         self._log.error("exit: %s", str(e))
                 except Exception:
                     pass
-        else:
-            logger.debug(
-                "Not exiting MAPDL %s on collection due to ``cleanup_on_exit=False``",
-                self._name
-            )
 
     @supress_logging
     def get_array(

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -126,7 +126,7 @@ def warns_in_cdread_error_log(mapdl):
 
     warns = []
     for each in error_files:
-        with open(os.path.join(mapdl.directory, each)) as fid:
+        with open(os.path.join(mapdl.directory, each), errors='ignore') as fid:
             error_log = ''.join(fid.readlines())
         warns.append((warn_cdread_1 in error_log) or (warn_cdread_2 in error_log) or (warn_cdread_3 in error_log))
         return any(warns)


### PR DESCRIPTION
Resolve #800 by removing the additional reference to the mapdl instance in `ansys/mapdl/core/logging.py`.

@germa89, note that adding `self.extra = extra` created an additional reference to our mapdl instance, which then created a circular reference since our mapdl instance contained a reference to the logger, which contained a reference to the mapdl instance.

Once this is merged, let's plan to push a release.