### PR TITLE
Fix `SELTOL` always resetting to default values

### DIFF
--- a/src/ansys/mapdl/core/_commands/database/selecting.py
+++ b/src/ansys/mapdl/core/_commands/database/selecting.py
@@ -1554,5 +1554,5 @@ class Selecting:
         if toler:
             cmd = f"SELTOL,{toler}"
         else:
-            cmd = "SELTOL,"
+            cmd = "SELTOL"
         return self.run(cmd, **kwargs)

--- a/src/ansys/mapdl/core/_commands/database/selecting.py
+++ b/src/ansys/mapdl/core/_commands/database/selecting.py
@@ -1518,7 +1518,7 @@ class Selecting:
         Parameters
         ----------
         toler
-            Tolerance value. If blank, restores the default tolerance
+            Tolerance value. If blank or None, restores the default tolerance
             logic.
 
         Notes
@@ -1551,4 +1551,8 @@ class Selecting:
         >>> seltol(1E-5)
 
         """
-        return self.run(f"SELTOL{toler}", **kwargs)
+        if toler:
+            cmd = f"SELTOL,{toler}"
+        else:
+            cmd = "SELTOL,"
+        return self.run(cmd, **kwargs)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1447,9 +1447,7 @@ def test_parameters_name_in_get(mapdl, par_name):
     mapdl.get(par=par_name, entity="node", item1="count")
 
 
-@pytest.mark.parametrize(
-    "value",
-    [1E-6, 1E-5, 1E-3, None])
+@pytest.mark.parametrize("value", [1e-6, 1e-5, 1e-3, None])
 def test_seltol(mapdl, value):
     if value:
         assert "SELECT TOLERANCE=" in mapdl.seltol(value)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1445,3 +1445,13 @@ def test_parameters_name(mapdl, par_name):
 )
 def test_parameters_name_in_get(mapdl, par_name):
     mapdl.get(par=par_name, entity="node", item1="count")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [1E-6, 1E-5, 1E-3, None])
+def test_seltol(mapdl, value):
+    if value:
+        assert "SELECT TOLERANCE=" in mapdl.seltol(value)
+    else:
+        assert "SELECT TOLERANCE SET TO DEFAULT" == mapdl.seltol(value)


### PR DESCRIPTION
Close #945 by fixing an error in the cmd string generation.

