### PR TITLE
Return camera position is optional in general plotter

### DIFF
--- a/ansys/mapdl/core/plotting.py
+++ b/ansys/mapdl/core/plotting.py
@@ -43,6 +43,7 @@ def general_plotter(
     text_color=None,
     theme=None,
     return_plotter=False,
+    return_cpos = False
 ):
     """General pymapdl plotter for APDL geometry and meshes.
 
@@ -158,6 +159,9 @@ def general_plotter(
         Return the plotting object rather than showing the plot and
         returning the camera position.  Default ``False``.
 
+    return_cpos : bool, optional
+        Returns the camera position as an array. Default ``False``.
+
     Returns
     -------
     cpos or pyvista.Plotter
@@ -268,6 +272,20 @@ def general_plotter(
     if title:
         pl.add_title(title)
 
+    returns_parameter = []
+    if return_plotter:
+        returns_parameter.append(pl)
+    if return_cpos:
+        returns_parameter.append(pl.camera_position)
+
+    if not returns_parameter:
+        returns_parameter = None
+    else:
+        if len(returns_parameter) == 1:
+            returns_parameter = returns_parameter[0]
+        else:
+            returns_parameter = tuple(returns_parameter)
+
     # permit user to save the figure as a screenshot
     if savefig:
         pl.show(title=title, auto_close=False, window_size=window_size, screenshot=True)
@@ -275,14 +293,14 @@ def general_plotter(
 
         # return unclosed plotter
         if return_plotter:
-            return pl
+            return returns_parameter
 
         # if not returning plotter, close right away
         pl.close()
 
     elif return_plotter:
-        return pl
+        return returns_parameter
     else:
         pl.show()
 
-    return pl.camera_position
+    return returns_parameter

--- a/ansys/mapdl/core/plotting.py
+++ b/ansys/mapdl/core/plotting.py
@@ -43,7 +43,7 @@ def general_plotter(
     text_color=None,
     theme=None,
     return_plotter=False,
-    return_cpos = False
+    return_cpos=False,
 ):
     """General pymapdl plotter for APDL geometry and meshes.
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -214,7 +214,7 @@ def test_kplot(cleared, mapdl_console, tmpdir):
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl_console.kplot(savefig=filename)
-    assert isinstance(cpos, CameraPosition)
+    assert cpos is None
     assert os.path.isfile(filename)
 
     mapdl_console.kplot(knum=True, vtk=False)  # make sure legacy still works
@@ -298,7 +298,7 @@ def test_lplot(cleared, mapdl_console, tmpdir):
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl_console.lplot(show_keypoint_numbering=True, savefig=filename)
-    assert isinstance(cpos, CameraPosition)
+    assert cpos is None
     assert os.path.isfile(filename)
 
     mapdl_console.lplot(vtk=False)  # make sure legacy still works

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -13,7 +13,6 @@ from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core.errors import MapdlRuntimeError
 from ansys.mapdl.reader import examples
 from pyvista.plotting import system_supports_plotting
-from pyvista.plotting.renderer import CameraPosition
 
 skip_no_xserver = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires active X Server"

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -209,7 +209,7 @@ def test_kplot(cleared, mapdl_corba, tmpdir):
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl_corba.kplot(savefig=filename)
-    assert isinstance(cpos, CameraPosition)
+    assert cpos is None
     assert os.path.isfile(filename)
 
     mapdl_corba.kplot(knum=True, vtk=False)  # make sure legacy still works
@@ -292,7 +292,7 @@ def test_lplot(cleared, mapdl_corba, tmpdir):
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl_corba.lplot(show_keypoint_numbering=True, savefig=filename)
-    assert isinstance(cpos, CameraPosition)
+    assert cpos is None
     assert os.path.isfile(filename)
 
     mapdl_corba.lplot(vtk=False)  # make sure legacy still works

--- a/tests/test_corba.py
+++ b/tests/test_corba.py
@@ -13,7 +13,6 @@ from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core.errors import MapdlRuntimeError
 from ansys.mapdl.reader import examples
 from pyvista.plotting import system_supports_plotting
