### PR TITLE
Fix misspelled `_channel_str` attribute

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -380,7 +380,7 @@ class MapdlGrpc(_MapdlCore):
 
         if not connected:
             raise IOError(
-                f"Unable to connect to MAPDL gRPC instance at {self._target_str}"
+                f"Unable to connect to MAPDL gRPC instance at {self._channel_str}"
             )
 
     @property

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -204,3 +206,10 @@ def test_elems_push(elems):
 
     with pytest.raises(ValueError, match="`elmdat` must be length 10"):
         elems.push(ielm_new, [1, 2, 3], elem_info.nodes)
+
+
+def test__channel_str(db):
+    assert db._channel_str is not None
+    assert ":" in db._channel_str
+    assert re.search("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", db._channel_str)
+    assert re.search("\d{4,6}", db._channel_str)

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -359,3 +359,10 @@ def test_download_project_extensions(mapdl, tmpdir):
     assert "out" in files_extensions
     assert "err" not in files_extensions
     assert "lock" not in files_extensions
+
+
+def test__channel_str(mapdl):
+    assert mapdl._channel_str is not None
+    assert ":" in mapdl._channel_str
+    assert re.search("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", mapdl._channel_str)
+    assert re.search("\d{4,6}", mapdl._channel_str)


### PR DESCRIPTION
As the title. This was showing when PyMAPDL wasn't able to connect. 

This was introduced in #996 