### PR TITLE
Fixing ``CWD`` and failing tests

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -448,7 +448,7 @@ class _MapdlCore(Commands):
             self._parent()._store_commands = True
 
         def __exit__(self, *args):
-            self._parent()._log.debug("Entering non-interactive mode")
+            self._parent()._log.debug("Exiting non-interactive mode")
             self._parent()._flush_stored()
 
     class _chain_commands:
@@ -2747,7 +2747,8 @@ class _MapdlCore(Commands):
         """Wraps cwd"""
         returns_ = super().cwd( *args, **kwargs)
 
-        if '*** WARNING ***' in self._response:
-            warn('\n' + self._response)
+        if returns_: # if sucessfull, it should be none.
+            if '*** WARNING ***' in self._response:
+                warn('\n' + self._response)
 
         return returns_

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -2747,7 +2747,7 @@ class _MapdlCore(Commands):
         """Wraps cwd"""
         returns_ = super().cwd( *args, **kwargs)
 
-        if returns_: # if sucessfull, it should be none.
+        if returns_: # if successful, it should be none.
             if '*** WARNING ***' in self._response:
                 warn('\n' + self._response)
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -825,7 +825,6 @@ def test_cdread(mapdl, cleared):
     assert random_letters in mapdl.parameters['PARMTEST']
 
 
-# CDREAD tests are actually a good way to test 'input' command.
 @skip_in_cloud
 def test_cdread_different_location(mapdl, cleared, tmpdir):
     random_letters = mapdl.directory.split('/')[0][-3:0]
@@ -948,25 +947,22 @@ def test_inval_commands_silent(mapdl, tmpdir, cleared):
 @skip_in_cloud
 def test_path_without_spaces(mapdl, path_tests):
     resp = mapdl.cwd(path_tests.path_without_spaces)
-    assert 'WARNING' not in resp
+    assert resp is None
 
 
 @skip_in_cloud
 def test_path_with_spaces(mapdl, path_tests):
     resp = mapdl.cwd(path_tests.path_with_spaces)
-    assert 'WARNING' not in resp
+    assert resp is None
 
 
 @skip_in_cloud
 def test_path_with_single_quote(mapdl, path_tests):
     with pytest.raises(RuntimeError):
         resp = mapdl.cwd(path_tests.path_with_single_quote)
-        assert 'WARNING' not in resp
-
 
 @skip_in_cloud
 def test_cwd_directory(mapdl, tmpdir):
-
     mapdl.directory = str(tmpdir)
     assert mapdl.directory == str(tmpdir).replace('\\', '/')
 


### PR DESCRIPTION
The PR #840 broke this. 

This was not catch by CICD because those test do not run on CICD. Not sure why. 