### PR TITLE
Expand download options

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,10 @@ omit =
     ansys/mapdl/core/mapdl_console.py
     ansys/mapdl/core/mapdl_corba.py
     ansys/mapdl/core/jupyter.py
+
+
+
+[report]
+exclude_lines =
+    @skip_in_cloud
+    pragma: no cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,9 +8,3 @@ omit =
     ansys/mapdl/core/mapdl_corba.py
     ansys/mapdl/core/jupyter.py
 
-
-
-[report]
-exclude_lines =
-    @skip_in_cloud
-    pragma: no cover

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1414,7 +1414,7 @@ class MapdlGrpc(_MapdlCore):
         chunk_size : int, optional
             Chunk size in bytes.  Must be less than 4MB.  Defaults to 256 kB.
 
-        progress_bar : bool, optional 
+        progress_bar : bool, optional
             Display a progress bar using
             ``tqdm`` when ``True``.  Helpful for showing download
             progress.

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1446,7 +1446,7 @@ class MapdlGrpc(_MapdlCore):
                     elif '*' in files:
                         list_files = glob.glob(files)  # using filter
                         if not list_files:
-                            raise ValueError(f"The `'files'` parameter ({files}) didn't match any file using global expresions in the local client.")
+                            raise ValueError(f"The `'files'` parameter ({files}) didn't match any file using global expressions in the local client.")
                     else:
                         raise ValueError(f"The files parameter ('{files}') does not match a file or a pattern.")
 
@@ -1457,7 +1457,7 @@ class MapdlGrpc(_MapdlCore):
                         # try filter on the list_files
                         list_files = fnmatch.filter(self_files, files)
                         if not list_files:
-                            raise ValueError(f"The `'files'` parameter ({files}) didn't match any file using global expresion in the remote server.")
+                            raise ValueError(f"The `'files'` parameter ({files}) didn't match any file using global expressions in the remote server.")
                     else:
                         raise ValueError(f"The `'files'` parameter ('{files}') does not match a file or a pattern.")
 
@@ -1473,9 +1473,11 @@ class MapdlGrpc(_MapdlCore):
             try:
                 self._download(each_file, chunk_size=chunk_size, progress_bar=progress_bar)
             except FileNotFoundError:
-                # So far the grpc interface returns size of the file equal zero, if the file does not exists or
-                # its size is zero, but they are two differen things!
-                # In theory, since we are obtaining the files name from `mapdl.list_files()` they do exist, so
+                # So far the grpc interface returns size of the file equal
+                # zero, if the file does not exists or its size is zero,
+                # but they are two different things!
+                # In theory, since we are obtaining the files name from
+                # `mapdl.list_files()` they do exist, so
                 # if there is any error, it means their size is zero.
                 pass  # this is not the best.
 

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1379,7 +1379,7 @@ class MapdlGrpc(_MapdlCore):
 
             * `'ALL'`
                 Download all the files ending in: 'out', 'full', 'rst', 'cdb',
-                'err', 'db', or 'log', in the MAPDL working directory 
+                'err', 'db', or 'log', in the MAPDL working directory
                 (:func:`Mapdl.directory <ansys.mapdl.core.Mapdl.directory>`).
 
             * `'EVERYTHING'`
@@ -1403,12 +1403,12 @@ class MapdlGrpc(_MapdlCore):
         .. note::
 
             * The global pattern search does not search recursively.
-            * If you are in local and provide a file path, downloading files 
+            * If you are in local and provide a file path, downloading files
               from a different folder is allowed.
               However it is not a recommended approach.
 
         Examples
-        --------        
+        --------
         Download all the simulation files ('out', 'full', 'rst', 'cdb', 'err', 'db', or 'log'):
 
         >>> mapdl.download('all')

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1363,6 +1363,22 @@ class MapdlGrpc(_MapdlCore):
         raise RuntimeError(f"Unsupported type {getresponse.type} response from MAPDL")
 
     def download_project(self, extensions=None, target_dir=None):
