### PR TITLE
Check printout option before using get

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1804,7 +1804,16 @@ class _MapdlCore(Commands):
         """
         command = f"*GET,{par},{entity},{entnum},{item1},{it1num},{item2},{it2num}"
         kwargs["mute"] = False
+
+        # Checking printout is not suppressed by checking "wrinqr" flag.
+        flag = 0
+        if self.wrinqr(1) != 1: # using wrinqr is more reliable than *get
+            flag = 1
+            self._run("/gopr")
         response = self.run(command, **kwargs)
+        if flag == 1:
+            self._run("/nopr")
+
         value = response.split("=")[-1].strip()
         try:  # always either a float or string
             return float(value)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1045,3 +1045,24 @@ def test_tbft_not_found(mapdl):
         mat_id = mapdl.get_value('MAT', 0, 'NUM', 'MAX') + 1
         mapdl.tbft('FADD', mat_id, 'HYPER', 'MOONEY', '3', mute=True)
         mapdl.tbft('EADD', mat_id, 'UNIA', 'non_existing.file', '', '', mute=True)
+
+
+def test_get_with_gopr(mapdl):
+    """Get should work independently of the /gopr state."""
+
+    mapdl._run("/gopr")
+    assert mapdl.wrinqr(1) == 1
+    par = mapdl.get("__par__", "ACTIVE", "", "TIME", "WALL")
+    assert mapdl.scalar_param('__par__') is not None
+    assert par is not None
+    assert np.allclose(mapdl.scalar_param('__par__'), par)
+
+    mapdl._run("/nopr")
+    assert mapdl.wrinqr(1) == 0
+    par = mapdl.get("__par__", "ACTIVE", "", "TIME", "WALL")
+    assert mapdl.scalar_param('__par__') is not None
+    assert par is not None
+    assert np.allclose(mapdl.scalar_param('__par__'), par)
+
+    mapdl._run("/gopr") # Going back
+    assert mapdl.wrinqr(1) == 1


### PR DESCRIPTION
``*GET`` command gives empty response if we are using it after ``NOPR``, of course this should be the case, everytime we issue a ``NOPR`` we should ensure a ``GOPR`` follows up. However I find difficult to track this in the converter module, hence I'm checking the state of the printout before issuing ``*GET`` command.

We should probably consider to get rid of this old implementation of "*get", by getting the parameter value using grpc API instead of parsing output.
