### PR TITLE
Add parsing to the mapdl.ndist to get the list of coordinates

### DIFF
--- a/ansys/mapdl/core/_commands/parse.py
+++ b/ansys/mapdl/core/_commands/parse.py
@@ -99,3 +99,10 @@ def parse_output_volume_area(msg):
         res = re.search(r"OUTPUT (AREA|VOLUME|AREAS) =\s*([0-9]+)", msg)
         if res is not None:
             return int(res.group(2))
+
+
+def parse_ndist(msg):
+    """Parse the node value from a node message"""
+    finds = re.findall(NUM_PATTERN, msg)[-3:]
+    if len(finds) == 3:
+        return [float(val) for val in finds]

--- a/ansys/mapdl/core/_commands/preproc/nodes.py
+++ b/ansys/mapdl/core/_commands/preproc/nodes.py
@@ -404,9 +404,24 @@ class Nodes:
         functions and display the value on your model.
 
         This command is valid in any processor.
+
+        Returns
+        -------
+        list
+            ``[X, Y, Z]`` distance between two nodes.
+        Examples
+        --------
+        Compute the distance between two nodes.
+        >>> node1 = (0, 8, -3)
+        >>> node1 = (13, 5, 7)
+        >>> node_num0 = mapdl.n("", *kp0)
+        >>> node_num1 = mapdl.n("", *kp1)
+        >>> node_dist = mapdl.ndist(node_num0, node_num1)
+        >>> node_dist
+        [13.0, -3.0, 10.0]
         """
-        command = f"NDIST,{nd1},{nd2}"
-        return self.run(command, **kwargs)
+
+        return parse.parse_ndist(self.run(f"NDIST,{nd1},{nd2}", **kwargs))
 
     def ngen(
         self,


### PR DESCRIPTION
**Modification of the `mapdl.ndist` to get directly list of [X, Y, Z]-coordinates instead of the string output.**

It will be the same idea as we are using for `mapli.kdist`:[https://github.com/pyansys/pymapdl/blob/d8c70c26c7dd973ca12611ba76aed56dbe052650/ansys/mapdl/core/_commands/preproc/keypoints.py#L198-L238](url)

where the parsing part for `mapli.kdist` is located:
[https://github.com/pyansys/pymapdl/blob/d8c70c26c7dd973ca12611ba76aed56dbe052650/ansys/mapdl/core/_commands/parse.py#L21-L25](url)

