### PR TITLE
mapdl.add_file_handler: correct lever.upper()

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1618,7 +1618,7 @@ class _MapdlCore(Commands):
         self._log_filehandler = logging.FileHandler(filepath, mode=mode)
         self._log_filehandler.setFormatter(logging.Formatter(formatstr))
         if isinstance(level, str):
-            level = level.uppder()
+            level = level.upper()
         self._log_filehandler.setLevel(level)
         self._log.addHandler(self._log_filehandler)
         self._log.info("Added file handler at %s", filepath)


### PR DESCRIPTION
The string `level`: The right method is `upper`.