### PR TITLE
Docstring formatting issues

### DIFF
--- a/src/ansys/mapdl/core/_commands/apdl/array_param.py
+++ b/src/ansys/mapdl/core/_commands/apdl/array_param.py
@@ -1224,13 +1224,13 @@ class ArrayParam:
         element of B and stores the result in the first element of A.
         Operations continue on successive array elements ``[*VLEN, *VMASK]`` with
         the default being all successive elements.  Skipping array elements via
-        ``*VMASK`` or ``*VLEN`` for the DER and INT functions skips only the writing
+        ``*VMASK`` or ``*VLEN`` for the ``DER`` and ``INT`` functions skips only the writing
         of the results (skipped array element data are used in all
         calculations).
 
         Parameter functions and operations are available to operate on a scalar
-        parameter or a single element of an array parameter, such as SQRT(B) or
-        SQRT(A(4)).  See the ``*SET`` command for details.  Operations on a
+        parameter or a single element of an array parameter, such as ``SQRT(B)`` or
+        ``SQRT(A(4))``.  See the ``*SET`` command for details.  Operations on a
         sequence of array elements can be done by repeating the desired
         function or operation in a do-loop ``[*DO]``.  The vector operations within
         the ANSYS program (``*VXX`` commands) are internally programmed do-loops

--- a/src/ansys/mapdl/core/_commands/apdl/array_param.py
+++ b/src/ansys/mapdl/core/_commands/apdl/array_param.py
@@ -1077,7 +1077,7 @@ class ArrayParam:
 
             * ``LT``
               Less than comparison: ``Par1<Par2`` gives 1.0 if true, 0.0 if
-            false.
+              false.
 
             * ``LE``
               Less than or equal comparison: ``Par1 <= Par2`` gives
@@ -1103,7 +1103,7 @@ class ArrayParam:
               First derivative:
 
               .. math::
-                 \dfrac{\partial(Par1)}{\partial(Par2)}
+                 \dfrac{\mathrm{d}(\mathrm{Par1})}{\mathrm{d}(\mathrm{Par2})}
 
               The derivative at a point is determined over points
               half way between the previous and next points
@@ -1116,7 +1116,7 @@ class ArrayParam:
               Second derivative:
 
               .. math::
-                 \dfrac{\partial^2(Par1)}{\partial(Par2)^2}
+                 \dfrac{\mathrm{d}^2(\mathrm{Par1})}{\mathrm{d}(\mathrm{Par2})^2}
 
               See also ``DER1``.
 

--- a/src/ansys/mapdl/core/_commands/apdl/array_param.py
+++ b/src/ansys/mapdl/core/_commands/apdl/array_param.py
@@ -239,7 +239,7 @@ class ArrayParam:
               * ``Par1`` is the ``Nout`` x 3 array of points that will be mapped
                 to. ``Par2`` is the ``Nin`` x ``M`` array that contains ``M`` values of
                 data to be interpolated at each point and corresponds to
-                the ``Nin`` x 3 points in Par3. The resulting ``ParR`` is the ``Nout``
+                the ``Nin`` x 3 points in ``Par3``. The resulting ``ParR`` is the ``Nout``
                 x ``M`` array of mapped data points.
 
                 For each point in the destination mesh, all possible
@@ -292,7 +292,7 @@ class ArrayParam:
 
             * ``Val1, Val2, ..., Val6``
               Additional input used in the operation. The meanings of
-              Val1 through Val6 vary depending on the specified matrix
+              ``Val1`` through ``Val6`` vary depending on the specified matrix
               operation. See the description of Oper for details.
         """
         command = (
@@ -322,11 +322,11 @@ class ArrayParam:
             Filename extension (eight-character maximum).
 
         label
-            Can use a value of IJK, IKJ, JIK, JKI, KIJ, KJI, or blank (JIK).
+            Can use a value of ``IJK``, ``IKJ``, ``JIK``, ``JKI``, ``KIJ``, ``KJI``, or blank (``JIK``).
 
         n1, n2, n3
-            Write as (((ParR(i,j,k), k = 1,n1), i = 1, n2), j = 1, n3) for
-            Label = KIJ. n1, n2, and n3 default to the corresponding dimensions
+            Write as ``(((ParR(i,j,k), k = 1,n1), i = 1, n2), j = 1, n3)`` for
+            ``Label = KIJ``. ``n1``, ``n2``, and ``n3`` default to the corresponding dimensions
             of the array parameter ParR.
 
         Notes
@@ -370,7 +370,7 @@ class ArrayParam:
         to this command, while ``*VCUM`` does not apply to this command. See the
         ``*VOPER`` command for details. If you are in the GUI, the ``*MWRITE`` command
         must be contained in an externally prepared file and read into ANSYS
-        (i.e., ``*USE``, /INPUT, etc.).
+        (i.e., ``*USE``, ``/INPUT``, etc.).
 
         This command is valid in any processor.
         """
@@ -526,7 +526,7 @@ class ArrayParam:
             Name of the first table parameter.
 
         oper
-            The operation to be performed: ADD.  The operation is:
+            The operation to be performed: ``ADD``.  The operation is:
             ``ParR(i,j,k) = FACT1*Par1(i,j,k) + FACT2 *Par2(i,j,k) +CON1``
 
         par2
@@ -568,22 +568,22 @@ class ArrayParam:
         kabsr
             Absolute value of results parameter:
 
-            Do not take absolute value of results parameter (ParR). - Take absolute value.
+            Do not take absolute value of results parameter (``ParR``). - Take absolute value.
 
         kabs1
             Absolute value of first parameter:
 
-            Do not take absolute value of first parameter (Par1 or ParI). - Take absolute value.
+            Do not take absolute value of first parameter (``Par1`` or ``ParI``). - Take absolute value.
 
         kabs2
             Absolute value of second parameter:
 
-            Do not take absolute value of second parameter (Par2 or ParJ). - Take absolute value.
+            Do not take absolute value of second parameter (``Par2`` or ``ParJ``). - Take absolute value.
 
         kabs3
             Absolute value of third parameter:
 
-            Do not take absolute value of third parameter (Par3 or ParK). - Take absolute value.
+            Do not take absolute value of third parameter (``Par3`` or ``ParK``). - Take absolute value.
 
         Notes
         -----
@@ -683,18 +683,18 @@ class ArrayParam:
         Parameters
         ----------
         factr
-            Scale factor applied to results (ParR) parameter.  Defaults to 1.0.
+            Scale factor applied to results (``ParR``) parameter.  Defaults to 1.0.
 
         fact1
