### PR TITLE
Fix nightly doc build

### DIFF
--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -39,9 +39,9 @@ jobs:
 
       - name: Install ansys-mapdl-core
         run: |
+          python -m pip install --upgrade pip
           pip install -r requirements/requirements_build.txt
-          python setup.py bdist_wheel
-          pip install dist/ansys*.whl
+          pip install .
           xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
 
       - name: Pull, launch, and validate MAPDL service

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install ansys-mapdl-core
         run: |
-          pip install -r requirements_build.txt
+          pip install -r requirements/requirements_build.txt
           python setup.py bdist_wheel
           pip install dist/ansys*.whl
           xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
@@ -58,7 +58,7 @@ jobs:
   
       - name: Build Documentation
         run: |
-          pip install -r requirements_docs.txt
+          pip install -r requirements/requirements_docs.txt
           xvfb-run make -C doc html
 
       - name: Deploy


### PR DESCRIPTION
The nightly doc building was failing because of the changes in the requirements files, now they are located in the requirements directory.

I'm just re-pointing them to the right file.

This was caught with the help of the teams notification.