### PR TITLE
only run latest validation nightly

### DIFF
--- a/.github/workflows/nightly-mapdl-check.yml
+++ b/.github/workflows/nightly-mapdl-check.yml
@@ -1,8 +1,6 @@
 name: GitHub Actions
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
   schedule:  # UTC at 0400
     - cron:  '0 4 * * *'


### PR DESCRIPTION
Do not run on push and PR as latest image may be invalid.

Resolves #851.