-            Scale factor applied to first parameter (Par1 or ParI).  Defaults
+            Scale factor applied to first parameter (``Par1`` or ``ParI``).  Defaults
             to 1.0.
 
         fact2
-            Scale factor applied to second parameter (Par2 or ParJ).  Defaults
+            Scale factor applied to second parameter (``Par2`` or ``ParJ``).  Defaults
             to 1.0.
 
         fact3
-            Scale factor applied to third parameter (Par3 or ParK).  Defaults
+            Scale factor applied to third parameter (``Par3`` or ``ParK``).  Defaults
             to 1.0.
 
         Notes
@@ -732,54 +732,152 @@ class ArrayParam:
         func
             Function to be performed:
 
-            Arccosine: ACOS(Par1). - Arcsine: ASIN(Par1).
+            * ACOS
+              Arccosine: ``ACOS(Par1)``.
 
-            Par1 is sorted in ascending order.  ``*VCOL``, ``*VMASK``,
-            ``*VCUM``, and ``*VLEN,,NINC`` do not apply.
-            ``*VLEN,NROW`` does apply.
+            * ``ASIN``
+              Arcsine: ``ASIN(Par1)``.
 
-            Compress: Selectively compresses data set.  "True"
-            (``*VMASK``) values of Par1 (or row positions to be considered
-            according to the NINC value on the ``*VLEN`` command) are
-            written in compressed form to ParR, starting at the
-            specified position. - Copy: Par1 copied to ParR.
+            * ``ASORT``
+              ``Par1`` is sorted in ascending order.  ``*VCOL``, ``*VMASK``,
+              ``*VCUM``, and ``*VLEN,,NINC`` do not apply.
+              ``*VLEN,NROW`` does apply.
 
-            Cosine: COS(Par1). - Hyperbolic cosine: COSH(Par1).
+            * ``ATAN``
+              Arctangent: ``ATAN(Par1)``
 
-            Direction cosines of the principal stresses (nX9).  Par1
-            contains the nX6 component stresses for the n locations of
-            the calculations. - Par1 is sorted in descending order.
-            ``*VCOL``, ``*VMASK``, ``*VCUM``, and ``*VLEN,,NINC`` do not apply.
-            ``*VLEN,NROW`` does apply.
+            * ``COMP``
+              Compress: Selectively compresses data set.  "True"
+              (``*VMASK``) values of ``Par1`` (or row positions to be considered
+              according to the ``NINC`` value on the ``*VLEN`` command) are
+              written in compressed form to ``ParR``, starting at the
+              specified position.
 
-            Euler angles of the principal stresses (nX3).  Par1
-            contains the nX6 component stresses for the n locations of
-            the calculations. - Exponential: EXP(Par1).
+            * ``COPY``
+              Copy: ``Par1`` copied to ``ParR``.
 
-            Expand: Reverse of the COMP function.  All elements of
-            Par1 (starting at the position specified) are written in
-            expanded form to corresponding "true" (``*VMASK``) positions
-            (or row positions to be considered according to the NINC
-            value on the ``*VLEN`` command) of ParR. - Natural logarithm:
-            LOG(Par1).
+            * ``COS``
+              Cosine: ``COS(Par1)``.
 
-            Common logarithm: LOG10(Par1). - Nearest integer: 2.783
-            becomes 3.0, -1.75 becomes -2.0.
+            * ``COSH``
+              Hyperbolic cosine: ``COSH(Par1)``.
 
-            Logical complement: values 0.0 (false) become 1.0 (true).
-            Values > 0.0 (true) become 0.0 (false). - Principal
-            stresses (nX5). Par1 contains the nX6 component stresses
-            for the n locations of the calculations.
+            * ``DIRCOS``
+              Direction cosines of the principal stresses (nX9).  ``Par1``
+              contains the nX6 component stresses for the ``n`` locations of
+              the calculations.
 
-            Power function: ``Par1**CON1``. Exponentiation of any negative
-            number in the vector Par1 to a non-integer power is
-            performed by exponentiating the positive number and
-            prepending the minus sign. For example, ``-4**2.3`` is
-            ``-(4**2.3)``.
+            * ``DSORT``
+              ``Par1`` is sorted in descending order.
+              ``*VCOL``, ``*VMASK``, ``*VCUM``, and ``*VLEN,,NINC`` do not apply.
+              ``*VLEN,NROW`` does apply.
 
-            Hyperbolic sine: SINH(Par1). - Square root: SQRT(Par1).
+            * ``EURLER``
+              Euler angles of the principal stresses (nX3).  ``Par1``
+              contains the nX6 component stresses for the ``n`` locations of
+              the calculations.
 
