### PR TITLE
Not plotting if `return_plotter` is equal `True`.

### DIFF
--- a/src/ansys/mapdl/core/plotting.py
+++ b/src/ansys/mapdl/core/plotting.py
@@ -328,7 +328,8 @@ def general_plotter(
         pl.close()
 
     else:
-        pl.show()
+        if not return_plotter:
+            pl.show()
 
     # Recreating "returns" to update cpos
     returns_parameter = return_from_plotter()


### PR DESCRIPTION
I belie it does not make sense to plot when you are requesting the plotter as an output. Currently:

```py
>>> pl = mapdl.plot_nodal_displacements(return_plotter=True)  # This shows the plot
>>> pl.title = "New title"
>>> pl.show()
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Input In [4], in <module>
----> 1 p.show()

File c:\users\gayuso\other_projects\pyvista\pyvista\plotting\plotting.py:5027, in Plotter.show(self, title, window_size, interactive, auto_close, interactive_update, full_screen, screenshot, return_img, cpos, use_ipyvtk, jupyter_backend, return_viewer, return_cpos, **kwargs)
   5024     raise DeprecationError(txt)
   5026 if not hasattr(self, "ren_win"):
-> 5027     raise RuntimeError("This plotter has been closed and cannot be shown.")
   5029 if full_screen is None:
   5030     full_screen = self._theme.full_screen

RuntimeError: This plotter has been closed and cannot be shown.
```

When you do plot, then the plotter is closed when you close the window (needed to give back the control to python) hence later changes cannot display. 

### Alternative (or it will be nice to know)
Other option will be to do something to recreate the closed plot. I haven't seen anything in pyvista docs though. The idea will be:

```py
pl = mapdl.plot_nodal_displacements(return_plotter=True)  # This shows the plot
pl.title = "New title"
pl.recreate_plot()  # Hypothetical method
pl.show()
```