### PR TITLE
check for empty geometry when plotting

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1061,6 +1061,12 @@ class _MapdlCore(Commands):
 
         if vtk:
             kwargs.setdefault("title", "MAPDL Volume Plot")
+            if not self.geometry.n_volu:
+                warnings.warn(
+                    "Either no volumes have been selected or there is nothing to plot."
+                )
+                return general_plotter([], [], [], **kwargs)
+
             cm_name = "__tmp_area2__"
             self.cm(cm_name, "AREA", mute=True)
             self.aslv("S", mute=True)  # select areas attached to active volumes
@@ -1178,6 +1184,13 @@ class _MapdlCore(Commands):
             kwargs.setdefault("show_scalar_bar", False)
             kwargs.setdefault("title", "MAPDL Area Plot")
             kwargs.setdefault("scalar_bar_args", {"title": "Scalar Bar Title"})
+
+            if not self.geometry.n_area:
+                warnings.warn(
+                    "Either no areas have been selected or there is nothing to plot."
+                )
+                return general_plotter([], [], [], **kwargs)
+
             if quality > 10:
                 quality = 10
             if quality < 1:
@@ -1367,7 +1380,7 @@ class _MapdlCore(Commands):
             kwargs.setdefault("title", "MAPDL Line Plot")
             if not self.geometry.n_line:
                 warnings.warn(
-                    "Either no lines have been selected or there " "is nothing to plot"
+                    "Either no lines have been selected or there is nothing to plot."
                 )
                 return general_plotter([], [], [], **kwargs)
 

--- a/src/ansys/mapdl/core/mapdl_geometry.py
+++ b/src/ansys/mapdl/core/mapdl_geometry.py
@@ -221,7 +221,8 @@ class Geometry:
     @supress_logging
     @run_as_prep7
     def generate_surface(self, density=4, amin=None, amax=None, ninc=None):
-        """Generate an all-triangular surface of the active surfaces.
+        """
+        Generate an all-triangular surface of the active surfaces.
 
         Parameters
         ----------
@@ -325,7 +326,8 @@ class Geometry:
 
     @property
     def n_volu(self):
-        """Number of volumes currently selected
+        """
+        Number of volumes currently selected.
 
         Examples
         --------
@@ -336,7 +338,8 @@ class Geometry:
 
     @property
     def n_area(self):
-        """Number of areas currently selected
+        """
+        Number of areas currently selected.
 
         Examples
         --------
@@ -347,7 +350,8 @@ class Geometry:
 
     @property
     def n_line(self):
-        """Number of lines currently selected
+        """
+        Number of lines currently selected.
 
         Examples
         --------
@@ -358,7 +362,8 @@ class Geometry:
 
     @property
     def n_keypoint(self):
-        """Number of keypoints currently selected
+        """
+        Number of keypoints currently selected.
 
         Examples
         --------
@@ -369,12 +374,13 @@ class Geometry:
 
     @supress_logging
     def _item_count(self, entity):
-        """Return item count for a given entity"""
+        """Return item count for a given entity."""
         return int(self._mapdl.get(entity=entity, item1="COUNT"))
 
     @property
     def knum(self):
-        """Array of keypoint numbers.
+        """
+        Array of keypoint numbers.
 
         Examples
         --------


### PR DESCRIPTION
Encountered a fairly alarming and cryptic error when running:

```py

from ansys.mapdl.core import launch_mapdl
mapdl = launch_mapdl()
mapdl.aplot()
```

Error traceback included being unable to update an empty geometry cache.

Area plotting now includes a basic test to verify that when there is no geometry to plot, nothing is plotted (as in standard MAPDL behavior).