-            Tangent: TAN(Par1). - Hyperbolic tangent: TANH(Par1).
+            * ``EXP``
+              Exponential: ``EXP(Par1)``.
+
+            * ``EXPA``
+              Expand: Reverse of the COMP function.  All elements of
+              ``Par1`` (starting at the position specified) are written in
+              expanded form to corresponding "true" (``*VMASK``) positions
+              (or row positions to be considered according to the ``NINC``
+              value on the ``*VLEN`` command) of ``ParR``.
+
+            * ``LOG``
+              Natural logarithm: ``LOG(Par1)``.
+
+            * ``LOG10``
+              Common logarithm: ``LOG10(Par1)``.
+
+            * ``NINT``
+              Nearest integer: 2.783 becomes 3.0, -1.75 becomes -2.0.
+
+            * ``NOT``
+              Logical complement: values 0.0 (false) become 1.0 (true).
+              Values > 0.0 (true) become 0.0 (false).
+
+            * ``PRIN``
+              Principal stresses (nX5). ``Par1`` contains the ``nX6`` component stresses
+              for the ``n`` locations of the calculations.
+
+            * ``PWR``
+              Power function: ``Par1**CON1``. Exponentiation of any negative
+              number in the vector ``Par1`` to a non-integer power is
+              performed by exponentiating the positive number and
+              prepending the minus sign. For example, ``-4**2.3`` is
+              ``-(4**2.3)``.
+
+            * ``SIN``
+              Sine: ``SIN(Par1)``
+
+            * ``SINH``
+              Hyperbolic sine: ``SINH(Par1)``.
+
+            * ``SQRT``
+              Square root: ``SQRT(Par1)``.
+
+            * ``TAN``
+              Tangent: ``TAN(Par1)``.
+
+            * ``TANH``
+              Hyperbolic tangent: ``TANH(Par1)``.
+
+            * ``TANG``
+              Tangent to a path at a point: the slope at a point is determined by linear interpolation half
+              way between the previous and next points. Points are assumed to be in the global Cartesian
+              coordinate system. Path points are specified in array ``Par1`` (having 3 consecutive columns
+              of data, with the columns containing the ``x``, ``y``, and ``z`` coordinate locations, respectively, of
+              the points). Only the starting row index and the column index for the x coordinates are
+              specified, such as ``A(1,1)``. The y and z coordinates of the vector are assumed to begin in the
+              corresponding next columns, such as ``A(1,2)`` and ``A(1,3)``. The tangent result, ``ParR``, must also
+              have 3 consecutive columns of data and will contain the tangent direction vector (normalized
+              to 1.0); such as 1,0,0 for an x-direction vector.
+
+            * ``NORM``
+              Normal to a path and an input vector at a point: determined from the cross-product of the
+              calculated tangent vector (see ``TANG``) and the input direction vector (with the ``i``,
+              ``j``, and ``k`` components input as ``CON1``, ``CON2``, and ``CON3``).
+              Points are assumed to be in the global Cartesian coordinate system.
+              Path points are specified in array ``Par1`` (having 3 consecutive
+              columns of data, with the columns containing the ``x``, ``y``, and ``z``
+              coordinate locations, respectively, of the points).
+              Only the starting row index and the column index for the ``x`` coordinates
+              are specified, such as ``A(1,1)``. The ``y`` and ``z`` coordinates of the vector are assumed to begin
+              in the corresponding next columns, such as ``A(1,2)`` and ``A(1,3)``. The normal result, ``ParR``,
+              must also have 3 consecutive columns of data and will contain the normal direction vector
+              (normalized to 1.0); such as ``1,0,0`` for an x-direction vector
+
+            * ``LOCAL``
+              Transforms global Cartesian coordinates of a point to the coordinates of a specified system:
+              points to be transformed are specified in array ``Par1`` (having 3 consecutive columns of
+              data, with the columns containing the ``x``, ``y``, and ``z`` global Cartesian coordinate locations,
+              respectively, of the points).
+              Only the starting row index and the column index for the ``x``
+              coordinates are specified, such as ``A(1,1)``.
+              The y and z coordinates of the vector are assumed
+              to begin in the corresponding next columns, such as ``A(1,2)`` and ``A(1,3)``.
+              Results are transformed to coordinate system ``CON1`` (which may be any valid coordinate system number,
+              such as 1,2,11,12, etc.). The transformed result, ``ParR``, must also have 3 consecutive columns
+              of data and will contain the corresponding transformed coordinate locations.
+
+            * ``GLOBAL``
+              Transforms specified coordinates of a point to global Cartesian coordinates: points to be
+              transformed are specified in array ``Par1`` (having 3 consecutive columns of data, with the
+              columns containing the local coordinate locations (``x``, ``y``, ``z`` or ``r``, ``θ``, ``z``
+              or etc.) of the points).
+              Only the starting row index and the column index for the x coordinates are specified, such
+              as ``A(1,1)``.
+              The y and z coordinates (or ``θ`` and ``z``, or etc.) of the vector are assumed to begin
+              in the corresponding next columns, such as ``A(1,2)`` and ``A(1,3)``.
+              Local coordinate locations are assumed to be in coordinate system ``CON1``
+              (which may be any valid coordinate system number, such as 1,2,11,12, etc.).
+              The transformed result, ``ParR``, must also have 3 consecutive
+              columns of data, with the columns containing the global Cartesian ``x``, y, and z coordinate
+              locations, respectively.
 
         par1
             Array parameter vector in the operation.
@@ -828,22 +926,22 @@ class ArrayParam:
 
         Notes
         -----
-        Forms an array parameter (of type ARRAY) by interpolating values of an
-        array parameter (of type TABLE) at specified table index locations
+        Forms an array parameter (of type ``ARRAY``) by interpolating values of an
+        array parameter (of type ``TABLE``) at specified table index locations
         according to:
 
-        ParR = f(ParT, Parl, ParJ, ParK)
+        ``ParR = f(ParT, Parl, ParJ, ParK)``
 
-        where ParT is the type TABLE array parameter, and ParI, ParJ, ParK are
-        the type ARRAY array parameter vectors of index values for
-        interpolation in ParT.  See the ``*DIM`` command for TABLE and ARRAY
+        where ``ParT`` is the type ``TABLE`` array parameter, and ``ParI``, ``ParJ``, ``ParK`` are
+        the type ``ARRAY`` array parameter vectors of index values for
+        interpolation in ``ParT``.  See the ``*DIM`` command for ``TABLE`` and ``ARRAY``
         declaration types.  Linear interpolation is used.  The starting array
-        element number for the TABLE array (ParT) is not used (but a value must
+        element number for the ``TABLE`` array (``ParT``) is not used (but a value must
         be input).  Starting array element numbers must be defined for each
         array parameter vector if it does not start at the first location. For
         example, ``*VITRP,R(5),TAB(1,1),X(2),Y(4)`` uses the second element of X
         and the fourth element of Y as index values (row and column) for a 2-D
-        interpolation in TAB and stores the result in the fifth element of R.
+        interpolation in ``TAB`` and stores the result in the fifth element of R.
         Operations continue on successive array elements ``[*VLEN, *VMASK]`` with
         the default being all successive elements.  Absolute values and scale
         factors may be applied to the result parameter ``[*VABS, *VFACT]``.
@@ -874,25 +972,25 @@ class ArrayParam:
         The size of the submatrix used is determined from the upper left
         starting array element (defined on the operation command) to the lower
         right array element (defined by the number of rows on this command and
-        the number of columns on the ``*VCOL`` command).  NINC allows skipping row
+        the number of columns on the ``*VCOL`` command).  ``NINC`` allows skipping row
         operations for some operation commands.  Skipped rows are included in
         the row count.  The starting row number must be defined on the
         operation command for each parameter read and for the result written.
 
-        The default NROW is calculated from the maximum number of rows of the
+        The default ``NROW`` is calculated from the maximum number of rows of the
         result array (the ``*DIM`` row dimension) minus the starting location + 1.
-        For example, ``*DIM,R,,10`` and a starting location of R(7) gives a default
-        of 4 loops (filling R(7), R(8), R(9), and R(10)).  Repeat operations
+        For example, ``*DIM,R,,10`` and a starting location of ``R(7)`` gives a default
+        of 4 loops (filling ``R(7)``, ``R(8)``, ``R(9)``, and ``R(10)``).  Repeat operations
         automatically terminate at the last row of the result array.  Existing
         values in the rows and columns of the results matrix remain unchanged
         where not overwritten by the requested input or operation values.
 