+        """Download all the project files located in the MAPDL working directory.
+
+        Parameters
+        ----------
+        extensions : List[Str], Tuple[Str], optional
+            List of extensions to filter the files before downloading,
+            by default None.
+
+        target_dir : Str, optional
+            Path where the downloaded files will be located, by default None.
+
+        Returns
+        -------
+        List[Str]
+            List of downloaded files.
+        """
         if not extensions:
             files = self.list_files()
             list_of_files = self.download(files, target_dir=target_dir)
@@ -1398,9 +1414,13 @@ class MapdlGrpc(_MapdlCore):
         chunk_size : int, optional
             Chunk size in bytes.  Must be less than 4MB.  Defaults to 256 kB.
 
-        progress_bar : bool, optional Display a progress bar using
+        progress_bar : bool, optional 
+            Display a progress bar using
             ``tqdm`` when ``True``.  Helpful for showing download
             progress.
+
+        recursive : bool
+            Use recursion when using glob pattern.
 
         .. warning::
             This feature is only available for MAPDL 2021R1 or newer.

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -1362,7 +1362,7 @@ class MapdlGrpc(_MapdlCore):
 
         raise RuntimeError(f"Unsupported type {getresponse.type} response from MAPDL")
 
-    def download_project(self, extensions=None, target_dir=None):
+    def download_project(self, extensions=None, target_dir=None): # pragma: no cover
         """Download all the project files located in the MAPDL working directory.
 
         Parameters
@@ -1396,7 +1396,7 @@ class MapdlGrpc(_MapdlCore):
                  target_dir = None,
                  chunk_size=DEFAULT_CHUNKSIZE,
                  progress_bar=True,
-                 recursive=False):  # pragma: no cover
+                 recursive=False): # pragma: no cover
         """Download files from the gRPC instance workind directory
 
         Parameters

--- a/ansys/mapdl/core/mapdl_grpc.py
+++ b/ansys/mapdl/core/mapdl_grpc.py
@@ -919,7 +919,7 @@ class MapdlGrpc(_MapdlCore):
         def _download(targets):
             for target in targets:
                 save_name = os.path.join(path, target)
-                self.download(target, save_name, progress_bar=progress_bar)
+                self._download(target, save_name, progress_bar=progress_bar)
 
         if preference:
             if preference not in ["rst", "rth"]:
@@ -947,7 +947,7 @@ class MapdlGrpc(_MapdlCore):
 
         if result_file:  # found non-distributed result
             save_name = os.path.join(path, result_file)
-            self.download(result_file, save_name, progress_bar=progress_bar)
+            self._download(result_file, save_name, progress_bar=progress_bar)
             return save_name
 
         # otherwise, download all the distributed result files
@@ -1620,7 +1620,7 @@ class MapdlGrpc(_MapdlCore):
 
         temp_dir = tempfile.gettempdir()
         save_name = os.path.join(temp_dir, "tmp.png")
-        self.download(filename, out_file_name=save_name)
+        self._download(filename, out_file_name=save_name)
         return save_name
 
     @protect_grpc
@@ -1809,7 +1809,7 @@ class MapdlGrpc(_MapdlCore):
         else:
             self.igesout(basename, att=1)
             filename = os.path.join(tempfile.gettempdir(), basename)
-            self.download(basename, filename, progress_bar=False)
+            self._download(basename, filename, progress_bar=False)
         return filename
 
     @property

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -646,21 +646,30 @@ example, to list the remote files and download one of them:
 
    This feature is only available for MAPDL 2021R1 or newer.
 
-Alternatively, you can download several files at once using the following arguments
-on :func:`Mapdl.download() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download>`:
+Alternatively, you can download several files at once using the glob pattern 
+or list of file names in :func:`Mapdl.download() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download>`.
+For example:
 
-* `'ALL'`
-    Download all the files ending in: 'out', 'full', 'rst', 'cdb',
-    'err', 'db', or 'log', in the MAPDL working directory 
-    (:func:`Mapdl.directory <ansys.mapdl.core.Mapdl.directory>`).
+.. code:: python
 
-* `'EVERYTHING'`
-    Download every single file in the MAPDL working directory.
+    # Using a list of file names
+    mapdl.download(['file0.log', 'file1.out'])
 
-* `'file*'`
-    Global expressions can be used to match file names.
+    # Using glob pattern to match the list_files
+    mapdl.download('file*')
 
