### PR TITLE
Empty mesh object instabilities

### DIFF
--- a/src/ansys/mapdl/core/mapdl_geometry.py
+++ b/src/ansys/mapdl/core/mapdl_geometry.py
@@ -329,7 +329,7 @@ class Geometry:
 
         Examples
         --------
-        >>> mapdl.n_area
+        >>> mapdl.n_volu
         1
         """
         return self._item_count("VOLU")
@@ -382,6 +382,9 @@ class Geometry:
         >>> mapdl.knum
         array([1, 2, 3, 4, 5, 6, 7, 8], dtype=int32)
         """
+        if self._mapdl.geometry.n_keypoint == 0:
+            return np.array([], dtype=np.int32)
+
         return self._mapdl.get_array("KP", item1="KLIST").astype(np.int32)
 
     @property
@@ -394,6 +397,10 @@ class Geometry:
         >>> mapdl.lnum
         array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12], dtype=int32)
         """
+        # For clean exit when there is no lines.
+        if self._mapdl.geometry.n_line == 0:
+            return np.array([], dtype=np.int32)
+
         # this (weirdly) sometimes fails
         for _ in range(5):
             lnum = self._mapdl.get_array("LINES", item1="LLIST")
@@ -411,6 +418,10 @@ class Geometry:
         >>> mapdl.anum
         array([1, 2, 3, 4, 5, 6], dtype=int32)
         """
+        # Clean exit
+        if self._mapdl.geometry.n_area == 0:
+            return np.array([], dtype=np.int32)
+
         return self._mapdl.get_array("AREA", item1="ALIST").astype(np.int32)
 
     @property
@@ -423,6 +434,9 @@ class Geometry:
         >>> mapdl.vnum
         array([1], dtype=int32)
         """
+        if self._mapdl.geometry.n_volu == 0:
+            return np.array([], dtype=np.int32)
+
         return self._mapdl.get_array("VOLU", item1="VLIST").astype(np.int32)
 
     @supress_logging
@@ -437,6 +451,10 @@ class Geometry:
         self._mapdl.lsel("ALL", mute=True)
         self._mapdl.asel("ALL", mute=True)
         self._mapdl.vsel("NONE", mute=True)
+
+        # Clean exit if there is no lines.
+        if self._mapdl.geometry._item_count("LINE") == 0:
+            return pv.PolyData()
 
         iges = self._load_iges()
 
@@ -873,6 +891,8 @@ class Geometry:
         # FLST,5,76,4,ORDE,74
         # FITEM,5,2
         # LSEL, , , ,P51X
+        if self._item_count(item_type) == 0:
+            return
 
         # unordered option
         with self._mapdl.non_interactive:

--- a/src/ansys/mapdl/core/mapdl_geometry.py
+++ b/src/ansys/mapdl/core/mapdl_geometry.py
@@ -452,10 +452,6 @@ class Geometry:
         self._mapdl.asel("ALL", mute=True)
         self._mapdl.vsel("NONE", mute=True)
 
-        # # Clean exit if there is no lines.
-        # if self._mapdl.geometry._item_count("LINE") == 0:
-        #     return pv.PolyData()
-
         iges = self._load_iges()
 
         self._mapdl.cmsel("S", "__tmp_volu__", "VOLU", mute=True)
@@ -891,8 +887,6 @@ class Geometry:
         # FLST,5,76,4,ORDE,74
         # FITEM,5,2
         # LSEL, , , ,P51X
-        # if self._item_count(item_type) == 0:
-        #     return
 
         # unordered option
         with self._mapdl.non_interactive:

--- a/src/ansys/mapdl/core/mapdl_geometry.py
+++ b/src/ansys/mapdl/core/mapdl_geometry.py
@@ -452,9 +452,9 @@ class Geometry:
         self._mapdl.asel("ALL", mute=True)
         self._mapdl.vsel("NONE", mute=True)
 
-        # Clean exit if there is no lines.
-        if self._mapdl.geometry._item_count("LINE") == 0:
-            return pv.PolyData()
+        # # Clean exit if there is no lines.
+        # if self._mapdl.geometry._item_count("LINE") == 0:
+        #     return pv.PolyData()
 
         iges = self._load_iges()
 
@@ -891,8 +891,8 @@ class Geometry:
         # FLST,5,76,4,ORDE,74
         # FITEM,5,2
         # LSEL, , , ,P51X
-        if self._item_count(item_type) == 0:
-            return
+        # if self._item_count(item_type) == 0:
+        #     return
 
         # unordered option
         with self._mapdl.non_interactive:

--- a/src/ansys/mapdl/core/mesh_grpc.py
+++ b/src/ansys/mapdl/core/mesh_grpc.py
@@ -202,7 +202,7 @@ class MeshGrpc(Mesh):
         """
         if self._enum is None:
             if self._mapdl.mesh.n_elem == 0:
-                return np.array([], dtype=np.int32)  #
+                return np.array([], dtype=np.int32)
             else:
                 self._enum = self._mapdl.get_array("ELEM", item1="ELIST").astype(
                     np.int32

--- a/src/ansys/mapdl/core/mesh_grpc.py
+++ b/src/ansys/mapdl/core/mesh_grpc.py
@@ -201,7 +201,12 @@ class MeshGrpc(Mesh):
         array([    1,     2,     3, ...,  9998,  9999, 10000])
         """
         if self._enum is None:
-            self._enum = self._mapdl.get_array("ELEM", item1="ELIST").astype(np.int32)
+            if self._mapdl.mesh.n_elem == 0:
+                return np.array([], dtype=np.int32)  #
+            else:
+                self._enum = self._mapdl.get_array("ELEM", item1="ELIST").astype(
+                    np.int32
+                )
         return self._enum
 
     @threaded

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -484,3 +484,12 @@ def test_ndist(cleared, mapdl):
     assert node_xdist == node2[0] - node1[0]
     assert node_ydist == node2[1] - node1[1]
     assert node_zdist == node2[2] - node1[2]
+
+
+def test_empty_model(mapdl):
+    mapdl.clear()
+
+    assert mapdl.geometry.knum.size == 0
+    assert mapdl.geometry.lnum.size == 0
+    assert mapdl.geometry.anum.size == 0
+    assert mapdl.geometry.vnum.size == 0

--- a/tests/test_mesh_grpc.py
+++ b/tests/test_mesh_grpc.py
@@ -1,0 +1,29 @@
+"""Test mesh """
+import numpy as np
+
+
+def test_empty_model(mapdl):
+    mapdl.clear()
+
+    assert mapdl.mesh.nnum.size == 0
+    assert mapdl.mesh.enum.size == 0
+
+    assert mapdl.mesh.n_elem == 0
+    assert mapdl.mesh.n_node == 0
+
+
+def test_mesh_attributes(mapdl, cube_solve):
+    mapdl.allsel()
+    assert mapdl.mesh.n_node == mapdl.get("__par__", "node", "0", "count")
+    assert mapdl.mesh.n_elem == mapdl.get("__par__", "elem", "0", "count")
+
+    assert len(mapdl.mesh.nnum) == mapdl.get("__par__", "node", "0", "count")
+    assert len(mapdl.mesh.enum) == mapdl.get("__par__", "elem", "0", "count")
+
+    mapdl.dim("par", "", len(mapdl.mesh.nnum))
+    mapdl.starvget("par", "NODE", "0", "NLIST")
+    assert np.allclose(mapdl.parameters["par"].flatten(), mapdl.mesh.nnum)
+
+    mapdl.dim("par", "", len(mapdl.mesh.enum))
+    mapdl.starvget("par", "ELEM", "0", "ELIST")
+    assert np.allclose(mapdl.parameters["par"].flatten(), mapdl.mesh.enum)


### PR DESCRIPTION
I have noticed that MAPDL was returning errors when querying the number of entities using `vget` but there was none. This crashed the MAPDL session.

I have improved (I believe) the checks on the PyMAPDL side, so we avoid requesting those parameters using `vget` when there is no entities. 

Closes #971 
Improves #965 