### PR TITLE
do not get application token unless deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
 
       # used for documentation deployment
       - name: Get Bot Application Token
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v1
         with:


### PR DESCRIPTION
Quick fix for our dependabot PRs. We only need the application token for tags, and dependabot will never tag.