-        The stride (NINC) allows operations to be performed at regular
+        The stride (``NINC``) allows operations to be performed at regular
         intervals.  It has no effect on the total number of row operations.
         Skipped operations retain the previous result.  For example, ``*DIM,R,,6,``
-        with a starting location of R(1), NROW = 10, and NINC = 2 calculates
-        values for locations R(1), R(3), and R(5) and retains values for
-        locations R(2), R(4), and R(6).  A more general skip control may be
+        with a starting location of ``R(1)``, ``NROW = 10``, and ``NINC = 2`` calculates
+        values for locations ``R(1)``, ``R(3)``, and ``R(5)`` and retains values for
+        locations ``R(2)``, ``R(4)``, and ``R(6)``.  A more general skip control may be
         done by masking ``[*VMASK]``.  The row control settings are reset to the
         defaults after each ``*VXX`` or ``*MXX`` operation.  Use ``*VSTAT`` to list
         settings.
@@ -921,16 +1019,17 @@ class ArrayParam:
         corresponding mask vector value is checked.  A true value allows the
         operation to be done.  A false value skips the operation (and retains
         the previous results).  A mask vector can be created from direct input,
-        such as M(1) = 1,0,0,1,1,0,1; or from the DATA function of the ``*VFILL``
+        such as ``M(1) = 1,0,0,1,1,0,1``; or from the DATA function of the ``*VFILL``
         command.  The NOT function of the ``*VFUN`` command can be used to reverse
         the logical sense of the mask vector.  The logical compare operations
-        (LT, LE, EQ, NE, GE, and GT) of the ``*VOPER`` command also produce a mask
+        (``LT``, ``LE``, ``EQ``, ``NE``, ``GE``, and ``GT``) of
+        the ``*VOPER`` command also produce a mask
         vector by operating on two other vectors.  Any numeric vector can be
         used as a mask vector since the actual interpretation assumes values
         less than 0.0 are 0.0 (false) and values greater than 0.0 are 1.0
         (true).  If the mask vector is not specified (or has fewer values than
         the result vector), true (1.0) values are assumed for the unspecified
-        values.  Another skip control may be input with NINC on the ``*VLEN``
+        values.  Another skip control may be input with ``NINC`` on the ``*VLEN``
         command.  If both are present, operations occur only when both are
         true.  The mask setting is reset to the default (no mask) after each
         ``*VXX`` or ``*MXX`` operation.  Use ``*VSTAT`` to list settings.
@@ -947,106 +1046,177 @@ class ArrayParam:
 
         Parameters
         ----------
-        parr
+        PARR
             The name of the resulting array parameter vector.  See ``*SET``  for
             name restrictions.
 
-        par1
+        PAR1
             First array parameter vector in the operation.  May also be a
             scalar parameter or a literal constant.
 
-        oper
+        OPER
             Operations:
 
-            Addition: Par1+Par2. - Subtraction: Par1-Par2.
+            * ``ADD``
+              Addition: ``Par1+Par2``.
 
-            Multiplication: ``Par1*Par2``.
+            * ``SUB``
+              Subtraction: ``Par1-Par2``.
 
-            Division: Par1/Par2  (a divide by zero results in a value of zero).
+            * ``MULT``
+              Multiplication: ``Par1*Par2``.
 
-            Minimum: minimum of Par1 and Par2. - Maximum: maximum of Par1 and Par2.
+            * ``DIV``
+              Division: ``Par1/Par2``  (a divide by zero results in a value of zero).
 
-            Less than comparison: Par1<Par2 gives 1.0 if true, 0.0 if
-            false. - Less than or equal comparison: Par1 Par2 gives
-            1.0 if true, 0.0 if false.
+            * ``MIN``
+              Minimum: minimum of ``Par1`` and ``Par2``.
 
-            Equal comparison: Par1 = Par2 gives 1.0 if true, 0.0 if
-            false. - Not equal comparison: Par1 ≠ Par2 gives 1.0 if
-            true, 0.0 if false.
+            * ``MAX``
+              Maximum: maximum of ``Par1`` and ``Par2``.
 
-            Greater than or equal comparison: Par1 Par2 gives 1.0 if
-            true, 0.0 if false. - Greater than comparison: Par1>Par2
-            gives 1.0 if true, 0.0 if false.
+            * ``LT``
+              Less than comparison: ``Par1<Par2`` gives 1.0 if true, 0.0 if
+            false.
 
-            First derivative: d(Par1)/d(Par2).  The derivative at a
-            point is determined over points half way between the
-            previous and next points (by linear interpolation). Par1
-            must be a function (a unique Par1 value for each Par2
-            value) and Par2 must be in ascending order. - Second
-            derivative: d2(Par1)/d(Par2)2.  See also DER1.
+            * ``LE``
+              Less than or equal comparison: ``Par1 <= Par2`` gives
+              1.0 if true, 0.0 if false.
 
-            Single integral: Par1 d(Par2), where CON1 is the
-            integration constant.  The integral at a point is
-            determined by using the single integration procedure
-            described in the Mechanical APDL Theory Reference. -
-            Double integral: Par1 d(Par2), where CON1 is the
-            integration constant of the first integral and CON2 is the
-            integration constant of the second integral.  If Par1
-            contains acceleration data, CON1 is the initial velocity
-            and CON2 is the initial displacement.  See also INT1.
+            * ``EQ``
+              Equal comparison: ``Par1 = Par2`` gives 1.0 if true, 0.0 if
+              false.
 
-            Dot product: Par1 . Par2.  Par1 and Par2 must each have
-            three consecutive columns of data, with the columns
-            containing the i, j, and k vector components,
-            respectively.  Only the starting row index and the column
-            index for the i components are specified for Par1 and
-            Par2, such as A(1,1).  The j and k components of the
-            vector are assumed to begin in the corresponding next
-            columns, such as A(1,2) and A(1,3). - Cross product: Par1
-            x Par2.  Par1, Par2, and ParR must each have 3 components,
-            respectively.  Only the starting row index and the column
-            index for the i components are specified for Par1, Par2,
-            and ParR, such as A(1,1).  The j and k components of the
-            vector are assumed to begin in the corresponding next
-            columns, such as A(1,2) and A(1,3).
+            * ``NE``
+              Not equal comparison: ``Par1 ≠ Par2`` gives 1.0 if
+              true, 0.0 if false.
 
