### PR TITLE
disable multi-cpu by default

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j auto
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -12,12 +12,6 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
-
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
 
 # customized clean due to examples gallery
 clean:
@@ -30,6 +24,16 @@ clean-except-examples:
 	rm -rf $(BUILDDIR)/*
 	rm -rf images/auto-generated
 	find . -type d -name "_autosummary" -exec rm -rf {} +
+
+# build html docs in parallel using all available CPUs
+# WARNING: this is a resource hog
+phtml:
+	$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -j auto
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # customized to build the pdf rather than using latexpdf due to various issues
 # with our docs like GIFs being written as PNG.


### PR DESCRIPTION
The past several CI runs have been failing due to long running documentation builds. Based on experience with pyvista builds, this is likely due to multi-cpu when using osmesa wheels or xvfb.
