### PR TITLE
make jupyter.py compatible for upstream ansys-jupyterhub-manager

### DIFF
--- a/ansys/mapdl/core/__init__.py
+++ b/ansys/mapdl/core/__init__.py
@@ -42,3 +42,8 @@ try:
 
 except:  # pragma: no cover
     pass
+
+
+# override default launcher when on pyansys.com
+if 'ANSJUPHUB_VER' in os.environ:
+    from ansys.mapdl.core.jupyter import launch_mapdl_on_cluster as launch_mapdl

--- a/ansys/mapdl/core/jupyter.py
+++ b/ansys/mapdl/core/jupyter.py
@@ -118,7 +118,7 @@ def launch_mapdl_on_cluster(
 
     if "-smp" in additional_switches:
         raise ValueError(
-            'Ignoring additional switch "-smp".  Incompatible with docker container.'
+            'The additional switch "-smp" is incompatible with docker containers.'
         )
 
     additional_switches += f"-m -{memory} -np {nproc}"

--- a/ansys/mapdl/core/jupyter.py
+++ b/ansys/mapdl/core/jupyter.py
@@ -1,12 +1,11 @@
 """Contains methods used only when running on ANSYS's jupyterhub cluster"""
-import warnings
 
 try:
     from ansys.jupyterhub import manager
 except ImportError:
     raise ImportError(
         "Module `ansys-jupyterhub-manager` missing.\n"
-        "This module is required to spawn instances on jupyterhub"
+        "This library is required to spawn instances on pyansys.com"
     )
 
 
@@ -30,13 +29,14 @@ def check_manager():
 
 
 def launch_mapdl_on_cluster(
-    nproc=2,
-    memory=4,
-    loglevel="INFO",
-    additional_switches="",
-    verbose=True,
-    start_timeout=600,
-    **kwargs,
+        nproc=2,
+        memory=4,
+        loglevel="ERROR",
+        additional_switches="",
+        verbose=False,
+        start_timeout=600,
+        tag="latest",
+        **kwargs,
 ):
     """Start MAPDL on the ANSYS jupyter cluster in gRPC mode.
 
@@ -44,35 +44,35 @@ def launch_mapdl_on_cluster(
     ----------
     nproc : int, optional
         Number of processors.  Defaults to 2.
-
     memory : float, optional
         Fixed amount of memory to request for MAPDL in Gigabytes.  If
         the mapdl instance requires more ram than your provide MAPDL
         may segfault.
-
     loglevel : str, optional
         Sets which messages are printed to the console.  Default
-        'INFO' prints out all ANSYS messages, 'WARNING` prints only
-        messages containing ANSYS warnings, and 'ERROR' prints only
+        ``'INFO'`` logs out all MAPDL messages, ``'WARNING``` prints only
+        messages containing MAPDL warnings, and ``'ERROR'`` prints only
         error messages.
-
     additional_switches : str, optional
-        Additional switches for MAPDL, for example aa_r, and academic
-        research license, would be added with:
+        Additional switches for MAPDL, for example ``"-p aa_r"``, the
+        academic research license, would be added with:
 
-        - ``additional_switches="-aa_r"``
+        - ``additional_switches="-p aa_r"``
 
-        Avoid adding switches like -i -o or -b as these are already
-        included to start up the MAPDL server.  See the notes
-        section for additional details.
-
+        Avoid adding switches like ``"-i"`` ``"-o"`` or ``"-b"`` as
+        these are already included to start up the MAPDL server.  See
+        the notes section for additional details.
     start_timeout : float, optional
         Maximum allowable time to connect to the MAPDL server.
+    tag : str, optional
+        Docker image tag from `PyAnsys MAPDL Image
+        <https://github.com/orgs/pyansys/packages/container/package/pymapdl%2Fmapdl>`. Defaults
+        to ``"latest"``. For example "v22.1.0".
 
     Returns
     -------
-    port : int
-        Returns the port number that the gRPC instance started on.
+    MapdlGrpc
+        MAPDL instance.
 
     Examples
     --------
@@ -80,6 +80,11 @@ def launch_mapdl_on_cluster(
 
     >>> from ansys.mapdl import launch_mapdl
     >>> mapdl = launch_mapdl()
+
+    Launch MAPDL and guarantee 16 GB minimum RAM and 8 CPUs.
+
+    >>> mapdl = launch_mapdl(memory=16, nproc=8)
+
     """
     # attempt to connect to the remote scheduler
     check_manager()
@@ -88,53 +93,38 @@ def launch_mapdl_on_cluster(
     if "-m " in additional_switches:
         raise ValueError(
             'Memory option "-m" not permitted when launching from the '
-            "kubernetes cluster and is set with the `memory` parameter"
+            "kubernetes cluster and is set with the ``memory`` parameter"
         )
     if "-np " in additional_switches:
         raise ValueError(
             'CPU option "-np" not permitted when launching from the '
-            "kubernetes cluster and is set with the `nproc` parameter"
+            "kubernetes cluster and is set with the ``nproc`` parameter"
         )
 
     # check resources
     nproc = int(nproc)
     if nproc < 0:
-        raise ValueError("Requested CPUs `nproc` must be greater than 0")
+        raise ValueError("Requested CPUs ``nproc`` must be greater than 0")
     if nproc > MAX_CPU:
-        raise ValueError(f"Requested CPUs `nproc` must be less than {MAX_CPU}")
+        raise ValueError(f"Requested CPUs ``nproc`` must be less than {MAX_CPU}")
 
     if memory < 0.25:
-        raise ValueError("Requested memory `mem` must be greater than 0.25")
+        raise ValueError("Requested memory ``mem`` must be greater than 0.25")
     if memory > MAX_MEM:
-        raise ValueError(f"Requested memory `mem` must be less than than {MAX_MEM}")
+        raise ValueError(f"Requested memory ``mem`` must be less than than {MAX_MEM}")
 
-    # convert memory from GB to Mi
+    # # convert memory from GB to Mi
     memory *= 1024
-    if "-smp" in additional_switches:
-        warnings.warn(
-            'Ignoring additional switch "-smp".  Incompatible with docker ' "container."
-        )
-        additional_switches = additional_switches.replace("-smp", "")
-    additional_switches += f"-m -{memory} -np {nproc}"
 
-    # need a way of making the image user-selectable
-    image = "mapdlhelm.azurecr.io/mapdl:v22.0.0"
-    command = (
-        'printf "" | /ansys_inc/v202/ansys/bin/mapdl %s -smp -grpc -custom /ansys_inc/v202/grpc/ansys.e201t.DEBUG-0.53.1'
-        % additional_switches
-    )
-    env = {"ANSYSLMD_LICENSE_FILE": "1055@10.0.0.16"}
-    ip, pod_name = manager.spawn_pod(
-        image,
-        env=env,
-        cpu=1000 * nproc,
-        memory=memory,
-        command=command,
-        start_timeout=start_timeout,
-        verbose=verbose,
-    )
+    if "-smp" in additional_switches:
+        raise ValueError(
+            'Ignoring additional switch "-smp".  Incompatible with docker container.'
+        )
+
+    additional_switches += f"-m -{memory} -np {nproc}"
+    args = additional_switches.split()
+    ip, name = manager.spawn_mapdl(version=tag, args=args, verbose=verbose)
 
     # connect to the pod instance
-    from ansys.mapdl import Mapdl  # import here to avoid recursive
-
+    from ansys.mapdl.core import Mapdl
     return Mapdl(ip, loglevel=loglevel)


### PR DESCRIPTION
Modify `jupyter.py` to work with changes from `ansys-jupyterhub-manager`. Specifically, assembly and execution of the spawning of MAPDL is offloaded and resonsibility is limited to instantiating MAPDL.