-            Gather: For a vector of position numbers, Par2, copy the
-            value of Par1 at each position number to ParR.  Example:
-            for Par1 = 10,20,30,40 and Par2 = 2,4,1; ParR =
-            20,40,10. - Scatter: Opposite of GATH operation.  For a
-            vector of position numbers, Par2, copy the value of Par1
-            to that position number in ParR.  Example: for Par1 =
-            10,20,30,40,50 and Par2 = 2,1,0,5,3; ParR = 20,10,50,0,40.
+            * ``GE``
+              Greater than or equal comparison: ``Par1 >= Par2`` gives 1.0 if
+              true, 0.0 if false.
 
-            Arctangent: arctangent of Par1/Par2 with the sign of each
-            component considered. - Transform the data in Par1 from
-            the global Cartesian coordinate system to the local
-            coordinate system given in CON1. Par1 must be an N x 3
-            (i.e., vector) or an N x 6 (i.e., stress or strain tensor)
-            array. If the local coordinate system is a cylindrical,
-            spherical, or toroidal system, then you must provide the
-            global Cartesian coordinates in Par2 as an N x 3 array.
-            Set CON2 = 1 if the data is strain data.
+            * ``GT``
+              Greater than comparison: ``Par1>Par2``
+              gives 1.0 if true, 0.0 if false.
 
-        par2
+            * ``DER``
+              First derivative:
+
+              .. math::
+                 \dfrac{\partial(Par1)}{\partial(Par2)}
+
+              The derivative at a point is determined over points
+              half way between the previous and next points
+              (by linear interpolation).
+              ``Par1`` must be a function (a unique ``Par1``
+              value for each ``Par2``
+              value) and ``Par2`` must be in ascending order.
+
+            * ``DER2``
+              Second derivative:
+
+              .. math::
+                 \dfrac{\partial^2(Par1)}{\partial(Par2)^2}
+
+              See also ``DER1``.
+
+            * ``INT1``
+              Single integral:
+
+              .. math::
+
+                 \int Par1 \, d(Par2)
+
+              where ``CON1`` is the integration constant.
+              The integral at a point is
+              determined by using the single integration procedure
+              described in the Mechanical APDL Theory Reference.
+
+            * ``INT2``
+              Double integral:
+
+              .. math::
+
+                 \iint Par1 \, d(Par2)
+
+              where ``CON1`` is the integration constant of the first
+              integral and ``CON2`` is the integration constant
+              of the second integral.  If ``Par1``
+              contains acceleration data, ``CON1`` is the initial velocity
+              and ``CON2`` is the initial displacement.  See also ``INT1``.
+
+            * ``DOT``
+              Dot product: ``Par1 . Par2``.
+              ``Par1`` and ``Par2`` must each have
+              three consecutive columns of data, with the columns
+              containing the ``i``, ``j``, and ``k`` vector components,
+              respectively.  Only the starting row index and the column
+              index for the ``i`` components are specified for ``Par1`` and
+              ``Par2``, such as ``A(1,1)``.  The ``j`` and ``k`` components of the
+              vector are assumed to begin in the corresponding next
+              columns, such as ``A(1,2)`` and ``A(1,3)``.
+
+            * ``CROSS``
+              Cross product: ``Par1 x Par2``.
+              ``Par1``, ``Par2``, and ``ParR`` must each have 3 components,
+              respectively.  Only the starting row index and the column
+              index for the i components are specified for ``Par1``, ``Par2``,
+              and ``ParR``, such as ``A(1,1)``.  The j and k components of the
+              vector are assumed to begin in the corresponding next
+              columns, such as ``A(1,2)`` and ``A(1,3)``.
+
+            * ``GATH``
+              Gather: For a vector of position numbers, ``Par2``, copy the
+              value of ``Par1`` at each position number to ParR.  Example:
+              for ``Par1 = 10,20,30,40`` and ``Par2 = 2,4,1``; ``ParR =
+              20,40,10``.
+
+            * ``SCAT``
+              Scatter: Opposite of ``GATH`` operation.  For a
+              vector of position numbers, ``Par2``, copy the value of ``Par1``
+              to that position number in ``ParR``.  Example: for ``Par1 =
+              10,20,30,40,50`` and ``Par2 = 2,1,0,5,3``; ``ParR = 20,10,50,0,40``.
+
+            * ``ATN2``
+              Arctangent: arctangent of ``Par1/Par2`` with the sign of each
+              component considered.
+
+            * ``LOCAL``
+              Transform the data in ``Par1`` from
+              the global Cartesian coordinate system to the local
+              coordinate system given in ``CON1``. ``Par1`` must be an ``N`` x 3
+              (i.e., vector) or an ``N`` x 6 (i.e., stress or strain tensor)
+              array. If the local coordinate system is a cylindrical,
+              spherical, or toroidal system, then you must provide the
+              global Cartesian coordinates in ``Par2`` as an ``N`` x 3 array.
+              Set ``CON2 = 1`` if the data is strain data.
+
+            * ``GLOBAL``
+              Transform the data in ``Par1`` from the local coordinate system given in ``CON1`` to the global
+              Cartesian coordinate system. ``Par1`` must be an ``N`` x 3 (that is, vector) or an ``N`` x 6 (that is,
+              stress or strain tensor) array. If the local coordinate system is a cylindrical, spherical, or
+              toroidal system, then you must provide the global Cartesian coordinates in ``Par2`` as an ``N``
+              x 3 array. Set ``CON2 = 1`` if the data is strain data.
+
+        PAR2
             Second array parameter vector in the operation.  May also be a
             scalar parameter or a literal constant.
 
-        con1
-            First constant (used only with the INT1 and INT2 operations).
+        CON1
+            First constant (used only with the ``INT1`` and ``INT2`` operations).
 
-        con2
-            Second constant (used only with the INT2 operation).
+        CON2
+            Second constant (used only with the ``INT2`` operation).
 
         Notes
         -----
         Operates on two input array parameter vectors and produces one output
         array parameter vector according to:
 
-        ParR = Par1 o Par2
+        ``ParR = Par1 o Par2``
 
         where the operations (o) are described below.  ParR may be the same as
-        Par1 or Par2.  Absolute values and scale factors may be applied to all
+        ``Par1`` or ``Par2``.  Absolute values and scale factors may be applied to all
         parameters [``*VABS``, ``*VFACT``].  Results may be cumulative [``*VCUM``].
         Starting array element numbers must be defined for each array parameter
         vector if it does not start at the first location, such as
