### PR TITLE
Changing priority between env_vars and args.

### DIFF
--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -18,7 +18,15 @@ from ansys.mapdl.core.errors import LockFileException, VersionError
 from ansys.mapdl.core.licensing import ALLOWABLE_LICENSES, LicenseChecker
 from ansys.mapdl.core.mapdl import _MapdlCore
 from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
-from ansys.mapdl.core.misc import create_temp_dir, is_float, random_string, threaded
+from ansys.mapdl.core.misc import (
+    check_valid_ip,
+    check_valid_port,
+    check_valid_start_instance,
+    create_temp_dir,
+    is_float,
+    random_string,
+    threaded,
+)
 
 # settings directory
 SETTINGS_DIR = appdirs.user_data_dir("ansys_mapdl_core")
@@ -800,7 +808,7 @@ def launch_mapdl(
     start_timeout=120,
     port=None,
     cleanup_on_exit=True,
-    start_instance=True,
+    start_instance=None,
     ip=None,
     clear_on_connect=True,
     log_apdl=None,
@@ -1076,12 +1084,18 @@ def launch_mapdl(
 
     if ip is None:
         ip = os.environ.get("PYMAPDL_IP", LOCALHOST)
+        check_valid_ip(ip)
 
     if port is None:
         port = int(os.environ.get("PYMAPDL_PORT", MAPDL_DEFAULT_PORT))
+        check_valid_port(port)
 
     # connect to an existing instance if enabled
-    if not get_start_instance(start_instance):
+    if start_instance is None:
+        start_instance = os.environ.get("PYMAPDL_START_INSTANCE", True)
+        start_instance = check_valid_start_instance(start_instance)
+
+    if not start_instance:
         mapdl = MapdlGrpc(
             ip=ip,
             port=port,

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -801,7 +801,7 @@ def launch_mapdl(
     port=None,
     cleanup_on_exit=True,
     start_instance=True,
-    ip=LOCALHOST,
+    ip=None,
     clear_on_connect=True,
     log_apdl=None,
     verbose_mapdl=False,
@@ -1073,11 +1073,12 @@ def launch_mapdl(
     """
     # These parameters are partially used for unit testing
     set_no_abort = kwargs.get("set_no_abort", True)
-    ip = os.environ.get("PYMAPDL_IP", ip)
-    if "PYMAPDL_PORT" in os.environ:
-        port = int(os.environ.get("PYMAPDL_PORT", "50052"))
+
+    if ip is None:
+        ip = os.environ.get("PYMAPDL_IP", LOCALHOST)
+
     if port is None:
-        port = MAPDL_DEFAULT_PORT
+        port = int(os.environ.get("PYMAPDL_PORT", MAPDL_DEFAULT_PORT))
 
     # connect to an existing instance if enabled
     if not get_start_instance(start_instance):

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -7,7 +7,6 @@ import io
 import os
 import re
 import shutil
-import socket
 import subprocess
 import tempfile
 import threading
@@ -56,6 +55,7 @@ from ansys.mapdl.core.common_grpc import (
 from ansys.mapdl.core.errors import MapdlExitedError, MapdlRuntimeError, protect_grpc
 from ansys.mapdl.core.mapdl import _MapdlCore
 from ansys.mapdl.core.misc import (
+    check_valid_ip,
     last_created,
     random_string,
     run_as_prep7,
@@ -159,13 +159,6 @@ class RepeatingTimer(threading.Timer):
         while not self.finished.is_set():
             self.function(*self.args, **self.kwargs)
             self.finished.wait(self.interval)
-
-
-def check_valid_ip(ip):
-    """Check for valid IP address"""
-    if ip != "localhost":
-        ip = ip.replace('"', "").replace("'", "")
-        socket.inet_aton(ip)
 
 
 class MapdlGrpc(_MapdlCore):

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -380,7 +380,7 @@ class MapdlGrpc(_MapdlCore):
 
         if not connected:
             raise IOError(
-                f"Unable to connect to MAPDL gRPC instance at {self._target_str}"
+                f"Unable to connect to MAPDL gRPC instance at {self._channel_str}"
             )
 
     @property

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -383,7 +383,7 @@ def load_file(mapdl, fname):
 
 def check_valid_ip(ip):
     """Check for valid IP address"""
-    if ip != "localhost":
+    if ip.lower() != "localhost":
         ip = ip.replace('"', "").replace("'", "")
         socket.inet_aton(ip)
 
@@ -415,7 +415,7 @@ def check_valid_start_instance(start_instance):
     if isinstance(start_instance, bool):
         return start_instance
 
-    else:  # str
+    else:
         if start_instance.lower() not in ["true", "false"]:
             raise ValueError(
                 f"The value 'start_instance' should be equal to 'True' or 'False' (case insensitive)."

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import platform
 import random
+import socket
 import string
 import sys
 import tempfile
@@ -378,3 +379,46 @@ def load_file(mapdl, fname):
 
     # Simplifying name for MAPDL reads it.
     return os.path.basename(fname)
+
+
+def check_valid_ip(ip):
+    """Check for valid IP address"""
+    if ip != "localhost":
+        ip = ip.replace('"', "").replace("'", "")
+        socket.inet_aton(ip)
+
+
+def check_valid_port(port, lower_bound=1000, high_bound=60000):
+    if not isinstance(port, int):
+        raise ValueError("The 'port' parameter should be an integer.")
+
+    if lower_bound < port < high_bound:
+        return
+    else:
+        raise ValueError(
+            f"'port' values should be between {lower_bound} and {high_bound}."
+        )
+
+
+def check_valid_start_instance(start_instance):
+    """
+    Checks if the value obtained from the environmental variable is valid.
+
+    Parameters
+    ----------
+    start_instance : str
+        Value obtained from the correspondent environment variable.
+    """
+    if not isinstance(start_instance, (str, bool)):
+        raise ValueError("The value 'start_instance' should be an string or a boolean.")
+
+    if isinstance(start_instance, bool):
+        return start_instance
+
+    else:  # str
+        if start_instance.lower() not in ["true", "false"]:
+            raise ValueError(
+                f"The value 'start_instance' should be equal to 'True' or 'False' (case insensitive)."
+            )
+        else:
+            return start_instance.lower() == True

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -204,3 +206,10 @@ def test_elems_push(elems):
 
     with pytest.raises(ValueError, match="`elmdat` must be length 10"):
         elems.push(ielm_new, [1, 2, 3], elem_info.nodes)
+
+
+def test__channel_str(db):
+    assert db._channel_str is not None
+    assert ":" in db._channel_str
+    assert re.search("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", db._channel_str)
+    assert re.search("\d{4,6}", db._channel_str)

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -359,3 +359,10 @@ def test_download_project_extensions(mapdl, tmpdir):
     assert "out" in files_extensions
     assert "err" not in files_extensions
     assert "lock" not in files_extensions
+
+
+def test__channel_str(mapdl):
+    assert mapdl._channel_str is not None
+    assert ":" in mapdl._channel_str
+    assert re.search("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", mapdl._channel_str)
+    assert re.search("\d{4,6}", mapdl._channel_str)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,9 +1,64 @@
 """Small or misc tests that don't fit in other test modules"""
+import pytest
 from pyvista.plotting import system_supports_plotting
 
 from ansys.mapdl import core as pymapdl
+from ansys.mapdl.core.misc import (
+    check_valid_ip,
+    check_valid_port,
+    check_valid_start_instance,
+)
 
 
 def test_report():
     report = pymapdl.Report(gpu=system_supports_plotting())
     assert "PyMAPDL Software and Environment Report" in str(report)
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "localhost",
+        "LOCALhost",
+        "192.1.1.1",
+        "127.0.0.01",
+        pytest.param("asdf", marks=pytest.mark.xfail),
+        pytest.param("300.2.2.2", marks=pytest.mark.xfail),
+    ],
+)
+def test_check_valid_ip(ip):
+    check_valid_ip(ip)
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        5000,
+        50053,
+        10000,
+        pytest.param("asdf", marks=pytest.mark.xfail),
+        pytest.param("2323", marks=pytest.mark.xfail),
+        pytest.param(1, marks=pytest.mark.xfail),
+        pytest.param(1e9, marks=pytest.mark.xfail),
+    ],
+)
+def test_check_valid_port(port):
+    check_valid_port(port)
+
+
+@pytest.mark.parametrize(
+    "start_instance",
+    [
+        "true",
+        "TRue",
+        "False",
+        True,
+        False,
+        pytest.param("asdf", marks=pytest.mark.xfail),
+        pytest.param("2323", marks=pytest.mark.xfail),
+        pytest.param(1, marks=pytest.mark.xfail),
+        pytest.param(1e9, marks=pytest.mark.xfail),
+    ],
+)
+def test_check_valid_start_instance(start_instance):
+    check_valid_start_instance(start_instance)


### PR DESCRIPTION
### Current behavior:
When using any of the arguments `ip`, `port` and/or `start_instance` together with the env vars `PYMAPDL_IP`, `PYMAPDL_PORT` and `PYMAPDL_START_INSTANCE`, the environment variables have priority over the specified corresponding arguments. I believe this is not the most convenient.

### Proposed solution:

The priority will be:

1. Specified argument
2. Environment variable
3. Default argument

### Related issues

This respond to some comments made in #1014 which will help to fix.