### PR TITLE
Fix docker readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -44,9 +44,9 @@ MAPDL with:
 ```
 !/bin/bash
 LICENSE_SERVER=1055@XXX.XXX.XXX.XXX
-VERSION=v21.1.0
+VERSION=v21.2.0
 
-IMAGE=docker.pkg.github.com/pyansys/pymapdl/mapdl:$VERSION
+IMAGE=ghcr.io/pyansys/pymapdl/mapdl:$VERSION
 docker run -e ANSYSLMD_LICENSE_FILE=$LICENSE_SERVER -p 50052:50052 $IMAGE
 ```
 
@@ -54,8 +54,8 @@ Note that if you use elastic licencing, input your elastic licencing
 credentials with:
 ```
 ANSYS_ELASTIC_CLS=<CLSID>:<PIN>
-VERSION=v21.1.0
-IMAGE=docker.pkg.github.com/pyansys/pymapdl/mapdl:$VERSION
+VERSION=v21.2.0
+IMAGE=ghcr.io/pyansys/pymapdl/mapdl:$VERSION
 docker run -e ANSYS_ELASTIC_CLS=$ANSYS_ELASTIC_CLS -p 50052:50052 $IMAGE
 ```
 
@@ -120,7 +120,7 @@ See the main [README.md](https://github.com/pyansys/mapdl/blob/master/README.md)
 In the command:
 
 ```
-IMAGE=docker.pkg.github.com/pyansys/mapdl/mapdl_grpc:$VERSION
+IMAGE=ghcr.io/pyansys/pymapdl/mapdl:$VERSION
 docker run -e ANSYSLMD_LICENSE_FILE=$LICENSE_SERVER -p 50052:50052 $IMAGE -smp
 ```
 
@@ -136,7 +136,7 @@ number of processors (up to the number available on the host machine)
 with the `-np` switch.  For example:
 
 ```
-IMAGE=docker.pkg.github.com/pyansys/mapdl/mapdl_grpc:$VERSION
+IMAGE=ghcr.io/pyansys/pymapdl/mapdl:$VERSION
 docker run -e ANSYSLMD_LICENSE_FILE=$LICENSE_SERVER -p 50052:50052 $IMAGE -smp -np 4
 ```
 


### PR DESCRIPTION
Docker has migrated to the container registry, see [Migrating to the Container registry from the Docker registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry). This PR updates the docs accordingly.