@@ -1067,8 +1237,8 @@ class ArrayParam:
         that conveniently perform the indicated operation over a sequence of
         array elements.  If the array is multidimensional, only the first
         subscript is incremented in the do-loop, that is, the operation repeats
-        in column vector fashion "down" the array.  For example, for A(1,5),
-        A(2,5), A(3,5), etc.  The starting location of the row index must be
+        in column vector fashion "down" the array.  For example, for ``A(1,5)``,
+        ``A(2,5)``, ``A(3,5)``, etc.  The starting location of the row index must be
         defined for each parameter read and for the result written.
 
         The default number of loops is from the starting result location to the
@@ -1099,32 +1269,55 @@ class ArrayParam:
         func
             Functions:
 
-            Maximum: the maximum Par1 array element value. - Minimum:
-            the minimum Par1 array element value.
+            * ``MAX``
+              Maximum: the maximum ``Par1`` array element value.
 
-            Index location of the maximum Par1 array element value.
-            Array Par1 is searched starting from its specified
-            index. - Index location of the minimum Par1 array element
-            value.  Array Par1 is searched starting from its specified
-            index.
+            * ``MIN``
+              Minimum: the minimum ``Par1`` array element value.
 
-            Index location of the first nonzero value in array Par1.
-            Array Par1 is searched starting from its specified
-            index. - Index location of the last nonzero value in array
-            Par1.  Array Par1 is searched starting from its specified
-            index.
+            * ``LMAX``
+              Index location of the maximum ``Par1`` array element value.
+              Array ``Par1`` is searched starting from its specified
+              index.
 
-            Sum: Par1 (the summation of the Par1 array element
-            values). - Median: value of Par1 at which there are an
-            equal number of values above and below.
+            * ``LMIN``
+              Index location of the minimum ``Par1`` array element
+              value.  Array ``Par1`` is searched starting from its specified
+              index.
 
-            Mean: (σ Par1)/NUM, where NUM is the number of summed
-            values.
+            * ``FIRST``
+              Index location of the first nonzero value in array ``Par1``.
+              Array ``Par1`` is searched starting from its specified
+              index.
 
-            Variance: ``(σ ((Par1-MEAN)**2))/NUM``.
+            * ``LAST``
+              Index location of the last nonzero value in array
+              ``Par1``.  Array ``Par1`` is searched starting from its specified
+              index.
 
-            Standard deviation: square root of VARI. -
-            Root-mean-square: square root of ``(σ (Par1**2))/NUM``.
+            * ``SUM``
+              Sum: ``Par1`` (the summation of the ``Par1`` array element
+              values).
+
+            * ``MEDI``
+              Median: value of ``Par1`` at which there are an
+              equal number of values above and below.
+
+            * ``MEAN``
+              Mean: ``(σ Par1)/NUM``, where ``NUM`` is the number of summed
+              values.
+
+            * ``VARI``
+              Variance: ``(σ ((Par1-MEAN)**2))/NUM``.
+
+            * ``STDV``
+              Standard deviation: square root of ``VARI``.
+
+            * ``RMS``
+              Root-mean-square: square root of ``(σ (Par1**2))/NUM``.
+
+            * ``NUM``
+              Number: the number of summed values (masked values are not counted).
 
         par1
             Array parameter vector in the operation.
@@ -1134,12 +1327,12 @@ class ArrayParam:
         Operates on one input array parameter vector and produces one output
         scalar parameter according to:
 
-        ParR = f(Par1)
+        ``ParR = f(Par1)``
 
         where the functions (f) are described below. The starting array element
         number must be defined for the array parameter vector.  For example,
-        ``*VSCFUN,MU,MEAN,A(1)`` finds the mean of the A vector values, starting
-        from the first value and stores the result as parameter MU.  Operations
+        ``*VSCFUN,MU,MEAN,A(1)`` finds the mean of the ``A`` vector values, starting
+        from the first value and stores the result as parameter ``MU``.  Operations
         use successive array elements ``[*VLEN, *VMASK]`` with the default being
         all successive array elements.  Absolute values and scale factors may
         be applied to all parameters ``[*VABS, *VFACT]``.  Results may be

--- a/src/ansys/mapdl/core/_commands/apdl/array_param.py
+++ b/src/ansys/mapdl/core/_commands/apdl/array_param.py
@@ -143,158 +143,157 @@ class ArrayParam:
             name restrictions.
 
         par1
-            First array parameter matrix input to the operation. For Oper =
-            MAP, this is an N x 3 array of coordinate locations at which to
-            interpolate. ParR will then be an N(out) x M array containing the
+            First array parameter matrix input to the operation. For ``Oper =
+            MAP``, this is an ``N`` x 3 array of coordinate locations at which to
+            interpolate. ``ParR`` will then be an ``N(out)`` x ``M`` array containing the
             interpolated values.
 
         oper
             Matrix operations:
 
-            INVERT - ``(*MOPER, ParR, Par1, INVERT)``
-            Square matrix invert: Inverts the n x n matrix in Par1
-            into ParR. The matrix must be well conditioned.
+            * `INVERT` - ``(*MOPER, ParR, Par1, INVERT)``
+              Square matrix invert: Inverts the ``n`` x ``n`` matrix in ``Par1``
+              into ``ParR``. The matrix must be well conditioned.
 
-            Warning: Non-independent or ill-conditioned equations can
-            cause erroneous results. - For large matrices, use the
-            APDL Math operation ``*LSFACTOR`` for efficiency (see APDL
-            Math).
+              **Warning**: Non-independent or ill-conditioned equations can
+              cause erroneous results. - For large matrices, use the
+              APDL Math operation ``*LSFACTOR`` for efficiency (see APDL
+              Math).
 
-            MULT - ``(*MOPER, ParR, Par1, MULT, Par2)``
-            Matrix multiply: Multiplies Par1 by Par2.  The number of
-            rows of Par2 must equal the number of columns of Par1 for
-            the operation. If Par2 is input with a number of rows
-            greater than the number of columns of Par1, matrices are
-            still multiplied. However, the operation only uses a
-            number of rows of Par2 equal to the number of columns of
-            Par1.
+            * `MULT` - ``(*MOPER, ParR, Par1, MULT, Par2)``
+              Matrix multiply: Multiplies ``Par1`` by ``Par2``.  The number of
+              rows of ``Par2`` must equal the number of columns of ``Par1`` for
+              the operation. If ``Par2`` is input with a number of rows
+              greater than the number of columns of ``Par1``, matrices are
+              still multiplied. However, the operation only uses a
+              number of rows of ``Par2`` equal to the number of columns of
+              ``Par1``.
 