-from pyvista.plotting.renderer import CameraPosition
 
 skip_no_xserver = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires active X Server"

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -10,7 +10,6 @@ from ansys.mapdl.core.misc import random_string
 from ansys.mapdl.reader import examples
 from pyvista import PolyData
 from pyvista.plotting import system_supports_plotting
-from pyvista.plotting.renderer import CameraPosition
 
 from ansys.mapdl.core.launcher import get_start_instance, launch_mapdl
 
@@ -335,7 +334,7 @@ def test_kplot(cleared, mapdl, tmpdir):
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl.kplot(savefig=filename)
-    assert isinstance(cpos, CameraPosition)
+    assert cpos is None
     assert os.path.isfile(filename)
 
     mapdl.kplot(vtk=False)  # make sure legacy still works
@@ -416,7 +415,7 @@ def test_lplot(cleared, mapdl, tmpdir):
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl.lplot(show_keypoint_numbering=True, savefig=filename)
-    assert isinstance(cpos, CameraPosition)
+    assert cpos is None
     assert os.path.isfile(filename)
 
     mapdl.lplot(vtk=False)  # make sure legacy still works
@@ -442,7 +441,7 @@ def test_apdl_logging_start(tmpdir):
         text = ''.join(fid.readlines())
 
     assert 'PREP7' in text
-    assert '!comment test'
+    assert '!comment test' in text
     assert 'K,1,0,0,0' in text
     assert 'K,2,1,0,0' in text
     assert 'K,3,1,1,0' in text
@@ -469,7 +468,7 @@ def test_corba_apdl_logging_start(tmpdir):
         text = ''.join(fid.readlines())
 
     assert 'PREP7' in text
