### PR TITLE
Fix ` CDREAD` arguments

### DIFF
--- a/ansys/mapdl/core/_commands/preproc/database.py
+++ b/ansys/mapdl/core/_commands/preproc/database.py
@@ -57,7 +57,7 @@ class Database:
         fname
             File name and directory path (248 characters maximum, including the
             characters needed for the directory path).
-            An unspecified directory path defaults to the working directory; 
+            An unspecified directory path defaults to the working directory;
             in this case, you can use all 248 characters for the file name.
 
         ext

--- a/ansys/mapdl/core/_commands/preproc/database.py
+++ b/ansys/mapdl/core/_commands/preproc/database.py
@@ -30,31 +30,35 @@ class Database:
         option
             Selects which data to read:
 
-            ALL - Read all geometry, material property, load, and
-            component data (default).  Solid model geometry and loads
-            will be read from the file Fnamei.Exti.  All other data
-            will be read from the file Fname.Ext.
+            ALL
+                Read all geometry, material property, load, and
+                component data (default).  Solid model geometry and loads
+                will be read from the file ``Fnamei.Exti``.  All other data
+                will be read from the file ``Fname.Ext``.
 
-            DB - Read all database information contained in file
-            Fname.Ext. This file should contain all information
-            mentioned above except the solid model loads. If reading a
-            .CDB file written with the GEOM option of the CDWRITE
-            command, element types [ET] compatible with the
-            connectivity of the elements on the file must be defined
-            prior to reading.
+            DB
+                Read all database information contained in file
+                ``Fname.Ext``. This file should contain all information
+                mentioned above except the solid model loads.
+                If reading a ``.CDB`` file written with the ``GEOM`` option
+                of the ``CDWRITE`` command, element types [``ET``] compatible with the
+                connectivity of the elements on the file must be defined
+                prior to reading.
 
-            SOLID - Read the solid model geometry and solid model
-            loads from the file Fnamei.Exti.  This file could have
-            been written by the CDWRITE or IGESOUT command.
+            SOLID
+                Read the solid model geometry and solid model
+                loads from the file ``Fnamei.Exti``.
+                This file could have been written by the ``CDWRITE`` or ``IGESOUT`` command.
 
-            COMB - Read the combined solid model and database
-            information from the file Fname.Ext.
+            COMB
+                Read the combined solid model and database
+                information from the file ``Fname.Ext``.
 
         fname
             File name and directory path (248 characters maximum, including the
-            characters needed for the directory path).  An unspecified
-            directory path defaults to the working directory; in this case, you
-            can use all 248 characters for the file name.
+            characters needed for the directory path).
+            An unspecified directory path defaults to the working directory; 
+            in this case, you can use all 248 characters for the file name.
 
         ext
             Filename extension (eight-character maximum).
@@ -72,25 +76,25 @@ class Database:
         -----
         This command causes coded files of solid model (in IGES format) and
         database (in command format) information to be read.  These files are
-        normally written by the CDWRITE or IGESOUT command.  Note that the
+        normally written by the ``CDWRITE`` or ``IGESOUT`` command.  Note that the
         active coordinate system in these files has been reset to Cartesian
-        (CSYS,0).
+        (``CSYS,0``).
 
-        If a set of data exists prior to the CDREAD operation, that data set is
+        If a set of data exists prior to the ``CDREAD`` operation, that data set is
         offset upward to allow the new data to fit without overlap. The
-        NOOFFSET command allows this offset to be ignored on a set-by-set
+        ``NOOFFSET`` command allows this offset to be ignored on a set-by-set
         basis, causing the existing data set to be overwritten with the new
         data set.
 
-        When you write the geometry data using the CDWRITE,GEOM option, you use
-        the CDREAD,DB option to read the geometry information.
+        When you write the geometry data using the ``CDWRITE,GEOM`` option, you use
+        the ``CDREAD,DB`` option to read the geometry information.
 
-        Using the CDREAD,COMB option will not write NUMOFF commands to offset
+        Using the ``CDREAD,COMB`` option will not write ``NUMOFF`` commands to offset
         entity ID numbers if there is no solid model in the database.
 
         Multiple CDB file imports cannot have elements with real constants in
         one file and section definitions in another. The section attributes
-        will override the real constant attributes.  If you use CDREAD to
+        will override the real constant attributes.  If you use ``CDREAD`` to
         import multiple CDB files, define all of the elements using only real
         constants, or using only section definitions.  Combining real constants
         and section definitions is not recommended.

--- a/ansys/mapdl/core/_commands/preproc/database.py
+++ b/ansys/mapdl/core/_commands/preproc/database.py
@@ -61,7 +61,8 @@ class Database:
             in this case, you can use all 248 characters for the file name.
 
         ext
