### PR TITLE
Use latest grpc package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
     {name = "PyAnsys developers", email = "pyansys.support@ansys.com"},
 ]
 dependencies = [
-    "ansys-api-mapdl-v0==0.4.1",  # supports at least 2020R2 - 2021R2
+    "ansys-api-mapdl==0.5.1",  # supports at least 2020R2 - 2022R1
     "ansys-corba; python_version < '3.9'",
     "ansys-mapdl-reader>=0.50.15",
     "appdirs>=1.4.0",

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1435,7 +1435,6 @@ class AnsMat(ApdlMathObj):
 
         info = self._mapdl._data_info(self.id)
 
-        breakpoint()
         if meets_version(self._mapdl._server_version, (0, 5, 0)):  # pragma: no cover
             return info.mattype in [0, 1, 2]  # [UPPER, LOWER, DIAG] respectively
 

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1423,19 +1423,27 @@ class AnsMat(ApdlMathObj):
         """
         return (self.nrow, self.ncol)
 
-    def sym(self):  # BUG this is not always true
-        """Return if matrix is symmetric."""
+    def sym(self) -> bool:
+        """Return if matrix is symmetric.
+
+        Returns
+        -------
+        bool
+            ``True`` when this matrix is symmetric.
+
+        """
 
         info = self._mapdl._data_info(self.id)
 
+        breakpoint()
         if meets_version(self._mapdl._server_version, (0, 5, 0)):  # pragma: no cover
             return info.mattype in [0, 1, 2]  # [UPPER, LOWER, DIAG] respectively
-        else:
-            warn(
-                "Call to sym() function cannot evaluate if"
-                "it is symmetric or not in this MAPDL version."
-            )
-            return True
+
+        warn(
+            "Call to ``sym`` cannot evaluate if this matrix "
+            "is symmetric with this version of MAPDL."
+        )
+        return True
 
     def asarray(self, dtype=None) -> np.ndarray:
         """Returns vector as a numpy array.


### PR DESCRIPTION
This PR updates our dependencies to use the latest gRPC interface package `ansys-api-mapdl`, which has been renamed from `ansys-api-mapdl-v0` and updated to `v0.5.1`.

This opens up the usage of the database service API.
