### PR TITLE
Fix the PyVista deprecation warnings

### DIFF
--- a/tests/test_pyvista_warning.py
+++ b/tests/test_pyvista_warning.py
@@ -2,7 +2,6 @@
 # Check the Warning with PyVista
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   Examples -> 02-geometry -> 02-areas.py
-import numpy as np
 from ansys.mapdl.core import launch_mapdl
 
 # start MAPDL and enter the pre-processing routine

--- a/tests/test_pyvista_warning.py
+++ b/tests/test_pyvista_warning.py
@@ -1,0 +1,26 @@
+###############################################################################
+# Check the Warning with PyVista
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   Examples -> 02-geometry -> 02-areas.py
+import numpy as np
+from ansys.mapdl.core import launch_mapdl
+
+# start MAPDL and enter the pre-processing routine
+mapdl = launch_mapdl()
+mapdl.clear()
+mapdl.prep7()
+print(mapdl)
+
+
+###############################################################################
+# APDL Command: A
+# ~~~~~~~~~~~~~~~
+# Create a simple triangle in the XY plane using three keypoints.
+
+k0 = mapdl.k("", 0, 0, 0)
+k1 = mapdl.k("", 1, 0, 0)
+k2 = mapdl.k("", 0, 1, 0)
+a0 = mapdl.a(k0, k1, k2)
+
+# Plot areas.
+mapdl.aplot(show_lines=True, line_width=5, show_bounds=True, cpos="xy")

--- a/tests/test_pyvista_warning.py
+++ b/tests/test_pyvista_warning.py
@@ -2,6 +2,7 @@
 # Check the Warning with PyVista
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   Examples -> 02-geometry -> 02-areas.py
+
 from ansys.mapdl.core import launch_mapdl
 
 # start MAPDL and enter the pre-processing routine


### PR DESCRIPTION
Fix warnings after plotting of the areas, elements, nodes, etc.:

...\pymapdl\venv\lib\site-packages\pyvista\core\dataset.py:1192: PyvistaDeprecationWarning: Use of `point_arrays` is deprecated. Use `point_data` instead.
  warnings.warn(
  
...\pymapdl\venv\lib\site-packages\pyvista\core\dataset.py:1332: PyvistaDeprecationWarning: Use of `cell_arrays` is deprecated. Use `cell_data` instead.
  warnings.warn(
  
  