### PR TITLE
Run CI on 22.1 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mapdl-version: ['v21.1.1', 'v21.2.1']
+        mapdl-version: ['v21.1.1', 'v21.2.1', 'v22.1.0']
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,17 @@ repos:
 #   - id: pydocstyle
 #     additional_dependencies: [toml]
 #     exclude: "tests/"
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  - id: check-merge-conflict
+  - id: debug-statements
+  - id: no-commit-to-branch
+    args: [--branch, main]
+
+# this validates our github workflow files
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.14.0
+  hooks:
+    - id: check-github-workflows


### PR DESCRIPTION
This PR checks we can run CI on the 22.1 image.

Also implements additional pre-commit checks to stop pushing to main.
