### PR TITLE
Send a MS Teams notification if nightlies (MAPDL or docs) fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,3 +284,15 @@ jobs:
             ./**/*.whl
             ./**/*.tar.gz
             ./**/*.pdf
+      
+      - name: Notify if fail
+        uses: skitionek/notify-microsoft-teams@master
+        if: ${{ failure() }}
+        with:
+          webhook_url: ${{ secrets.TEAM_HOOK }}
+          needs: ${{ toJson(needs) }}
+          job: ${{ toJson(job) }}
+          steps: ${{ toJson(steps) }}
+          overwrite: "{
+            title: `Release FAILED!`, 
+            }"

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -69,3 +69,15 @@ jobs:
           BRANCH: gh-pages
           FOLDER: doc/build/html
           CLEAN: true
+
+      - name: Notify if fail
+        uses: skitionek/notify-microsoft-teams@master
+        if: ${{ failure() }}
+        with:
+          webhook_url: ${{ secrets.TEAM_HOOK }}
+          needs: ${{ toJson(needs) }}
+          job: ${{ toJson(job) }}
+          steps: ${{ toJson(steps) }}
+          overwrite: "{
+            title: `${workflow} failed.`, 
+            }"

--- a/.github/workflows/nightly-mapdl-check.yml
+++ b/.github/workflows/nightly-mapdl-check.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions
+name: Nightly MAPDL check
 
 on:
   workflow_dispatch:
@@ -56,4 +56,16 @@ jobs:
       - name: Display MAPDL Logs
         if: always()
         run: cat log.txt
+
+      - name: Notify if fail
+        uses: skitionek/notify-microsoft-teams@master
+        if: ${{ failure() }}
+        with:
+          webhook_url: ${{ secrets.TEAM_HOOK }}
+          needs: ${{ toJson(needs) }}
+          job: ${{ toJson(job) }}
+          steps: ${{ toJson(steps) }}
+          overwrite: "{
+            title: `${workflow} failed.`, 
+            }"
 


### PR DESCRIPTION
As the title.

I thought an email will be more useful, but
- it is difficult to setup an outlook email because of the 2FA
- We will need an email address for the project?

So, although I'm not big fan of MS Teams, let's give it a try.