-    assert '!comment test'
+    assert '!comment test' in text
     assert 'K,1,0,0,0' in text
     assert 'K,2,1,0,0' in text
     assert 'K,3,1,1,0' in text

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from pyvista.plotting.renderer import CameraPosition
+from pyvista import Plotter
 
 from ansys.mapdl.core.post import (
     COMPONENT_STRESS_TYPE, PRINCIPAL_TYPE, STRESS_TYPES
@@ -451,17 +452,15 @@ def test_disp_norm_all(mapdl, static_solve):
 
 @pytest.mark.parametrize("comp", ["X", "Y", "z", "norm"])  # lowercase intentional
 def test_disp_plot(mapdl, static_solve, comp):
-    cpos = mapdl.post_processing.plot_nodal_displacement(comp, smooth_shading=True)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_displacement(comp, smooth_shading=True) is None
 
 
 def test_disp_plot_subselection(mapdl, static_solve):
     mapdl.nsel("S", "NODE", vmin=500, vmax=2000, mute=True)
     mapdl.esel("S", "ELEM", vmin=500, vmax=2000, mute=True)
-    cpos = mapdl.post_processing.plot_nodal_displacement(
+    assert mapdl.post_processing.plot_nodal_displacement(
         "X", smooth_shading=True, show_node_numbering=True
-    )
-    assert isinstance(cpos, CameraPosition)
+    ) is None
     mapdl.allsel()
 
 
@@ -480,8 +479,7 @@ def test_nodal_eqv_stress(mapdl, static_solve):
 
 
 def test_plot_nodal_eqv_stress(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_eqv_stress(smooth_shading=True)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_eqv_stress(smooth_shading=True) is None
 
 
 def test_node_selection(mapdl, static_solve):
@@ -518,8 +516,7 @@ def test_rot(mapdl, static_solve, comp):
 
 @pytest.mark.parametrize("comp", ["X", "Y", "z"])  # lowercase intentional
 def test_plot_rot(mapdl, static_solve, comp):
-    cpos = mapdl.post_processing.plot_nodal_rotation(comp)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_rotation(comp) is None
 
 
 # TODO: add valid result
@@ -538,13 +535,11 @@ def test_element_temperature(mapdl, static_solve):
 
 def test_plot_element_temperature(mapdl, static_solve):
     mapdl.set(1, 1, mute=True)
-    cpos = mapdl.post_processing.plot_element_temperature()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_element_temperature() is None
 
 
 def test_plot_temperature(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_temperature()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_temperature() is None
 
 
 # TODO: add valid result
@@ -554,8 +549,7 @@ def test_pressure(mapdl, static_solve):
 
 
 def test_plot_pressure(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_pressure()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_pressure() is None
 
 
 # TODO: add valid result
@@ -565,8 +559,7 @@ def test_voltage(mapdl, static_solve):
 
 
 def test_plot_voltage(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_voltage()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_voltage() is None
 
 
 @pytest.mark.parametrize("comp", COMPONENT_STRESS_TYPE)
@@ -587,8 +580,7 @@ def test_nodal_component_stress(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_component_stress(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_component_stress("X")
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_component_stress("X") is None
 
 
 @pytest.mark.parametrize("comp", PRINCIPAL_TYPE)
@@ -609,8 +601,7 @@ def test_nodal_principal_stress(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_principal_stress(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_principal_stress(1)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_principal_stress(1) is None
 
 
 def test_nodal_stress_intensity(mapdl, static_solve):
@@ -628,8 +619,7 @@ def test_nodal_stress_intensity(mapdl, static_solve):
 
 
 def test_plot_nodal_stress_intensity(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_stress_intensity()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_stress_intensity() is None
 
 
 @pytest.mark.parametrize("comp", COMPONENT_STRESS_TYPE)
@@ -650,8 +640,7 @@ def test_nodal_total_component_strain(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_total_component_strain(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_total_component_strain("x")
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_total_component_strain("x") is None
 
 
 @pytest.mark.parametrize("comp", PRINCIPAL_TYPE)
@@ -672,8 +661,7 @@ def test_nodal_principal_total_strain(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_principal_total_strain(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_total_principal_strain(1)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_total_principal_strain(1) is None
 
 
 def test_nodal_total_strain_intensity(mapdl, static_solve):
@@ -691,8 +679,7 @@ def test_nodal_total_strain_intensity(mapdl, static_solve):
 
 
 def test_plot_nodal_total_strain_intensity(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_total_strain_intensity()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_total_strain_intensity() is None
 
 
 def test_nodal_total_eqv_strain(mapdl, static_solve):
@@ -710,8 +697,7 @@ def test_nodal_total_eqv_strain(mapdl, static_solve):
 
 
 def test_plot_nodal_total_eqv_strain(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_total_eqv_strain(smooth_shading=True)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_total_eqv_strain(smooth_shading=True) is None
 
 
 ###############################################################################
@@ -733,8 +719,7 @@ def test_nodal_component_stress(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_component_stress(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_component_stress("X")
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_component_stress("X") is None
 
 
 @pytest.mark.parametrize("comp", PRINCIPAL_TYPE)
@@ -754,8 +739,7 @@ def test_nodal_principal_stress(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_principal_stress(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_principal_stress(1)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_principal_stress(1) is None
 
 
 def test_nodal_stress_intensity(mapdl, static_solve):
@@ -773,8 +757,7 @@ def test_nodal_stress_intensity(mapdl, static_solve):
 
 
 def test_plot_nodal_stress_intensity(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_stress_intensity()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_stress_intensity() is None
 
 
 @pytest.mark.parametrize("comp", COMPONENT_STRESS_TYPE)
@@ -795,8 +778,7 @@ def test_nodal_elastic_component_strain(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_elastic_component_strain(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_elastic_component_strain("x")
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_elastic_component_strain("x") is None
 
 
 @pytest.mark.parametrize("comp", PRINCIPAL_TYPE)
@@ -817,8 +799,7 @@ def test_nodal_elastic_principal_strain(mapdl, static_solve, comp):
 
 
 def test_plot_nodal_elastic_principal_strain(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_elastic_principal_strain(1)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_elastic_principal_strain(1) is None
 
 
 def test_nodal_elastic_strain_intensity(mapdl, static_solve):
@@ -836,8 +817,7 @@ def test_nodal_elastic_strain_intensity(mapdl, static_solve):
 
 
 def test_plot_nodal_elastic_strain_intensity(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_elastic_strain_intensity()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_elastic_strain_intensity() is None
 
 
 def test_nodal_elastic_eqv_strain(mapdl, static_solve):
@@ -855,8 +835,7 @@ def test_nodal_elastic_eqv_strain(mapdl, static_solve):
 
 
 def test_plot_nodal_elastic_eqv_strain(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_elastic_eqv_strain(smooth_shading=True)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_elastic_eqv_strain(smooth_shading=True) is None
 
 
 @pytest.mark.parametrize("comp", ["X", "Y", "z"])  # lowercase intentional
@@ -907,8 +886,7 @@ def test_elem_disp_norm(mapdl, static_solve):
 def test_elem_disp_plot(mapdl, static_solve, comp):
     mapdl.post1(mute=True)
     mapdl.set(1, 1, mute=True)
-    cpos = mapdl.post_processing.plot_element_displacement(comp)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_element_displacement(comp) is None
 
 
 @pytest.mark.parametrize("component", STRESS_TYPES[::3])
@@ -931,15 +909,13 @@ def test_element_stress(mapdl, static_solve, component, option):
 def test_plot_element_stress(mapdl, static_solve, comp):
     mapdl.post1(mute=True)
     mapdl.set(1, 1, mute=True)
-    cpos = mapdl.post_processing.plot_element_stress(comp)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_element_stress(comp) is None
 
 
 def test_plot_element_values(mapdl, static_solve):
     mapdl.post1(mute=True)
     mapdl.set(1, 1, mute=True)
-    cpos = mapdl.post_processing.plot_element_values("S", "X")
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_element_values("S", "X") is None
 
 
 ###############################################################################
@@ -961,8 +937,7 @@ def test_nodal_plastic_component_strain(mapdl, plastic_solve, comp):
 
 
 def test_plot_nodal_plastic_component_strain(mapdl, plastic_solve):
-    cpos = mapdl.post_processing.plot_nodal_plastic_component_strain("x")
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_plastic_component_strain("x") is None
 
 
 @pytest.mark.parametrize("comp", PRINCIPAL_TYPE)
@@ -982,8 +957,7 @@ def test_nodal_plastic_principal_strain(mapdl, plastic_solve, comp):
 
 
 def test_plot_nodal_plastic_principal_strain(mapdl, plastic_solve):
-    cpos = mapdl.post_processing.plot_nodal_plastic_principal_strain(1)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_plastic_principal_strain(1) is None
 
 
 def test_nodal_plastic_strain_intensity(mapdl, plastic_solve):
@@ -998,8 +972,7 @@ def test_nodal_plastic_strain_intensity(mapdl, plastic_solve):
 
 
 def test_plot_nodal_plastic_strain_intensity(mapdl, plastic_solve):
-    cpos = mapdl.post_processing.plot_nodal_plastic_strain_intensity()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_plastic_strain_intensity() is None
 
 
 def test_nodal_plastic_eqv_strain(mapdl, plastic_solve):
@@ -1014,8 +987,7 @@ def test_nodal_plastic_eqv_strain(mapdl, plastic_solve):
 
 
 def test_plot_nodal_plastic_eqv_strain(mapdl, plastic_solve):
-    cpos = mapdl.post_processing.plot_nodal_plastic_eqv_strain(smooth_shading=True)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_plastic_eqv_strain(smooth_shading=True) is None
 
 
 def test_nodal_contact_friction_stress(mapdl, contact_solve):
@@ -1038,20 +1010,27 @@ def test_nodal_contact_friction_stress(mapdl, contact_solve):
 
 
 def test_plot_nodal_contact_friction_stress(mapdl, contact_solve):
-    cpos = mapdl.post_processing.plot_nodal_contact_friction_stress(smooth_shading=True)
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_nodal_contact_friction_stress(smooth_shading=True) is None
 
 
 def test_plot_incomplete_element_selection(mapdl, contact_solve):
     mapdl.esel('S', 'ELEM', '', 1, mapdl.mesh.n_elem//2)
-    cpos = mapdl.post_processing.plot_element_displacement()
-    assert isinstance(cpos, CameraPosition)
+    assert mapdl.post_processing.plot_element_displacement() is None
 
 
 def test_plot_incomplete_nodal_selection(mapdl, contact_solve):
     mapdl.nsel('S', 'NODE', '', 1, mapdl.mesh.n_node//2)
-    cpos = mapdl.post_processing.plot_nodal_displacement()
+    assert mapdl.post_processing.plot_nodal_displacement() is None
+
+
+def test_general_plotter_returns(mapdl, static_solve):
+    cpos = mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, return_cpos=True)
     assert isinstance(cpos, CameraPosition)
+
+    plotter = mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, return_plotter=True)
+    assert isinstance(plotter, Plotter)
+
+    assert mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True) is None
 
 
 ###############################################################################
@@ -1071,8 +1050,7 @@ def test_plot_incomplete_nodal_selection(mapdl, contact_solve):
 
 
 # def test_plot_nodal_thermal_component_strain(mapdl, thermal_solve):
-#     cpos = mapdl.post_processing.plot_nodal_thermal_component_strain('x')
-#     assert isinstance(cpos, CameraPosition)
+#     assert mapdl.post_processing.plot_nodal_thermal_component_strain('x') is None
 
 
 # @pytest.mark.parametrize('comp', PRINCIPAL_TYPE)
@@ -1092,8 +1070,7 @@ def test_plot_incomplete_nodal_selection(mapdl, contact_solve):
 
 
 # def test_plot_nodal_thermal_principal_strain(mapdl, thermal_solve):
-#     cpos = mapdl.post_processing.plot_nodal_thermal_principal_strain(1)
-#     assert isinstance(cpos, CameraPosition)
+#     assert mapdl.post_processing.plot_nodal_thermal_principal_strain(1) is None
 
 
 # def test_nodal_thermal_strain_intensity(mapdl, thermal_solve):
@@ -1108,8 +1085,7 @@ def test_plot_incomplete_nodal_selection(mapdl, contact_solve):
 
 
 # def test_plot_nodal_thermal_strain_intensity(mapdl, thermal_solve):
-#     cpos = mapdl.post_processing.plot_nodal_thermal_strain_intensity()
-#     assert isinstance(cpos, CameraPosition)
+#     assert mapdl.post_processing.plot_nodal_thermal_strain_intensity() is None
 
 
 # def test_nodal_thermal_eqv_strain(mapdl, thermal_solve):
@@ -1124,7 +1100,6 @@ def test_plot_incomplete_nodal_selection(mapdl, contact_solve):
 
 
 # def test_plot_nodal_thermal_eqv_strain(mapdl, thermal_solve):
-#     cpos = mapdl.post_processing.plot_nodal_thermal_eqv_strain(smooth_shading=True)
-#     assert isinstance(cpos, CameraPosition)
+#     assert mapdl.post_processing.plot_nodal_thermal_eqv_strain(smooth_shading=True) is None
 
 ###############################################################################

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1024,13 +1024,17 @@ def test_plot_incomplete_nodal_selection(mapdl, contact_solve):
 
 
 def test_general_plotter_returns(mapdl, static_solve):
-    cpos = mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, return_cpos=True)
-    assert isinstance(cpos, CameraPosition)
-
-    plotter = mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, return_plotter=True)
-    assert isinstance(plotter, Plotter)
-
+    # Returns
     assert mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True) is None
+    assert isinstance(mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, return_cpos=True), CameraPosition)
+    assert isinstance(mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, return_plotter=True), Plotter)
+    assert isinstance(mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, return_cpos=True, return_plotter=True), tuple)
+
+    # Returns + Save figure.
+    assert mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, savefig=True, return_cpos=False, return_plotter=False) is None
+    assert isinstance(mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, savefig=True, return_cpos=True, return_plotter=False), CameraPosition)
+    assert isinstance(mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, savefig=True, return_cpos=False, return_plotter=True), Plotter)
+    assert isinstance(mapdl.post_processing.plot_nodal_displacement('X', smooth_shading=True, savefig=True, return_cpos=True, return_plotter=True), tuple)
 
 
 ###############################################################################


### PR DESCRIPTION
Close #863 by implementing ``return_cpos`` optional keyword.

I also added the option that if no output is request, it will return ``None``. I think it is more pythonic.
