### PR TITLE
Fixing BC parsing issue

### DIFF
--- a/ansys/mapdl/core/commands.py
+++ b/ansys/mapdl/core/commands.py
@@ -661,7 +661,7 @@ class BoundaryConditionsListingOutput(CommandListingOutput):
             if line:
                 items = BC_REGREP.findall(line)
                 if items:
-                    parsed_lines.append(items)
+                    parsed_lines.append(list(items[0]))
 
         return parsed_lines
 


### PR DESCRIPTION
### Objective
Fix conversion to dataframe issue by making sure a correct parsing in `to_list()` method.

### Current situation:
`to_dataframe()` method in `BCListingOutputCommand` is broken because of a bad format output in `to_list`.

**Current to list**
```python:
>>> outlist = out.to_list()
[[[(...)]],[[(...)]],...]
>>> outlist[0]
[('1', 'UX', '0.00000000', '0.00000000')]
```
The tuple is unnecessary.

### Procedure
Basically:

If we use `findall` in a line, we should retrieve the first item if exist:
```python
    def _parse_table(self):
        """Parse tabular command output."""
        parsed_lines = []
        for line in self.splitlines():
            # exclude any line containing characters [A-Z] except for E
            if line:
                items = BC_REGREP.findall(line)
                if items:
                    parsed_lines.append(list(items[0]))  #Here!
```

Also, this problem was not caught by CI/CD because at the moment pandas is optional library and because of that, we do not check methods which requires pandas.
Although this is a format issue in `to_list`, it was flagged up when calling `to_dataframe` which requires a simple list format.

## Notes

If we are starting to include pandas, we should probably include it in the requirements and test against it, even if our dependency on it is minimum.