### PR TITLE
Fix doc build auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # used for documentation deployment
+      - name: Get Bot Application Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
+        with:
+          application_id: ${{ secrets.BOT_APPLICATION_ID }}
+          application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -152,7 +160,6 @@ jobs:
         working-directory: doc
         run: |
           # Overwrite MAPDL commands section so it doesn't show up
-          mv source/mapdl_commands/.fake source/mapdl_commands/index.rst
           make latex
           python validate_png.py  # clean-up GIFs mislabeled as PNG
           cd build/latex
@@ -163,16 +170,17 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: PDF-Documentation
-          path: doc/build/latex/pymapdl.pdf
+          path: doc/build/latex/pymapdl*.pdf
           retention-days: 7
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
-        if: startsWith(github.ref, 'refs/tags/')
+        uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: doc/build/html
+          repository-name: pyansys/pymapdl-docs
+          token: ${{ steps.get_workflow_token.outputs.token }}
+          BRANCH: gh-pages
+          FOLDER: doc/build/html
+          CLEAN: true
 
   build_test:
     name: Build and Unit Testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  PYMAPDL_PORT: 32771  # default won't work on azure
+  PYMAPDL_PORT: 21000  # default won't work on azure
   PYMAPDL_START_INSTANCE: FALSE
   PYANSYS_OFF_SCREEN: True
   DOCKER_PACKAGE: docker.pkg.github.com/pyansys/pymapdl/mapdl
@@ -174,6 +174,7 @@ jobs:
           retention-days: 7
 
       - name: Deploy
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           repository-name: pyansys/pymapdl-docs

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -1,9 +1,18 @@
 name: Nightly Documentation Build
 
+# on:
+#   schedule:  # UTC at 0400
+#     - cron:  '0 4 * * *'
+#   workflow_dispatch:
+
 on:
-  schedule:  # UTC at 0400
-    - cron:  '0 4 * * *'
+  pull_request:
   workflow_dispatch:
+  push:
+    tags:
+      - "*"
+    branches:
+      - main
 
 jobs:
   nightly_docs_build:

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -19,6 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get Bot Application Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -58,7 +65,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           repository-name: pyansys/pymapdl-dev-docs
-          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          token: ${{ steps.get_workflow_token.outputs.token }}
           BRANCH: gh-pages
           FOLDER: doc/build/html
           CLEAN: true

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -1,18 +1,9 @@
 name: Nightly Documentation Build
 
-# on:
-#   schedule:  # UTC at 0400
-#     - cron:  '0 4 * * *'
-#   workflow_dispatch:
-
 on:
-  pull_request:
+  schedule:  # UTC at 0400
+    - cron:  '0 4 * * *'
   workflow_dispatch:
-  push:
-    tags:
-      - "*"
-    branches:
-      - main
 
 jobs:
   nightly_docs_build:
@@ -28,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # used for documentation deployment
       - name: Get Bot Application Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v1
@@ -42,8 +34,8 @@ jobs:
 
       - name: Install OS packages
         run: |
-          sudo apt update
-          sudo apt install libgl1-mesa-glx xvfb
+          sudo apt-get update
+          sudo apt-get install libgl1-mesa-glx xvfb pandoc -qy
 
       - name: Install ansys-mapdl-core
         run: |
@@ -66,7 +58,6 @@ jobs:
   
       - name: Build Documentation
         run: |
-          sudo apt install pandoc -qy
           pip install -r requirements_docs.txt
           xvfb-run make -C doc html
 

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       DISPLAY: ':99.0'
       MAPDL_IMAGE: 'docker.pkg.github.com/pyansys/pymapdl/mapdl:v21.2.1'
-      PYMAPDL_PORT: 32771  # default won't work on azure
+      PYMAPDL_PORT: 21000  # default won't work on azure
       PYMAPDL_START_INSTANCE: FALSE
       PYANSYS_OFF_SCREEN: True
 

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -23,8 +23,8 @@ jobs:
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v1
         with:
-          application_id: ${{ secrets.APPLICATION_ID }}
-          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          application_id: ${{ secrets.BOT_APPLICATION_ID }}
+          application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/nightly-mapdl-check.yml
+++ b/.github/workflows/nightly-mapdl-check.yml
@@ -8,7 +8,7 @@ on:
     - cron:  '0 4 * * *'
 
 env:
-  PYMAPDL_PORT: 32771  # default won't work on azure
+  PYMAPDL_PORT: 21000  # default won't work on azure
   PYMAPDL_START_INSTANCE: FALSE
   PYANSYS_OFF_SCREEN: True
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,3 +1,5 @@
+"""Sphinx documentation configuration file."""
+from datetime import datetime
 import os
 import warnings
 
@@ -36,7 +38,7 @@ warnings.filterwarnings(
 # -- Project information -----------------------------------------------------
 
 project = "ansys.mapdl.core"
-copyright = "(c) 2021 ANSYS, Inc. All rights reserved"
+copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS Inc."
 
 # The short X.Y version

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,5 +1,5 @@
-PyMAPDL Documentation
-=====================
+PyMAPDL Documentation |version|
+===============================
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Authorize using an application rather than a GH PAT.

This fixes #797, and also makes it possible to automate our release of documentation for [PyMAPDL Documentation](https://mapdldocs.pyansys.com/) to https://github.com/pyansys/pymapdl-docs.

Misc Changes
- Use port 21000 for MAPDL docker container due instability with 32771. Should the port keep breaking, we're going to implement an open port ID tool.
- Fix PDF documentation artifact upload.
- Dynamic date for copyright and version in the documentation.