-* List or tuple containing the file names.
+You can also download all the files in the MAPDL working directory
+(:func:`Mapdl.directory <ansys.mapdl.core.Mapdl.directory>`), using:
+
+.. code:: python
+
+    mapdl.download_project()
+
+Or filter by extensions, for example:
+
+.. code:: python
+
+    mapdl.download_project(['log', 'out'], target_dir='myfiles')  # Download the files to 'myfiles' directory
 
 
 Uploading a Local MAPDL File

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -646,6 +646,22 @@ example, to list the remote files and download one of them:
 
    This feature is only available for MAPDL 2021R1 or newer.
 
+Alternatively, you can download several files at once using the following arguments
+on :func:`Mapdl.download() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download>`:
+
+* `'ALL'`
+    Download all the files ending in: 'out', 'full', 'rst', 'cdb',
+    'err', 'db', or 'log', in the MAPDL working directory 
+    (:func:`Mapdl.directory <ansys.mapdl.core.Mapdl.directory>`).
+
+* `'EVERYTHING'`
+    Download every single file in the MAPDL working directory.
+
+* `'file*'`
+    Global expressions can be used to match file names.
+
+* List or tuple containing the file names.
+
 
 Uploading a Local MAPDL File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -160,10 +160,10 @@ def test_large_output(mapdl, cleared):
     assert len(msg) > 4 * 1024 ** 2
 
 
-def test_download_missing_file(mapdl, tmpdir):
+def test__download_missing_file(mapdl, tmpdir):
     target = tmpdir.join("tmp")
     with pytest.raises(FileNotFoundError):
-        mapdl.download("__notafile__", target)
+        mapdl._download("__notafile__", target)
 
 
 @skip_launch_mapdl  # need to be able to start/stop an instance of MAPDL

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -224,7 +224,7 @@ def test_no_get_value_non_interactive(mapdl):
 
 
 def test__download(mapdl, tmpdir):
-    # Creating temp file 
+    # Creating temp file
     with mapdl.non_interactive:
         mapdl.cfopen('myfile0', 'txt')
         mapdl.vwrite('dummy_file')  # Needs to write something, File cannot be empty.

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -272,7 +272,6 @@ def test_download(mapdl, tmpdir, option, expected_files):
     mapdl.download(option, target_dir=target_dir)
     for file_to_check in expected_files:
         assert os.path.exists(os.path.join(target_dir, file_to_check))
-        os.remove(file_to_check)
 
 
 @skip_in_cloud

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -37,7 +37,6 @@ def write_tmp(mapdl, filename, ext="txt"):
         mapdl.cfclos()
 
 
-
 @pytest.fixture(scope="function")
 def setup_for_cmatrix(mapdl, cleared):
     mapdl.prep7()

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -539,9 +539,9 @@ def test_nodes(tmpdir, cleared, mapdl):
         mapdl.nwrite(filename)
     else:
         mapdl.nwrite(basename)
-        mapdl.download(basename, filename)
+        mapdl.download(basename)
 
-    assert np.allclose(mapdl.mesh.nodes, np.loadtxt(filename)[:, 1:])
+    assert np.allclose(mapdl.mesh.nodes, np.loadtxt(basename)[:, 1:])
     assert mapdl.mesh.n_node == 11
     assert np.allclose(mapdl.mesh.nnum, range(1, 12))
 


### PR DESCRIPTION
Close #926 by implementing new behaviors for `mapdl.download`:

```py
mapdl.download('all')  # All simulation files, meaning files ending in 'out', 'full', 'rst', 'cdb', 'err', 'db', or 'log'
mapdl.download('everything')  # **Every single file** in the working directory.
mapdl.download('*.log')  # Every file which extension is 'log'. Uses global pattern.
mapdl.download('file.txt')  # Download 'file.txt'. Standard used behavior.
mapdl.download(['file0.txt', 'file0.rst']) # Download a list of files. Accept list of strings or tuple of strings.
```

### Notes
- Sure the labels could be improved. 'all' and 'everything' seems repetitive. But 'all' is a standard so I don't think it should include every single file in the MAPDL working directory. There many files there... batch, esav, mode, etc which I don't think will be useful most of the time.

Happy to have any kind of feedback.