-            COVAR - ``(*MOPER, ParR, Par1, COVAR, Par2)``
-            Covariance: The measure of association between two columns
-            of the input matrix (Par1).  Par1, of size m runs (rows)
-            by n data (columns) is first processed to produce a row
-            vector containing the mean of each column which is
-            transposed to a column vector (Par2) of n array elements.
-            The Par1 and Par2 operation then produces a resulting n x
-            n matrix (ParR) of covariances (with the variances as the
-            diagonal terms).
+            * `COVAR` - ``(*MOPER, ParR, Par1, COVAR, Par2)``
+              Covariance: The measure of association between two columns
+              of the input matrix (``Par1``).  ``Par1``, of size m runs (rows)
+              by ``n`` data (columns) is first processed to produce a row
+              vector containing the mean of each column which is
+              transposed to a column vector (``Par2``) of n array elements.
+              The ``Par1`` and ``Par2`` operation then produces a resulting ``n`` x
+              ``n`` matrix (``ParR``) of covariances (with the variances as the
+              diagonal terms).
 
-            CORR - ``(*MOPER, ParR, Par1, CORR, Par2)``
-            Correlation: The correlation coefficient between two
-            variables.  The input matrix (Par1), of size m runs (rows)
-            by n data (columns), is first processed to produce a row
-            vector containing the mean of each column which is then
-            transposed to a column vector (Par2) of n array elements.
-            The Par1 and Par2 operation then produces a resulting n x
-            n matrix (ParR) of correlation coefficients (with a value
-            of 1.0 for the diagonal terms).
+            * `CORR` - ``(*MOPER, ParR, Par1, CORR, Par2)``
+              Correlation: The correlation coefficient between two
+              variables.  The input matrix (``Par1``), of size m runs (rows)
+              by n data (columns), is first processed to produce a row
+              vector containing the mean of each column which is then
+              transposed to a column vector (``Par2``) of n array elements.
+              The ``Par1`` and ``Par2`` operation then produces a resulting ``n`` x
+              ``n`` matrix (``ParR``) of correlation coefficients (with a value
+              of 1.0 for the diagonal terms).
 
-            SOLV - ``(*MOPER, ParR, Par1, SOLV, Par2)``
-            Solution of simultaneous equations: Solves the set of n
-            equations of n terms of the form an1x1 + an2x2 + ... +
-            annxn = bn where Par1 contains the matrix of
-            a-coefficients, Par2 the vector(s) of b-values, and ParR
-            the vector(s) of x-results.  Par1 must be a square matrix.
-            The equations must be linear, independent, and well
-            conditioned.
+            * `SOLV` - ``(*MOPER, ParR, Par1, SOLV, Par2)``
+              Solution of simultaneous equations: Solves the set of ``n``
+              equations of n terms of the form ``an_1 x_1 + an_2 x_2 + ... +
+              an_n x_n = b_n`` where ``Par1`` contains the matrix of
+              a-coefficients, ``Par2`` the vector(s) of b-values, and ``ParR``
+              the vector(s) of x-results.  ``Par1`` must be a square matrix.
+              The equations must be linear, independent, and well
+              conditioned.
 
-            Warning: Non-independent or ill-conditioned equations can
-            cause erroneous results. - For large matrices, use the
-            APDL Math operation ``*LSFACTOR`` for efficiency (see APDL
-            Math).
+              **Warning**: Non-independent or ill-conditioned equations can
+              cause erroneous results. - For large matrices, use the
+              APDL Math operation ``*LSFACTOR`` for efficiency (see APDL
+              Math).
 
-            SORT - ``(*MOPER, ParR, Par1, SORT, Par2, n1, n2, n3)``
-            Matrix sort: Sorts matrix Par1 according to sort vector
-            Par2 and places the result back in Par1. Rows of Par1 are
-            moved to the corresponding positions indicated by the
-            values of Par2. Par2 may be a column of Par1 (in which
-            case it will also be reordered). Alternatively, you may
-            specify the column of Par1 to sort using n1 (leaving Par2
-            blank). A secondary sort can be specified by column n2,
-            and a third sort using n3. ParR is the vector of initial
-            row positions (the permutation vector).  Sorting Par1
-            according to ParR should reproduce the initial ordering.
+            * `SORT` - ``(*MOPER, ParR, Par1, SORT, Par2, n1, n2, n3)``
+              Matrix sort: Sorts matrix ``Par1`` according to sort vector
+              ``Par2`` and places the result back in ``Par1``. Rows of ``Par1`` are
+              moved to the corresponding positions indicated by the
+              values of ``Par2``. ``Par2`` may be a column of ``Par1`` (in which
+              case it will also be reordered). Alternatively, you may
+              specify the column of ``Par1`` to sort using n1 (leaving ``Par2``
+              blank). A secondary sort can be specified by column ``n2``,
+              and a third sort using ``n3``. ``ParR`` is the vector of initial
+              row positions (the permutation vector).  Sorting ``Par1``
+              according to ``ParR`` should reproduce the initial ordering.
 
-            NNEAR - ``(*MOPER, ParR, Par1, NNEAR, Toler)``
-            Nearest Node: Quickly determine all the nodes within a
-            specified tolerance of a given array.  ParR is a vector of
-            the nearest selected nodes, or 0 if no nodes are nearer
-            than Toler. Par1 is the n x 3 array of coordinate
-            locations. Toler defaults to 1 and is limited to the
-            maximum model size.
+            * `NNEAR` - ``(*MOPER, ParR, Par1, NNEAR, Toler)``
+              Nearest Node: Quickly determine all the nodes within a
+              specified tolerance of a given array.  ``ParR`` is a vector of
+              the nearest selected nodes, or 0 if no nodes are nearer
+              than ``Toler``. ``Par1`` is the ``n`` x 3 array of coordinate
+              locations. ``Toler`` defaults to 1 and is limited to the
+              maximum model size.
 
-            ENEAR - ``(*MOPER, ParR, Par1, ENEAR, Toler)``
-            Nearest Element: Quickly determine the elements with
-            centroids that are within a specified tolerance of the
-            points in a given array. - ParR is a vector of the nearest
-            selected elements, or 0 if no element centroids are nearer
-            than Toler. Par1 is the n x 3 array of coordinate
-            locations.
+            * `ENEAR` - ``(*MOPER, ``ParR``, ``Par1``, ENEAR, Toler)``
+              Nearest Element: Quickly determine the elements with
+              centroids that are within a specified tolerance of the
+              points in a given array. - ``ParR`` is a vector of the nearest
+              selected elements, or 0 if no element centroids are nearer
+              than ``Toler``. ``Par1`` is the ``n`` x 3 array of coordinate
+              locations.
 
