### PR TITLE
Linking ``mapdl.print_com`` behavior to ``mapdl.mute``

### DIFF
--- a/ansys/mapdl/core/_commands/session/list_controls.py
+++ b/ansys/mapdl/core/_commands/session/list_controls.py
@@ -27,7 +27,7 @@ class ListControls:
         This command is valid anywhere.
         """
         command = "/COM,%s" % (str(comment))
-        if self.print_com:
+        if self.print_com and not self.mute and not kwargs.get('mute', False):
             print(command)
         return self.run(command, **kwargs)
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1076,16 +1076,38 @@ def test_print_com(mapdl, capfd):
     mapdl.print_com = True
     string_ = "Testing print"
     mapdl.com(string_)
-
     out, err = capfd.readouterr()
     assert string_ in out
 
     mapdl.print_com = False
     string_ = "Testing disabling print"
     mapdl.com(string_)
-
     out, err = capfd.readouterr()
     assert string_ not in out
+
+    mapdl.print_com = True
+    mapdl.mute = True
+    mapdl.com(string_)
+    out, err = capfd.readouterr()
+    assert string_ not in out
+
+    mapdl.print_com = True
+    mapdl.mute = False
+    mapdl.com(string_, mute=True)
+    out, err = capfd.readouterr()
+    assert string_ not in out    
+
+    mapdl.print_com = True
+    mapdl.mute = True
+    mapdl.com(string_, mute=True)
+    out, err = capfd.readouterr()
+    assert string_ not in out
+
+    mapdl.print_com = True
+    mapdl.mute = False
+    mapdl.com(string_, mute=False)
+    out, err = capfd.readouterr()
+    assert string_ in out
 
     # Not allowed type for mapdl.print_com
     for each in ['asdf', (1, 2), 2, []]:

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1095,7 +1095,7 @@ def test_print_com(mapdl, capfd):
     mapdl.mute = False
     mapdl.com(string_, mute=True)
     out, err = capfd.readouterr()
-    assert string_ not in out    
+    assert string_ not in out
 
     mapdl.print_com = True
     mapdl.mute = True


### PR DESCRIPTION
If ``mute`` is activated in any of its ways (using ``kwarg`` or ``mapdl.mute``), the ``/COM`` commands are not printed to python console.