### PR TITLE
Increasing the format for printing numbers in _get_parameter_array

### DIFF
--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -359,7 +359,7 @@ class Parameters:
         array : np.ndarray
             Numpy array.
         """
-        format_str = "(1F20.12)"
+        format_str = "(1F64.12)"
         with self._mapdl.non_interactive:
             self._mapdl.mwrite(parm_name.upper(), label="kji")  # use C ordering
             self._mapdl.run(format_str)


### PR DESCRIPTION
Increase the format in the MWRITE command.

This was giving some errors when the number was higher than 1E7. 