-            Filename extension (eight-character maximum).
+            Filename extension (eight-character maximum). If there is an extension in
+            ``fname``, this option is ignored.
 
         fnamei
             Name of the IGES file and its directory path (248 characters

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1020,9 +1020,8 @@ class MapdlGrpc(_MapdlCore):
             return resp.response
 
     @wraps(_MapdlCore.cdread)
-    def cdread(self, *args, **kwargs):
+    def cdread(self, option="", fname="", ext="", fnamei="", exti="", **kwargs):
         """Wraps CDREAD"""
-        option = kwargs.get("option", args[0])
         if option == "ALL":
             raise ValueError(
                 'Option "ALL" not supported in gRPC mode.  Please '
@@ -1031,16 +1030,15 @@ class MapdlGrpc(_MapdlCore):
             )
         # the old behaviour is to supplied the name and the extension separatelly.
         # to make it easier let's going to allow names with extensions
-        fname = kwargs.get("fname", args[1])
         basename = os.path.basename(fname)
         if len(basename.split('.')) == 1:
             # there is no extension in the main name.
-            if len(args) > 2:
+            if ext:
                 # if extension is an input as an option (old APDL style)
-                fname = kwargs.get("fname", args[1])  + '.' + kwargs.get("ext", args[2])
+                fname = fname + '.' + ext
             else:
                 # Using default .db
-                fname = kwargs.get("fname", args[1])  + '.' + 'cdb'
+                fname = fname + '.' + 'cdb'
 
         kwargs.setdefault("verbose", False)
         kwargs.setdefault("progress_bar", False)

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1022,9 +1022,17 @@ class MapdlGrpc(_MapdlCore):
     @wraps(_MapdlCore.cdread)
     def cdread(self, option="", fname="", ext="", fnamei="", exti="", **kwargs):
         """Wraps CDREAD"""
-        if option == "ALL":
+        option = option.strip().upper()
+
+        if option not in ['DB', 'SOLID', 'COMB']:
             raise ValueError(
-                'Option "ALL" not supported in gRPC mode.  Please '
+                f'Option "{option}" is not supported.  Please '
+                "Input the geometry and mesh files separately "
+                r'with "\INPUT" or ``mapdl.input``'
+            )
+        if option == 'ALL':
+            raise ValueError(
+                f'Option "{option}" is not supported in gRPC mode.  Please '
                 "Input the geometry and mesh files separately "
                 r'with "\INPUT" or ``mapdl.input``'
             )

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -835,8 +835,13 @@ def test_cdread(mapdl, cleared):
     # Testing arguments
     mapdl.clear()
     mapdl.cdread('db', 'model2', extension='cdb')
-
     assert random_letters in mapdl.parameters['PARMTEST']
+
+    with pytest.raises(ValueError):
+        mapdl.cdread('all', 'model2', 'cdb')
+
+    with pytest.raises(ValueError):
+        mapdl.cdread('test', 'model2', 'cdb')
 
 
 @skip_in_cloud

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -820,6 +820,21 @@ def test_cdread(mapdl, cleared):
 
     mapdl.clear()
     mapdl.cdread("db", 'model2', 'cdb')
+    assert random_letters in mapdl.parameters['PARMTEST']
+
+    # Testing arguments
+    mapdl.clear()
+    mapdl.cdread(option='db', fname='model2', extension='cdb')
+    assert random_letters in mapdl.parameters['PARMTEST']
+
+    # Testing arguments
+    mapdl.clear()
+    mapdl.cdread('db', fname='model2', extension='cdb')
+    assert random_letters in mapdl.parameters['PARMTEST']
+
+    # Testing arguments
+    mapdl.clear()
+    mapdl.cdread('db', 'model2', extension='cdb')
 
     assert random_letters in mapdl.parameters['PARMTEST']
 
@@ -921,6 +936,18 @@ def test_cdread_in_apdl_directory(mapdl, cleared):
     clearing_cdread_cdwrite_tests(mapdl)
     fullpath = os.path.join(mapdl.directory, 'model')
     mapdl.cdread('db', fullpath)
+    assert asserting_cdread_cdwrite_tests(mapdl)
+
+    clearing_cdread_cdwrite_tests(mapdl)
+    mapdl.cdread(option='db', fname='model', ext='cdb')
+    assert asserting_cdread_cdwrite_tests(mapdl)
+
+    clearing_cdread_cdwrite_tests(mapdl)
+    mapdl.cdread('db', fname='model', ext='cdb')
+    assert asserting_cdread_cdwrite_tests(mapdl)
+
+    clearing_cdread_cdwrite_tests(mapdl)
+    mapdl.cdread('db', 'model', ext='cdb')
     assert asserting_cdread_cdwrite_tests(mapdl)
 
 


### PR DESCRIPTION
Close #879 by fixing the ``CDREAD`` argument mess. It also improve the test cases and doc string (format). 