### PR TITLE
Updating docstring in `download`

### DIFF
--- a/src/ansys/mapdl/core/_commands/preproc/meshing.py
+++ b/src/ansys/mapdl/core/_commands/preproc/meshing.py
@@ -2755,17 +2755,17 @@ class Meshing:
         ----------
         vol
             Number of the volume containing the tetrahedral elements to be
-            improved.  If VOL = ALL (default), improve the tetrahedral elements
-            in all selected volumes.  If VOL = P, graphical picking is enabled
+            improved.  If ``VOL = ALL`` (default), improve the tetrahedral elements
+            in all selected volumes.  If ``VOL = P``, graphical picking is enabled
             and all remaining command fields are ignored (valid only in the
-            GUI).  A component name may also be substituted for VOL.
+            GUI).  A component name may also be substituted for ``VOL``.
 
         chgbnd
             Specifies whether to allow boundary modification.  Boundary
             modification includes such things as changes in the connectivity of
             the element faces on the boundary and the addition of boundary
             nodes.  (Also see "Notes" below for important usage information for
-            CHGBND.)
+            ``CHGBND``.)
 
             0 - Do not allow boundary modification.
 
@@ -2782,21 +2782,21 @@ class Meshing:
 
             2 - Perform the greatest amount of swapping/smoothing.
 
-            3 - Perform the greatest amount of swapping/smoothing, plus additional improvement
-                techniques (default).
+            3 - Perform the greatest amount of swapping/smoothing, plus
+            additional improvement techniques (default).
 
         Notes
         -----
-        VIMP is useful for further improving a volume mesh created in ANSYS
-        [VMESH], especially quadratic tetrahedral element meshes.
+        ``VIMP`` is useful for further improving a volume mesh created in ANSYS
+        [``VMESH``], especially quadratic tetrahedral element meshes.
 
-        The VIMP command enables you to improve a given tetrahedral mesh by
+        The ``VIMP`` command enables you to improve a given tetrahedral mesh by
         reducing the number of poorly-shaped tetrahedral elements (in
         particular, the number of sliver tetrahedral elements)--as well as the
         overall number of elements--in the mesh.  It also improves the overall
         quality of the mesh.
 
-        Regardless of the value of the CHGBND argument, boundary mid-nodes can
+        Regardless of the value of the ``CHGBND`` argument, boundary mid-nodes can
         be moved.
 
         When loads or constraints have been placed on boundary nodes or mid-
@@ -2804,11 +2804,11 @@ class Meshing:
         message to let you know that it will not update the loads or
         constraints.
 
-        Even when CHGBND = 1, no boundary modification is performed on areas
+        Even when ``CHGBND = 1``, no boundary modification is performed on areas
         and lines that are not modifiable (for example, areas that are adjacent
         to other volumes or that contain shell elements, or lines that are not
         incident on modifiable areas, contain beam elements, or have line
-        divisions specified for them [LESIZE]).
+        divisions specified for them [``LESIZE``]).
         """
         command = f"VIMP,{vol},{chgbnd},{implevel}"
         return self.run(command, **kwargs)

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1540,26 +1540,19 @@ class MapdlGrpc(_MapdlCore):
         recursive : bool
             Use recursion when using glob pattern.
 
-        .. warning::
-            This feature is only available for MAPDL 2021R1 or newer.
+        .. warning:: This feature is only available for MAPDL 2021R1 or newer.
 
         .. note::
-            * The glob pattern search does not search recursively in remote instances.
-            * In a remote instance, it is not possible to list or download files in different
-              locations than the MAPDL working directory.
-            * If you are in local and provide a file path, downloading files
-              from a different folder is allowed.
-              However it is not a recommended approach.
+           * The glob pattern search does not search recursively in remote instances.
+           * In a remote instance, it is not possible to list or download files in different
+               locations than the MAPDL working directory.
+           * If you are in local and provide a file path, downloading files
+               from a different folder is allowed.
+               However it is not a recommended approach.
 
         Examples
         --------
-        Download all the simulation files ('out', 'full', 'rst', 'cdb', 'err', 'db', or 'log'):
 
-        >>> mapdl.download('all')
-
-        Download every single file in the MAPDL workind directory:
-
-        >>> mapdl.download('everything')
 
         Download a single file:
 
@@ -1568,6 +1561,14 @@ class MapdlGrpc(_MapdlCore):
         Download all the files starting with `'file'`:
 
         >>> mapdl.download('file*')
+
+        Download every single file in the MAPDL workind directory:
+
+        >>> mapdl.download('*.*')
+
+        Alternatively, you can download all the files using :func:`Mapdl.download_project <ansys.mapdl.core.Mapdl.download_project>` (Recommended):
+
+        >>> mapdl.download_project()
 
         """
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1477,7 +1477,7 @@ class MapdlGrpc(_MapdlCore):
 
         raise RuntimeError(f"Unsupported type {getresponse.type} response from MAPDL")
 
-    def download_project(self, extensions=None, target_dir=None):  # pragma: no cover
+    def download_project(self, extensions=None, target_dir=None):
         """Download all the project files located in the MAPDL working directory.
 
         Parameters
@@ -1517,6 +1517,8 @@ class MapdlGrpc(_MapdlCore):
     ):  # pragma: no cover
         """Download files from the gRPC instance workind directory
 
+        .. warning:: This feature is only available for MAPDL 2021R1 or newer.
+
         Parameters
         ----------
         files : str or List[str] or Tuple(str)
@@ -1540,20 +1542,19 @@ class MapdlGrpc(_MapdlCore):
         recursive : bool
             Use recursion when using glob pattern.
 
-        .. warning:: This feature is only available for MAPDL 2021R1 or newer.
+        Notes
+        -----
+        There are some considerations to keep in mind when using this command:
 
-        .. note::
-           * The glob pattern search does not search recursively in remote instances.
-           * In a remote instance, it is not possible to list or download files in different
-               locations than the MAPDL working directory.
-           * If you are in local and provide a file path, downloading files
-               from a different folder is allowed.
-               However it is not a recommended approach.
+        * The glob pattern search does not search recursively in remote instances.
+        * In a remote instance, it is not possible to list or download files in different
+          locations than the MAPDL working directory.
+        * If you are in local and provide a file path, downloading files
+          from a different folder is allowed.
+          However it is not a recommended approach.
 
         Examples
         --------
-
-
         Download a single file:
 
         >>> mapdl.download('file.out')
@@ -1566,11 +1567,18 @@ class MapdlGrpc(_MapdlCore):
 
         >>> mapdl.download('*.*')
 
-        Alternatively, you can download all the files using :func:`Mapdl.download_project <ansys.mapdl.core.Mapdl.download_project>` (Recommended):
+        Alternatively, you can download all the files using
+        :func:`Mapdl.download_project <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download_project>` (recommended):
 
         >>> mapdl.download_project()
 
         """
+
+        if chunk_size > 4 * 1024 * 1024:  # 4MB
+            raise ValueError(
+                f"Chunk sizes bigger than 4 MB can generate unstable behaviour in PyMAPDL. "
+                "Please decrease ``chunk_size`` value."
+            )
 
         self_files = self.list_files()  # to avoid calling it too much
 


### PR DESCRIPTION
Closes #1020 by reflecting the code changes made in #928 in the `download` docstring example section.

I also add a `chunk_size` check, and fix the `VIMP` docstring.