### PR TITLE
Revert "Bump imageio from 2.14.1 to 2.16.0"

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,7 +1,7 @@
 Sphinx==4.4.0
 ansys-mapdl-reader==0.51.3  # newer breaks doc build
 imageio-ffmpeg==0.4.5
-imageio==2.16.0
+imageio==2.14.1
 jupyter_sphinx==0.3.2
 jupyterlab>=3.2.8
 matplotlib==3.5.1


### PR DESCRIPTION
Reverts pyansys/pymapdl#898 in order to fix mapdl nightly docs