### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    insecure-external-code-execution: allow
+    schedule:
+      interval: "daily"
+    labels:
+      - "maintenance"
+      - "dependencies"
+    ignore:
+      - dependency-name: "vtk"
+      - dependency-name: "ansys-mapdl-reader"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,9 +1,8 @@
-autopep8
-matplotlib
-pandas
-pytest
-pytest
-pytest-cov
+autopep8==1.6.0
+matplotlib==3.5.1
+pandas==1.4.0
+pytest==6.2.5
+pytest-cov==3.0.0
 pyvista==0.32.1
-scipy
-vtk<9.1.0
+scipy==1.7.3
+vtk==9.0.3


### PR DESCRIPTION
This PR adds dependabot for our CI/CD. We have pinned requirements for our doc build, this pins our testing requirements as well.
