### PR TITLE
Removing python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     url="https://github.com/pyansys/pymapdl",
-    python_requires=">=3.6.*",
+    python_requires=">=3.7.*",
     keywords="ANSYS MAPDL gRPC",
     package_data={"ansys.mapdl.core.examples": ["verif/*.dat", "wing.dat"]},
     install_requires=install_requires,


### PR DESCRIPTION
Python 3.6 is in end-of-life support. Hence we are deprecating any CICD related.