### PR TITLE
Adding extra argument to ``*get``

### DIFF
--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1723,6 +1723,7 @@ class _MapdlCore(Commands):
         it1num="",
         item2="",
         it2num="",
+        item3="",
         **kwargs,
     ):
         """Retrieves a value and stores it as a scalar parameter or part of an array parameter.
@@ -1796,6 +1797,11 @@ class _MapdlCore(Commands):
             the item for which data are to be retrieved. Most items do
             not require this level of information.
 
+        item3
+            A third set of item labels to further qualify
+            the item for which data are to be retrieved. Almost all items do
+            not require this level of information.
+
         Returns
         -------
         float
@@ -1817,7 +1823,7 @@ class _MapdlCore(Commands):
         3003
 
         """
-        command = f"*GET,{par},{entity},{entnum},{item1},{it1num},{item2},{it2num}"
+        command = f"*GET,{par},{entity},{entnum},{item1},{it1num},{item2},{it2num},{item3}"
         kwargs["mute"] = False
 
         # Checking printout is not suppressed by checking "wrinqr" flag.

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1836,6 +1836,10 @@ class _MapdlCore(Commands):
             self._run("/nopr")
 
         value = response.split("=")[-1].strip()
+        if item3:
+            value = value.splitlines()[0]
+            self._log.info(f"The command '{command}' is showing the next message: '{value.splitlines()[1].strip()}'")
+
         try:  # always either a float or string
             return float(value)
         except ValueError:

--- a/ansys/mapdl/core/mapdl.py
+++ b/ansys/mapdl/core/mapdl.py
@@ -1837,8 +1837,8 @@ class _MapdlCore(Commands):
 
         value = response.split("=")[-1].strip()
         if item3:
-            value = value.splitlines()[0]
             self._log.info(f"The command '{command}' is showing the next message: '{value.splitlines()[1].strip()}'")
+            value = value.splitlines()[0]
 
         try:  # always either a float or string
             return float(value)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1091,3 +1091,7 @@ def test_print_com(mapdl, capfd):
     for each in ['asdf', (1, 2), 2, []]:
         with pytest.raises(ValueError):
             mapdl.print_com = each
+
+
+def test_extra_argument_in_get(mapdl, make_block):
+    assert isinstance(mapdl.get("_MAXNODENUM", "node", 0, "NUM", "MAX", "", "", "INTERNAL"), float)


### PR DESCRIPTION
Surprisingly there is a 7th hidden argument in ``*get``, and as far as I know (I should research it a bit more) it is only for including internal nodes in the ``*get`` calculations.

The following line is totally correct:
```
*get, _MAXNODENUM, node, 0, NUM, MAX,,,INTERNAL
```
However, that ``INTERNAL`` parameter is not documented anywhere, but it is used to output ``ds.dat`` files.

Funny part, it is that previous line will ouput:
```
*GET  _MAXNODENUM  FROM  NODE  ITEM=NUM  MAX   VALUE=  425.000000     \n  (INCLUDE INTERNAL NODES)
```
which our ``mapdl.get`` method will parse to:
```
425.000000     \n  (INCLUDE INTERNAL NODES)
```

Hence I'm making something to crop the rest of the text. Not sure what to do with the ``(INCLUDE INTERNAL NODES)`` part.
I guess if someone is using that undocumented argument, he/she should clever enough to not need a message, but I'm happy to hear suggestions. I'm going to add a message to the log anyway.