### PR TITLE
Removing undesired command output

### DIFF
--- a/src/ansys/mapdl/core/database/database.py
+++ b/src/ansys/mapdl/core/database/database.py
@@ -5,7 +5,14 @@ import time
 from warnings import warn
 import weakref
 
-from ansys.api.mapdl.v0 import mapdl_db_pb2_grpc
+try:
+    from ansys.api.mapdl.v0 import mapdl_db_pb2_grpc
+except ImportError:
+    raise ImportError(
+        "Please upgrade the 'ansys.api.mapdl' package to at least v0.5.1."
+        "You can use 'pip install ansys-api-mapdl --upgrade"
+    )
+
 import grpc
 
 from ..mapdl_grpc import MapdlGrpc

--- a/src/ansys/mapdl/core/database/database.py
+++ b/src/ansys/mapdl/core/database/database.py
@@ -7,7 +7,7 @@ import weakref
 
 try:
     from ansys.api.mapdl.v0 import mapdl_db_pb2_grpc
-except ImportError:  # Pragma: No cover
+except ImportError:  # pragma: no cover
     raise ImportError(
         "Please upgrade the 'ansys.api.mapdl' package to at least v0.5.1."
         "You can use 'pip install ansys-api-mapdl --upgrade"

--- a/src/ansys/mapdl/core/database/database.py
+++ b/src/ansys/mapdl/core/database/database.py
@@ -7,7 +7,7 @@ import weakref
 
 try:
     from ansys.api.mapdl.v0 import mapdl_db_pb2_grpc
-except ImportError:
+except ImportError:  # Pragma: No cover
     raise ImportError(
         "Please upgrade the 'ansys.api.mapdl' package to at least v0.5.1."
         "You can use 'pip install ansys-api-mapdl --upgrade"

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1048,7 +1048,6 @@ class MapdlGrpc(_MapdlCore):
                 targets = rth_files
             else:
                 remote_files_str = "\n".join("\t%s" % item for item in remote_files)
-                print("\t".join("\n%s" % item for item in ["a", "b", "c"]))
                 raise FileNotFoundError(
                     "Unable to locate any result file from the "
                     "following remote result files:\n\n" + remote_files_str


### PR DESCRIPTION
Fixing #965 I realized that when inspecting the `mapdl` object, some of their attributes raise an error:

![image](https://user-images.githubusercontent.com/28149841/163787564-dc0d2c41-8865-4514-aee2-1cf0d7552597.png)

- `mapdl.chain_commands`: Chained commands are not permitted in distributed ansys.
```
    'Traceback (most recent call last):\n  File "c:\\Users\\gayuso\\.vscode\\extensions\\ms-python.python-2022.4.1\\pythonFiles\\lib\\python\\debugpy\\_vendored\\pydevd\\_pydevd_bundle\\pydevd_resolver.py", line 192, in _get_py_dictionary\n    attr = getattr(var, name)\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\mapdl.py", line 416, in chain_commands\n    
    raise RuntimeError(\nRuntimeError: Chained commands are not permitted in distributed ansys.\n'
```

- `mapdl.db`: ImportError: cannot import name `mapdl_db_pb2_grpc` from `ansys.api.mapdl.v0` .
```
     'Traceback (most recent call last):\n  File "c:\\Users\\gayuso\\.vscode\\extensions\\ms-python.python-2022.4.1\\pythonFiles\\lib\\python\\debugpy\\_vendored\\pydevd\\_pydevd_bundle\\pydevd_resolver.py", line 192, in _get_py_dictionary\n    attr = getattr(var, name)\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\check_version.py", line 169, in wrapper\n    return func(self, *args, **kwargs)\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\mapdl_grpc.py", line 1948, in db\n    from ansys.mapdl.core.database import MapdlDb\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\database\\__init__.py", line 3, in <module>\n    from .database import DBDef, MapdlDb  # noqa: F401\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\database\\database.py", line 8, in <module>\n    from ansys.api.mapdl.v0 import mapdl_db_pb2_grpc\n
     ImportError: cannot import name \'mapdl_db_pb2_grpc\' from \'ansys.api.mapdl.v0\' (C:\\ProgramData\\Miniconda3\\envs\\pymapdl_0\\lib\\site-packages\\ansys\\api\\mapdl\\v0\\__init__.py)\n'
```

- `mapdl.result`: No result file(s)
```
    'Traceback (most recent call last):\n  File "c:\\Users\\gayuso\\.vscode\\extensions\\ms-python.python-2022.4.1\\pythonFiles\\lib\\python\\debugpy\\_vendored\\pydevd\\_pydevd_bundle\\pydevd_resolver.py", line 192, in _get_py_dictionary\n    attr = getattr(var, name)\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\mapdl_grpc.py", line 2205, in result\n    
    raise FileNotFoundError("No result file(s) at %s" % self.directory)\nFileNotFoundError: No result file(s) at C:/ansys_jobs/tmp\n'
```

- `mapdl.thermal_result`: No result file(s). Related to the previous one.
```
    'Traceback (most recent call last):\n  File "c:\\Users\\gayuso\\.vscode\\extensions\\ms-python.python-2022.4.1\\pythonFiles\\lib\\python\\debugpy\\_vendored\\pydevd\\_pydevd_bundle\\pydevd_resolver.py", line 192, in _get_py_dictionary\n    attr = getattr(var, name)\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\mapdl_grpc.py", line 2117, in thermal_result\n    
    result = self.result\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\mapdl_grpc.py", line 2182, in result\n    if self._distributed_result_file and self._result_file:\n  File "C:\\Users\\gayuso\\Others_pymapdls\\pymapdl_0\\pymapdl\\src\\ansys\\mapdl\\core\\mapdl_grpc.py", line 2070, in _distributed_result_file\n    
    raise FileNotFoundError("Thermal Result not available")\nFileNotFoundError: Thermal Result not available\n'
```

## Todo's
- [x] Fix the `'a','b','c'` strange output.
- [x] Analyze and fix 
    - [x] `db`- This is because `ansys.api.mapdl` is outdated. I just expanded the error message to inform about the new api version.
<strike>- [ ] `result` - Not applicable anymore. </strike>
 <strike> - [ ] `thermal_result`  - Not applicable anymore.  </strike>
 <strike> - [ ] `chain_commands`  - Not applicable anymore. </strike>

## Notes
Closes #965 