### PR TITLE
Ci/fixing the nightly build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
     ignore:
       - dependency-name: "vtk"
       - dependency-name: "ansys-mapdl-reader"
+      - dependency-name: "grpcio"

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -21,3 +21,4 @@ sphinx-notfound-page==0.8
 sphinxcontrib-websupport==1.2.4
 sphinxemoji==0.2.0
 vtk==9.0.3
+grpcio==1.43.0


### PR DESCRIPTION
## Summary
Fix nightly documentation building issue.

## Description
The log was taking forever and showing these messages:

> E0218 04:10:56.185307217    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.210220687    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.235387859    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.259668122    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.288337332    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.316517137    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.344221037    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.385278582    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
> E0218 04:10:56.410993360    3027 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies


The log ends up with:

> waiting for workers...
> Error: The operation was canceled.

## Fix
The issue was related to the last update of `grpcio` to 1.44. So we pinning it down to 1.43 during documentation building workflow only.