### PR TITLE
Flexible number format in `_get_parameter_array`

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1377,6 +1377,11 @@ class MapdlGrpc(_MapdlCore):
         self._response = out[out.find("LINE=       0") + 13 :]
         self._log.info(self._response)
 
+        if "*** ERROR ***" in self._response:
+            raise RuntimeError(
+                self._response.split("*** ERROR ***")[1].splitlines()[1].strip()
+            )
+
         # try/except here because MAPDL might have not closed the temp file
         try:
             os.remove(tmp_filename)

--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -373,8 +373,8 @@ class Parameters:
                 escaped = True
                 break
 
-        if not escaped:
-            raise Exception(
+        if not escaped:  # pragma: no cover
+            raise RuntimeError(
                 f"The array '{parm_name}' has a number format "
                 "that could not be read using '{format_str}'."
             )

--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -359,12 +359,26 @@ class Parameters:
         array : np.ndarray
             Numpy array.
         """
-        format_str = "(1F64.12)"
-        with self._mapdl.non_interactive:
-            self._mapdl.mwrite(parm_name.upper(), label="kji")  # use C ordering
-            self._mapdl.run(format_str)
+        escaped = False
+        for each_format_number in [20, 30, 40, 64, 100]:
+            format_str = f"(1F{each_format_number}.12)"
+            with self._mapdl.non_interactive:
+                # use C ordering
+                self._mapdl.mwrite(parm_name.upper(), label="kji")
+                self._mapdl.run(format_str)
 
-        st = self._mapdl.last_response.rfind(format_str) + len(format_str) + 1
+            st = self._mapdl.last_response.rfind(format_str) + len(format_str) + 1
+
+            if "**" not in self._mapdl.last_response[st:]:
+                escaped = True
+                break
+
+        if not escaped:
+            raise Exception(
+                f"The array '{parm_name}' has a number format "
+                "that could not be read using '{format_str}'."
+            )
+
         arr_flat = np.fromstring(self._mapdl.last_response[st:], sep="\n").reshape(
             shape
         )

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    "number",
+    [
+        1e11,
+        1e21,
+        1e31,
+        1e41,
+        1e51,
+        pytest.param(1e61, marks=pytest.mark.xfail),
+    ],
+)
+def test__get_parameter_array(mapdl, number):
+    name = "param_array"
+
+    # Testing 1D arrays
+    shape = (100,)
+    array = np.ones(shape) * number
+    mapdl.load_array(name=name, array=array)
+    assert np.allclose(array, mapdl.parameters._get_parameter_array(name, shape))
+
+    # Testing 2D arrays
+    shape = (100, 5)
+    array = np.ones(shape) * number
+    mapdl.load_array(name=name, array=array)
+    assert np.allclose(array, mapdl.parameters._get_parameter_array(name, shape))
+
+    # High number
+    with pytest.raises(RuntimeError):
+        shape = (100, 100)
+        array = np.ones(shape) * number
+        mapdl.load_array(name=name, array=array)
+        mapdl.parameters._get_parameter_array(name, shape)


### PR DESCRIPTION
Close #952 by implementing an iterative process.

Ok, it might be slow sometimes, but I think it is a reasonable approach for this case. I setup an upper limit at `F60.12` for the float format.