-            MAP - ``(*MOPER, ParR, Par1, MAP, Par2, Par3, kDim, --, kOut, LIMIT)``
+            * `MAP` - ``(*MOPER, ParR, Par1, MAP, Par2, Par3, kDim, --, kOut, LIMIT)``
+              Maps the results from one set of points to another. For
+              example, you can map pressures from a CFD analysis onto
+              your model for a structural analysis.
 
-            Maps the results from one set of points to another. For
-            example, you can map pressures from a CFD analysis onto
-            your model for a structural analysis.
+              * ``Par1`` is the ``Nout`` x 3 array of points that will be mapped
+                to. ``Par2`` is the ``Nin`` x ``M`` array that contains ``M`` values of
+                data to be interpolated at each point and corresponds to
+                the ``Nin`` x 3 points in Par3. The resulting ``ParR`` is the ``Nout``
+                x ``M`` array of mapped data points.
 
-            Par1 is the Nout x 3 array of points that will be mapped
-            to. Par2 is the Nin x M array that contains M values of
-            data to be interpolated at each point and corresponds to
-            the Nin x 3 points in Par3. The resulting ParR is the Nout
-            x M array of mapped data points.
+                For each point in the destination mesh, all possible
+                triangles in the source mesh are searched to find the best
+                triangle containing each point. It then does a linear
+                interpolation inside this triangle. You should carefully
+                specify your interpolation method and search criteria in
+                order to provide faster and more accurate results (see
+                ``LIMIT``, below).
 
-            For each point in the destination mesh, all possible
-            triangles in the source mesh are searched to find the best
-            triangle containing each point. It then does a linear
-            interpolation inside this triangle. You should carefully
-            specify your interpolation method and search criteria in
-            order to provide faster and more accurate results (see
-            LIMIT, below).
+              * ``kDim`` is the interpolation criteria. If ``kDim = 2 or 0``, two
+                dimensional interpolation is applied (interpolate on a
+                surface). If ``kDim = 3``, three dimensional interpolation is
+                applied (interpolate on a volume).
 
-            kDim is the interpolation criteria. If kDim = 2 or 0, two
-            dimensional interpolation is applied (interpolate on a
-            surface). If kDim = 3, three dimensional interpolation is
-            applied (interpolate on a volume).
+              * ``kOut`` specified how points outside of the domain are
+                handled. If ``kOut`` = 0, use the value(s) of the nearest
+                region point for points outside of the region. If ```kOut``` =
+                1, set results outside of the region to zero.
 
-            kOut specified how points outside of the domain are
-            handled. If kOut = 0, use the value(s) of the nearest
-            region point for points outside of the region. If kOut =
-            1, set results outside of the region to zero.
+            * `LIMIT` specifies the number of nearby points considered for
+              interpolation. The default is 20, and the minimum is
+              5. Lower values will reduce processing time; however, some
+              distorted or irregular sets of points will require a
+              higher ``LIMIT`` value to encounter three nodes for
+              triangulation.
 
-            LIMIT specifies the number of nearby points considered for
-            interpolation. The default is 20, and the minimum is
-            5. Lower values will reduce processing time; however, some
-            distorted or irregular sets of points will require a
-            higher LIMIT value to encounter three nodes for
-            triangulation.
+              Output points are incorrect if they are not within the
+              domain (area or volume) defined by the specified input
+              points. Also, calculations for out-of-bound points require
+              much more processing time than do points that are within
+              bounds. Results mapping is available from the command line
+              only.
 
-            Output points are incorrect if they are not within the
-            domain (area or volume) defined by the specified input
-            points. Also, calculations for out-of-bound points require
-            much more processing time than do points that are within
-            bounds. Results mapping is available from the command line
-            only.
+            * `INTP` - ``(*MOPER, ParR, Par1, INTP, Par2)``
+              Finds the elements that contain each point in the array of
+              ``n`` x 3 points in ``Par1``. ``Par2`` will contain the set of element
+              ID numbers and ``ParR`` will contain their ``n`` x 3 set of
+              natural element coordinates (values between -1 and
+              1). ``Par1`` must be in global Cartesian coordinates.
 
-            INTP - ``(*MOPER, ParR, Par1, INTP, Par2)``
-            Finds the elements that contain each point in the array of
-            n x 3 points in Par1. Par2 will contain the set of element
-            ID numbers and ParR will contain their n x 3 set of
-            natural element coordinates (values between -1 and
-            1). Par1 must be in global Cartesian coordinates.
+            * `SGET` - ``(*MOPER, ParR, Par1, SGET, Par2, Label, Comp)``
+              Gets the nodal solution item corresponding to Label and
+              Comp (see the PLNSOL command) and interpolates it to the
+              given element locations. ``Par1`` contains the ``n`` x 3 array of
+              natural element coordinates (values between -1 and 1) of
+              the ``n`` element ID numbers in ``Par2``. ``Par1`` and ``Par2`` are
+              usually the output of the ``*MOPER,,,INTP`` operation. ``ParR``
+              contains the ``n`` interpolated results.
 
-            SGET - ``(*MOPER, ParR, Par1, SGET, Par2, Label, Comp)``
-            Gets the nodal solution item corresponding to Label and
-            Comp (see the PLNSOL command) and interpolates it to the
-            given element locations. Par1 contains the n x 3 array of
-            natural element coordinates (values between -1 and 1) of
-            the n element ID numbers in Par2. Par1 and Par2 are
-            usually the output of the ``*MOPER,,,INTP`` operation. ParR
-            contains the n interpolated results.
-
-            Val1, Val2, ..., Val6
-            Additional input used in the operation. The meanings of
-            Val1 through Val6 vary depending on the specified matrix
-            operation. See the description of Oper for details.
+            * ``Val1, Val2, ..., Val6``
+              Additional input used in the operation. The meanings of
+              Val1 through Val6 vary depending on the specified matrix
+              operation. See the description of Oper for details.
         """
         command = (
             f"*MOPER,{parr},{par1},{oper},{val1},{val2},{val3},{val4},{val5},{val6}"


### PR DESCRIPTION
I just stumble upon some format issues in the docstrings in `array_param` file.

Final output look nicer (sample)

![image](https://user-images.githubusercontent.com/28149841/162729777-a4826a0b-2219-484c-8afb-4723c7be8a31.png)
