### PR TITLE
Fix mapdl: _log.logger.add_handler

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1620,7 +1620,7 @@ class _MapdlCore(Commands):
         if isinstance(level, str):
             level = level.uppder()
         self._log_filehandler.setLevel(level)
-        self._log.addHandler(self._log_filehandler)
+        self._log.looger.addHandler(self._log_filehandler)
         self._log.info("Added file handler at %s", filepath)
 
     def remove_file_handler(self):

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1620,7 +1620,7 @@ class _MapdlCore(Commands):
         if isinstance(level, str):
             level = level.uppder()
         self._log_filehandler.setLevel(level)
-        self._log.looger.addHandler(self._log_filehandler)
+        self._log.logger.addHandler(self._log_filehandler)
         self._log.info("Added file handler at %s", filepath)
 
     def remove_file_handler(self):


### PR DESCRIPTION
The object `self._log` if (type `PymapdlCustomAdapter`) has no method `addHandler`, it is in `self._log.logger` (type `Logger`).