### PR TITLE
Command output repr

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,12 +104,12 @@ Alternatively, install the latest from `PyMAPDL GitHub
    pip install git+https://github.com/pyansys/pymapdl.git
 
 
-For a local "development" version, install with:
+For a local "development" version, install with (requires pip >= 22.0):
 
 .. code::
 
    git clone https://github.com/pyansys/pymapdl.git
-   cd mapdl
+   cd pymapdl
    pip install -e .
 
 

--- a/README.rst
+++ b/README.rst
@@ -117,8 +117,7 @@ Dependencies
 ------------
 You will need a local licenced copy of ANSYS to run MAPDL prior and
 including 2021R1.  If you have the latest version of 2021R1 you do
-not need MAPDL installed locally and can connect to a remote instance
-via gRPC.
+not need MAPDL installed locally and can connect to a remote instance.
 
 
 Getting Started

--- a/src/ansys/mapdl/core/commands.py
+++ b/src/ansys/mapdl/core/commands.py
@@ -750,3 +750,11 @@ class BoundaryConditionsListingOutput(CommandListingOutput):
             df["IMAG"] = df["IMAG"].astype(np.float64, copy=False)
 
         return df
+
+
+class StringWithLiteralRepr(str):
+    def __init__(self, inner_str):
+        self._inner_str = inner_str
+
+    def __repr__(self):
+        return self._inner_str

--- a/src/ansys/mapdl/core/commands.py
+++ b/src/ansys/mapdl/core/commands.py
@@ -753,8 +753,5 @@ class BoundaryConditionsListingOutput(CommandListingOutput):
 
 
 class StringWithLiteralRepr(str):
-    def __init__(self, inner_str):
-        self._inner_str = inner_str
-
     def __repr__(self):
-        return self._inner_str
+        return self.__str__()

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -24,6 +24,7 @@ from ansys.mapdl.core.commands import (
     BoundaryConditionsListingOutput,
     CommandListingOutput,
     Commands,
+    StringWithLiteralRepr,
     inject_docs,
 )
 from ansys.mapdl.core.errors import MapdlInvalidRoutineError, MapdlRuntimeError
@@ -2349,14 +2350,6 @@ class _MapdlCore(Commands):
 
         text = text.replace("\\r\\n", "\n").replace("\\n", "\n")
         if text:
-
-            class StringWithLiteralRepr(str):
-                def __init__(self, inner_str):
-                    self._inner_str = inner_str
-
-                def __repr__(self):
-                    return self._inner_str
-
             self._response = StringWithLiteralRepr(text.strip())
             self._log.info(self._response)
         else:

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2349,7 +2349,12 @@ class _MapdlCore(Commands):
 
         text = text.replace("\\r\\n", "\n").replace("\\n", "\n")
         if text:
-            self._response = text.strip()
+            class StringWithLiteralRepr(str):
+                def __init__(self, inner_str):
+                    self._inner_str = inner_str
+                def __repr__(self):
+                    return self._inner_str
+            self._response = StringWithLiteralRepr(text.strip())
             self._log.info(self._response)
         else:
             self._response = None

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2349,11 +2349,14 @@ class _MapdlCore(Commands):
 
         text = text.replace("\\r\\n", "\n").replace("\\n", "\n")
         if text:
+
             class StringWithLiteralRepr(str):
                 def __init__(self, inner_str):
                     self._inner_str = inner_str
+
                 def __repr__(self):
                     return self._inner_str
+
             self._response = StringWithLiteralRepr(text.strip())
             self._log.info(self._response)
         else:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -238,6 +238,8 @@ def test_docstring_injector(mapdl, method):
 
 
 def test_string_with_literal():
-    output = StringWithLiteralRepr("asdf\nasdf")
+    base_ = "asdf\nasdf"
+    output = StringWithLiteralRepr(base_)
     assert output.__repr__() == output
+    assert output.__repr__() == base_
     assert len(output.split()) == 2

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -239,5 +239,5 @@ def test_docstring_injector(mapdl, method):
 
 def test_string_with_literal():
     output = StringWithLiteralRepr("asdf\nasdf")
-    assert output.__repr__()
+    assert output.__repr__() == output
     assert len(output.split()) == 2

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,6 +11,7 @@ from ansys.mapdl.core.commands import (
     CommandListingOutput,
     CommandOutput,
     Commands,
+    StringWithLiteralRepr,
 )
 
 try:
@@ -234,3 +235,9 @@ def test_docstring_injector(mapdl, method):
             assert "``str.to_list()``" in docstring
             assert "``str.to_array()``" in docstring
             assert "``str.to_dataframe()``" in docstring
+
+
+def test_string_with_literal():
+    output = StringWithLiteralRepr("asdf\nasdf")
+    assert output.__repr__()
+    assert len(output.split()) == 2


### PR DESCRIPTION
I was using pymapdl and was annoyed at the printout from commands.  I would see things like this:
```
>>> mapdl.prep7()
'*** ANSYS - ENGINEERING ANALYSIS SYSTEM  RELEASE 2022 R1          22.1BETA ***\n DISTRIBUTED Ansys Mechanical Enterprise                       \n\n 00000000  VERSION=WINDOWS x64   09:29:10  APR 20, 2022 CP=      0.391\n\n                                                                               \n\n\n\n ** WARNING: PRE-RELEASE VERSION OF ANSYS 22.1BETA\n  ANSYS,INC TESTING IS NOT COMPLETE - CHECK RESULTS CAREFULLY **\n\n          ***** ANSYS ANALYSIS DEFINITION (PREP7) *****'
>
```

with this change, the printout now looks like this:

```
>>> mapdl.post1()
***** ROUTINE COMPLETED *****  CP =         0.469



 *** ANSYS - ENGINEERING ANALYSIS SYSTEM  RELEASE 2022 R1          22.1BETA ***
 DISTRIBUTED Ansys Mechanical Enterprise

 00000000  VERSION=WINDOWS x64   09:45:32  APR 20, 2022 CP=      0.484





 ** WARNING: PRE-RELEASE VERSION OF ANSYS 22.1BETA
  ANSYS,INC TESTING IS NOT COMPLETE - CHECK RESULTS CAREFULLY **

          ***** ANSYS RESULTS INTERPRETATION (POST1) *****

 *** NOTE ***                            CP =       0.484   TIME= 09:45:32
 Reading results into the database (SET command) will update the current
 displacement and force boundary conditions in the database with the
 values from the results file for that load set.  Note that any
 subsequent solutions will use these values unless action is taken to
 either SAVE the current values or not overwrite them (/EXIT,NOSAVE).
>>>

```