### PR TITLE
Improve coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+ignore:
+  - "ansys/mapdl/core/_commands"
+  - "ansys/mapdl/core/jupyter.py"
+  - "ansys/mapdl/core/mapdl_console.py"
+  - "ansys/mapdl/core/mapdl_corba.py"
+
 comment:
   layout: "diff"
   behavior: default


### PR DESCRIPTION
This PR "improves" coverage by ignoring most of our commands section.

Note: We're doing intergration testing right now, which I think should still be run in our CI/CD, but we also should consider doing actual unit testing through a mocked Mapdl application.
