### PR TITLE
Using cache when building documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,23 +139,32 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/doc/examples
-          key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
+          key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache docs build directory
         uses: actions/cache@v2
         with:
           path: ~/doc/build
-          key: doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
+          key: doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache autosummary
         uses: actions/cache@v2
         with:
           path: ~/doc/**/_autosummary/*.rst
-          key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
-  
-      - name: Build Documentation
+          key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
+
+      - name: Install Docs Build Requirements
         run: |
           pip install -r requirements/requirements_docs.txt
+
+      - name: Build Documentation
+        run: |
           xvfb-run make -C doc html SPHINXOPTS="-j auto -w build_errors.txt -N"
 
       # Verify that sphinx generates no warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,24 +140,24 @@ jobs:
         with:
           path: doc/source/examples
           key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-          # restore-keys: |
-          #   Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
+          restore-keys: |
+            Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache docs build directory
         uses: actions/cache@v2
         with:
           path: doc/build
           key: doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-          # restore-keys: |
-          #   doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
+          restore-keys: |
+            doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache autosummary
         uses: actions/cache@v2
         with:
           path: doc/source/**/_autosummary/*.rst
           key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-          # restore-keys: |
-          #   autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
+          restore-keys: |
+            autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Install Docs Build Requirements
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,6 @@ jobs:
         with:
           path: doc/source/**/_autosummary/*.rst
           key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-          restore-keys: |
-            autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Install Docs Build Requirements
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,13 @@ jobs:
       - name: Retrieve PyMAPDL version
         run: |
           echo "::set-output name=PYMAPDL_VERSION::$(python -c "from ansys.mapdl.core import __version__; print(__version__)")"
-          echo "PyMAPDL version is: ${{ steps.version.outputs.PYMAPDL_VERSION }}"
+          echo "PyMAPDL version is: $(python -c "from ansys.mapdl.core import __version__; print(__version__)")"
         id: version
 
       - name: Cache examples
         uses: actions/cache@v2
         with:
-          path: ~/doc/examples
+          path: doc/examples
           key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
           restore-keys: |
             Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
@@ -146,7 +146,7 @@ jobs:
       - name: Cache docs build directory
         uses: actions/cache@v2
         with:
-          path: ~/doc/build
+          path: doc/build
           key: doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
           restore-keys: |
             doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
@@ -154,7 +154,7 @@ jobs:
       - name: Cache autosummary
         uses: actions/cache@v2
         with:
-          path: ~/doc/**/_autosummary/*.rst
+          path: doc/**/_autosummary/*.rst
           key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
           restore-keys: |
             autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Cache examples
         uses: actions/cache@v2
         with:
-          path: doc/examples
+          path: doc/source/examples
           key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
           restore-keys: |
             Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
@@ -154,7 +154,7 @@ jobs:
       - name: Cache autosummary
         uses: actions/cache@v2
         with:
-          path: doc/**/_autosummary/*.rst
+          path: doc/source/**/_autosummary/*.rst
           key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
           restore-keys: |
             autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,22 +140,24 @@ jobs:
         with:
           path: doc/source/examples
           key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-          restore-keys: |
-            Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
+          # restore-keys: |
+          #   Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache docs build directory
         uses: actions/cache@v2
         with:
           path: doc/build
           key: doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-          restore-keys: |
-            doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
+          # restore-keys: |
+          #   doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache autosummary
         uses: actions/cache@v2
         with:
           path: doc/source/**/_autosummary/*.rst
           key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
+          # restore-keys: |
+          #   autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Install Docs Build Requirements
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,17 +116,17 @@ jobs:
           restore-keys: |
             Examples-
 
-      # - name: Cache docs build directory
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/build
-      #     key: doc-build-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/*') }}
+      - name: Cache docs build directory
+        uses: actions/cache@v2
+        with:
+          path: ~/doc/build
+          key: doc-build-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/build/*') }}
 
-      # - name: Cache autosummary
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst
-      #     key: autosummary-rst-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst') }}
+      - name: Cache autosummary
+        uses: actions/cache@v2
+        with:
+          path: ~/doc/**/_autosummary/*.rst
+          key: autosummary-rst-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('~/doc/**/_autosummary/*.rst') }}
 
       - name: Test virtual framebuffer
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,14 @@ jobs:
           sudo apt update
           sudo apt install zip pandoc libgl1-mesa-glx xvfb texlive-latex-extra latexmk
 
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_docs*.txt') }}
+          restore-keys: |
+            Python-${{ runner.os }}-${{ matrix.python-version }}
+
       - name: Test virtual framebuffer
         run: |
           pip install -r .ci/requirements_test_xvfb.txt
@@ -124,23 +132,14 @@ jobs:
       - name: Retrieve PyMAPDL version
         run: |
           echo "::set-output name=PYMAPDL_VERSION::$(python -c "from ansys.mapdl.core import __version__; print(__version__)")"
+          echo "PyMAPDL version is: ${{ steps.version.outputs.PYMAPDL_VERSION }}"
         id: version
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_docs*.txt') }}
-          restore-keys: |
-            Python-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache examples
         uses: actions/cache@v2
         with:
           path: ~/doc/examples
           key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
-          restore-keys: |
-            Examples-
 
       - name: Cache docs build directory
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Cache examples
         uses: actions/cache@v2
         with:
-          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/
+          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples
           key: Examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/*') }}
           restore-keys: |
             Examples-
@@ -119,7 +119,7 @@ jobs:
       - name: Cache docs build directory
         uses: actions/cache@v2
         with:
-          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/build/
+          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/build
           key: doc-build-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/*') }}
 
       - name: Cache autosummary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,19 +100,24 @@ jobs:
           sudo apt update
           sudo apt install zip pandoc libgl1-mesa-glx xvfb texlive-latex-extra latexmk
 
+      - name: Retrieve PyMAPDL version
+        run: |
+          echo "::set-output name=PYMAPDL_VERSION::$(python -c "from ansys.mapdl.core import __version__; print(__version__)")"
+        id: version
+
       - name: Cache pip
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_docs*.txt') }}
           restore-keys: |
-            Python-${{ runner.os }}-${{ matrix.python-version }}
+            Python-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache examples
         uses: actions/cache@v2
         with:
           path: ~/doc/examples
-          key: Examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/examples/*') }}
+          key: Examples-${{ steps.version.outputs.PYMAPDL_VERSION }}
           restore-keys: |
             Examples-
 
@@ -120,13 +125,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/doc/build
-          key: doc-build-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/build/*') }}
+          key: doc-build-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Cache autosummary
         uses: actions/cache@v2
         with:
           path: ~/doc/**/_autosummary/*.rst
-          key: autosummary-rst-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('~/doc/**/_autosummary/*.rst') }}
+          key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: Test virtual framebuffer
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
   PYMAPDL_START_INSTANCE: FALSE
   PYANSYS_OFF_SCREEN: True
   DOCKER_PACKAGE: docker.pkg.github.com/pyansys/pymapdl/mapdl
+  DOCKER_IMAGE_VERSION_DOCS_BUILD: v21.2.1
 
 jobs:
 
@@ -100,6 +101,26 @@ jobs:
           sudo apt update
           sudo apt install zip pandoc libgl1-mesa-glx xvfb texlive-latex-extra latexmk
 
+      - name: Test virtual framebuffer
+        run: |
+          pip install -r .ci/requirements_test_xvfb.txt
+          xvfb-run python .ci/display_test.py
+
+      - name: Install ansys-mapdl-core
+        run: |
+          pip install build
+          python -m build
+          pip install dist/ansys*.whl
+          xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
+
+      - name: Pull, launch, and validate MAPDL service
+        run: .ci/start_mapdl.sh
+        env:
+          LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GH_PAT: ${{ secrets.REPO_DOWNLOAD_PAT }}
+          MAPDL_IMAGE: '${{ env.DOCKER_PACKAGE }}:${{ env.DOCKER_IMAGE_VERSION_DOCS_BUILD }}'
+
       - name: Retrieve PyMAPDL version
         run: |
           echo "::set-output name=PYMAPDL_VERSION::$(python -c "from ansys.mapdl.core import __version__; print(__version__)")"
@@ -132,26 +153,6 @@ jobs:
         with:
           path: ~/doc/**/_autosummary/*.rst
           key: autosummary-rst-${{ steps.version.outputs.PYMAPDL_VERSION }}
-
-      - name: Test virtual framebuffer
-        run: |
-          pip install -r .ci/requirements_test_xvfb.txt
-          xvfb-run python .ci/display_test.py
-
-      - name: Install ansys-mapdl-core
-        run: |
-          pip install build
-          python -m build
-          pip install dist/ansys*.whl
-          xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
-
-      - name: Pull, launch, and validate MAPDL service
-        run: .ci/start_mapdl.sh
-        env:
-          LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          GH_PAT: ${{ secrets.REPO_DOWNLOAD_PAT }}
-          MAPDL_IMAGE: '${{ env.DOCKER_PACKAGE }}:v21.2.1'
   
       - name: Build Documentation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,22 +111,22 @@ jobs:
       - name: Cache examples
         uses: actions/cache@v2
         with:
-          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples
-          key: Examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/*') }}
+          path: ~/doc/examples
+          key: Examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/examples/*') }}
           restore-keys: |
             Examples-
 
-      - name: Cache docs build directory
-        uses: actions/cache@v2
-        with:
-          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/build
-          key: doc-build-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/*') }}
+      # - name: Cache docs build directory
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/build
+      #     key: doc-build-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/*') }}
 
-      - name: Cache autosummary
-        uses: actions/cache@v2
-        with:
-          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst
-          key: autosummary-rst-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst') }}
+      # - name: Cache autosummary
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst
+      #     key: autosummary-rst-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst') }}
 
       - name: Test virtual framebuffer
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,11 @@ jobs:
 
       - name: Cache examples
         uses: actions/cache@v2
-          with:
-            path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/
-            key: Examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/*') }}
-            restore-keys: |
-              Examples-
+        with:
+          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/
+          key: Examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/*') }}
+          restore-keys: |
+            Examples-
 
       - name: Cache docs build directory
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,26 @@ jobs:
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
 
+      - name: Cache examples
+        uses: actions/cache@v2
+          with:
+            path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/
+            key: Examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/examples/*') }}
+            restore-keys: |
+              Examples-
+
+      - name: Cache docs build directory
+        uses: actions/cache@v2
+        with:
+          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/build/
+          key: doc-build-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('doc/*') }}
+
+      - name: Cache autosummary
+        uses: actions/cache@v2
+        with:
+          path: ${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst
+          key: autosummary-rst-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('${{ env:GITHUB_WORKSPACE }}/pymapdl/doc/**/_autosummary/*.rst') }}
+
       - name: Test virtual framebuffer
         run: |
           pip install -r .ci/requirements_test_xvfb.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,15 +10,7 @@ comment:
 
 coverage:
   status:
-    project:
-      default:
-        # basic
-        # target: 50%
-        threshold: 0%
-        # advanced
-        if_not_found: success
-        if_ci_failed: error
-        if_no_uploads: error
+    project: false
     patch:
       default:
         # basic


### PR DESCRIPTION
Using cache to avoid running all the examples every time we do push/PR


Close #951 