### PR TITLE
Improve the "Getting Started" documentation section.

### DIFF
--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -45,7 +45,7 @@ automatically connect to it:
 This is the easiest and fastest way to get PyMAPDL up and running. 
 But you need to have an ANSYS license server installed locally. 
 
-Lunching a gRPC MAPDL session
+Launching a gRPC MAPDL session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can start MAPDL from the command line and then connect to it.
 To launch MAPDL on Windows (assuming a ``C:/Program Files/ANSYS Inc/v211`` installation) use:


### PR DESCRIPTION
Fix a typo in one of the title in "Getting Started" documentation section.