### PR TITLE
Avoiding nodes mapping in PyMAPDL.

### DIFF
--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -648,7 +648,7 @@ class MapdlMath:
         fname = self._load_file(fname)
         return self.load_matrix_from_file(dtype, fname, "DAMP", asarray)
 
-    def get_vec(self, dtype=np.double, fname="file.full", mat_id="RHS", asarray=False):
+    def get_vec(self, dtype=None, fname="file.full", mat_id="RHS", asarray=False):
         """Load a vector from a file.
 
         Parameters
@@ -664,8 +664,10 @@ class MapdlMath:
 
             * ``"RHS"`` - Load vector
             * ``"GVEC"`` - Constraint equation constant terms
-            * ``"BACK"`` - nodal mapping vector (internal to user)
+            * ``"BACK"`` - nodal mapping vector (internal to user).
+            If this is used, the default ``dtype`` is ``np.int32``.
             * ``"FORWARD"`` - nodal mapping vector (user to internal)
+            If this is used, the default ``dtype`` is ``np.int32``.
         asarray : bool, optional
             Return a `scipy` array rather than an APDLMath matrix.
 
@@ -685,6 +687,17 @@ class MapdlMath:
         self._mapdl._log.info(
             "Call MAPDL to extract the %s vector from the file %s", mat_id, fname
         )
+
+        if mat_id.upper() not in ["RHS", "GVEC", "BACK", "FORWARD"]:
+            raise ValueError(
+                f"The 'mat_id' value ({mat_id}) is not allowed."
+                'Only "RHS", "GVEC", "BACK", or "FORWARD" are allowed.'
+            )
+
+        if mat_id.upper() in ["BACK", "FORWARD"] and not dtype:
+            dtype = np.int32
+        else:
+            dtype = np.double
 
         fname = self._load_file(fname)
         self._mapdl.run(

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -701,7 +701,7 @@ class MapdlMath:
         )
         ans_vec = AnsVec(name, self._mapdl)
         if asarray:
-            return self._mapdl._vec_data(ans_vec.id)
+            return self._mapdl._vec_data(ans_vec.id).astype(dtype)
         return ans_vec
 
     def set_vec(self, data, name=None):

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -701,7 +701,7 @@ class MapdlMath:
         )
         ans_vec = AnsVec(name, self._mapdl)
         if asarray:
-            return self._mapdl._vec_data(ans_vec.id).astype(dtype)
+            return self._mapdl._vec_data(ans_vec.id).astype(dtype, copy=False)
         return ans_vec
 
     def set_vec(self, data, name=None):

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -445,10 +445,6 @@ class MapdlMath:
             * ``"STIFF"`` - Stiffness matrix
             * ``"MASS"`` - Mass matrix
             * ``"DAMP"`` - Damping matrix
-            * ``"NOD2BCS"`` - Mapping vector relating the full set of
-              nodal DOFs to the subset that the solver uses
-            * ``"USR2BCS"`` - Mapping vector relating the full set of
-              external nodal DOFs to the subset that the solver uses
             * ``"GMAT"`` - Constraint equation matrix
             * ``"K_RE"`` - Real part of the stiffness matrix
             * ``"K_IM"`` - Imaginary part of the stiffness matrix
@@ -472,8 +468,8 @@ class MapdlMath:
             "STIFF",
             "MASS",
             "DAMP",
-            "NOD2BCS",
-            "USR2BCS",
+            # "NOD2BCS",  # Not allowed since #990
+            # "USR2BCS",
             "GMAT",
             "K_RE",
             "K_IM",
@@ -665,9 +661,9 @@ class MapdlMath:
             * ``"RHS"`` - Load vector
             * ``"GVEC"`` - Constraint equation constant terms
             * ``"BACK"`` - nodal mapping vector (internal to user).
-            If this is used, the default ``dtype`` is ``np.int32``.
+              If this is used, the default ``dtype`` is ``np.int32``.
             * ``"FORWARD"`` - nodal mapping vector (user to internal)
-            If this is used, the default ``dtype`` is ``np.int32``.
+              If this is used, the default ``dtype`` is ``np.int32``.
         asarray : bool, optional
             Return a `scipy` array rather than an APDLMath matrix.
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -388,6 +388,18 @@ def test_solve_py(mapdl, mm, cube_solve):
     assert np.allclose(rhs0, rhs1)
 
 
+@pytest.mark.parametrize(
+    "vec_type", ["RHS", "gvec", "BACK", pytest.param("dummy", marks=pytest.mark.xfail)]
+)
+def test_get_vec(mapdl, mm, cube_solve, vec_type):
+    vec = mm.get_vec(mat_id=vec_type).asarray()
+    if vec_type.upper() == "BACK":
+        assert vec.dtype == np.int32
+    else:
+        assert vec.dtype == np.double
+    assert vec.shape
+
+
 def test_get_vector(mm):
     vec = mm.ones(10)
     arr = vec.asarray()

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -392,10 +392,11 @@ def test_solve_py(mapdl, mm, cube_solve):
     "vec_type", ["RHS", "BACK", pytest.param("dummy", marks=pytest.mark.xfail)]
 )
 def test_get_vec(mapdl, mm, cube_solve, vec_type):
-    vec = mm.get_vec(mat_id=vec_type).asarray()
     if vec_type.upper() == "BACK":
+        vec = mm.get_vec(mat_id=vec_type, asarray=True)  # To test asarray arg.
         assert vec.dtype == np.int32
     else:
+        vec = mm.get_vec(mat_id=vec_type).asarray()
         assert vec.dtype == np.double
     assert vec.shape
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -389,7 +389,7 @@ def test_solve_py(mapdl, mm, cube_solve):
 
 
 @pytest.mark.parametrize(
-    "vec_type", ["RHS", "gvec", "BACK", pytest.param("dummy", marks=pytest.mark.xfail)]
+    "vec_type", ["RHS", "BACK", pytest.param("dummy", marks=pytest.mark.xfail)]
 )
 def test_get_vec(mapdl, mm, cube_solve, vec_type):
     vec = mm.get_vec(mat_id=vec_type).asarray()


### PR DESCRIPTION
Close #990 

You can still operate with these mappings but it should be done using `mapdl.run("*SMAT....")`. This allows to work inside MAPDL with these nodes mapping. 

Also adding default `dtype` for the `get_vec` when using `BACK` and `FORWARD` since MAPDL returns ints arrays.

Also, to avoid possible errors, I'm forcing array conversion (`array.astype`) when using `get_vec` and `asarray` keyword.

