### PR TITLE
fix release doc build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,16 @@ jobs:
           path: doc/build/html/PyMAPDL_documentation.zip
           retention-days: 7
 
+      - name: Deploy
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          repository-name: pyansys/pymapdl-docs
+          token: ${{ steps.get_workflow_token.outputs.token }}
+          BRANCH: gh-pages
+          FOLDER: doc/build/html
+          CLEAN: true
+
       - name: Build PDF Documentation
         working-directory: doc
         run: |
@@ -172,16 +182,6 @@ jobs:
           name: PDF-Documentation
           path: doc/build/latex/pymapdl*.pdf
           retention-days: 7
-
-      - name: Deploy
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-        uses: JamesIves/github-pages-deploy-action@4.1.4
-        with:
-          repository-name: pyansys/pymapdl-docs
-          token: ${{ steps.get_workflow_token.outputs.token }}
-          BRANCH: gh-pages
-          FOLDER: doc/build/html
-          CLEAN: true
 
   build_test:
     name: Build and Unit Testing

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -30,3 +30,16 @@ clean-except-examples:
 	rm -rf $(BUILDDIR)/*
 	rm -rf images/auto-generated
 	find . -type d -name "_autosummary" -exec rm -rf {} +
+
+# manually deploy to https://github.com/pyansys/pymapdl-docs
+# WARNING: Use with care as this overwrites history of gh-pages
+deploy:
+	touch build/html/.nojekyll
+	echo "mapdldocs.pyansys.com" >> build/html/CNAME
+	cd build/html && git init
+	cd build/html && git add .
+	cd build/html && git checkout -b gh-pages
+	cd build/html && git commit -am "manual build"
+	cd build/html && git remote add origin https://github.com/pyansys/pymapdl-docs
+	cd build/html && git push -u origin gh-pages --force
+	rm -rf build/html/.git

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -35,10 +35,10 @@ clean-except-examples:
 # WARNING: Use with care as this overwrites history of gh-pages
 deploy: 
 	@echo "*** Warning ***"
-        @echo "You are about to deploy to 'PyMAPDL docs'."
-        @echo "This overwrites the history of gh-pages."
-        @echo "Are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
-        @echo "Deploying..."
+	@echo "You are about to deploy to 'PyMAPDL docs'."
+	@echo "This overwrites the history of gh-pages."
+	@echo "Are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
+	@echo "Deploying..."
 	touch build/html/.nojekyll
 	echo "mapdldocs.pyansys.com" >> build/html/CNAME
 	cd build/html && git init

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,7 +33,12 @@ clean-except-examples:
 
 # manually deploy to https://github.com/pyansys/pymapdl-docs
 # WARNING: Use with care as this overwrites history of gh-pages
-deploy:
+deploy: 
+	@echo "*** Warning ***"
+        @echo "You are about to deploy to 'PyMAPDL docs'."
+        @echo "This overwrites the history of gh-pages."
+        @echo "Are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
+        @echo "Deploying..."
 	touch build/html/.nojekyll
 	echo "mapdldocs.pyansys.com" >> build/html/CNAME
 	cd build/html && git init


### PR DESCRIPTION
Release documentation build for v0.60.4 broken. This PR should fixs it by moving the PDF build step after the initial html build step.﻿

Additionally, this adds a manual upload step to overwrite broken release docs. Usage is `make -C doc html deploy`

