### PR TITLE
Making ``tqdm`` optional

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -68,7 +68,7 @@ try:
     from tqdm import tqdm
 
     _HAS_TQDM = True
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     _HAS_TQDM = False
 
 TMP_VAR = "__tmpvar__"
@@ -95,11 +95,11 @@ def get_file_chunks(filename, progress_bar=False):
     """Serializes a file into chunks"""
     pbar = None
     if progress_bar:
-        if not _HAS_TQDM:
+        if not _HAS_TQDM:  # pragma: no cover
             raise ModuleNotFoundError(
                 f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package."
                 "To avoid this message you can set 'progress_bar=False'."
-            )  # pragma: no cover
+            )
 
         n_bytes = os.path.getsize(filename)
 
@@ -142,11 +142,11 @@ def save_chunks_to_file(
     """
     pbar = None
     if progress_bar:
-        if not _HAS_TQDM:
+        if not _HAS_TQDM:  # pragma: no cover
             raise ModuleNotFoundError(
                 f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package."
                 "To avoid this message you can set 'progress_bar=False'."
-            )  # pragma: no cover
+            )
 
         pbar = tqdm(
             total=file_size,

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -99,7 +99,7 @@ def get_file_chunks(filename, progress_bar=False):
             raise ModuleNotFoundError(
                 f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package."
                 "To avoid this message you can set 'progress_bar=False'."
-            )
+            )  # pragma: no cover
 
         n_bytes = os.path.getsize(filename)
 
@@ -146,7 +146,7 @@ def save_chunks_to_file(
             raise ModuleNotFoundError(
                 f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package."
                 "To avoid this message you can set 'progress_bar=False'."
-            )
+            )  # pragma: no cover
 
         pbar = tqdm(
             total=file_size,
@@ -1601,10 +1601,6 @@ class MapdlGrpc(_MapdlCore):
         >>> mapdl.download_project()
 
         """
-
-        if not progress_bar and _HAS_TQDM:
-            progress_bar = True
-
         if chunk_size > 4 * 1024 * 1024:  # 4MB
             raise ValueError(
                 f"Chunk sizes bigger than 4 MB can generate unstable behaviour in PyMAPDL. "

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -15,6 +15,9 @@ from ansys.mapdl.core.launcher import (
 from ansys.mapdl.core.mapdl_grpc import _HAS_TQDM
 from ansys.mapdl.core.misc import create_temp_dir, threaded, threaded_daemon
 
+if _HAS_TQDM:
+    from tqdm import tqdm
+
 
 def available_ports(n_ports, starting_port=MAPDL_DEFAULT_PORT):
     """Return a list the first ``n_ports`` ports starting from ``starting_port``"""
@@ -111,7 +114,7 @@ class LocalMapdlPool:
         wait=True,
         run_location=None,
         port=MAPDL_DEFAULT_PORT,
-        progress_bar=False,
+        progress_bar=True,
         restart_failed=True,
         remove_temp_files=True,
         **kwargs,
@@ -158,7 +161,7 @@ class LocalMapdlPool:
                 raise ModuleNotFoundError(
                     f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package. "
                     "To avoid this message you can set 'progress_bar=False'."
-                )
+                )  # pragma: no cover
 
             pbar = tqdm(total=n_instances, desc="Creating Pool")
 
@@ -197,7 +200,7 @@ class LocalMapdlPool:
         self,
         func,
         iterable=None,
-        progress_bar=False,
+        progress_bar=True,
         close_when_finished=False,
         timeout=None,
         wait=True,
@@ -289,7 +292,7 @@ class LocalMapdlPool:
                 raise ModuleNotFoundError(
                     f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package. "
                     "To avoid this message you can set 'progress_bar=False'."
-                )
+                )  # pragma: no cover
 
             pbar = tqdm(total=n, desc="MAPDL Running")
 
@@ -389,7 +392,7 @@ class LocalMapdlPool:
         self,
         files,
         clear_at_start=True,
-        progress_bar=False,
+        progress_bar=True,
         close_when_finished=False,
         timeout=None,
         wait=True,

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -157,11 +157,11 @@ class LocalMapdlPool:
 
         pbar = None
         if wait and progress_bar:
-            if not _HAS_TQDM:
+            if not _HAS_TQDM:  # pragma: no cover
                 raise ModuleNotFoundError(
                     f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package. "
                     "To avoid this message you can set 'progress_bar=False'."
-                )  # pragma: no cover
+                )
 
             pbar = tqdm(total=n_instances, desc="Creating Pool")
 
@@ -288,11 +288,11 @@ class LocalMapdlPool:
 
         pbar = None
         if progress_bar:
-            if not _HAS_TQDM:
+            if not _HAS_TQDM:  # pragma: no cover
                 raise ModuleNotFoundError(
                     f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package. "
                     "To avoid this message you can set 'progress_bar=False'."
-                )  # pragma: no cover
+                )
 
             pbar = tqdm(total=n, desc="MAPDL Running")
 

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -5,8 +5,6 @@ import shutil
 import time
 import warnings
 
-from tqdm import tqdm
-
 from ansys.mapdl.core import LOG, get_ansys_path, launch_mapdl
 from ansys.mapdl.core.errors import VersionError
 from ansys.mapdl.core.launcher import (
@@ -14,6 +12,7 @@ from ansys.mapdl.core.launcher import (
     _version_from_path,
     port_in_use,
 )
+from ansys.mapdl.core.mapdl_grpc import _HAS_TQDM
 from ansys.mapdl.core.misc import create_temp_dir, threaded, threaded_daemon
 
 
@@ -112,7 +111,7 @@ class LocalMapdlPool:
         wait=True,
         run_location=None,
         port=MAPDL_DEFAULT_PORT,
-        progress_bar=True,
+        progress_bar=False,
         restart_failed=True,
         remove_temp_files=True,
         **kwargs,
@@ -155,6 +154,12 @@ class LocalMapdlPool:
 
         pbar = None
         if wait and progress_bar:
+            if not _HAS_TQDM:
+                raise ModuleNotFoundError(
+                    f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package. "
+                    "To avoid this message you can set 'progress_bar=False'."
+                )
+
             pbar = tqdm(total=n_instances, desc="Creating Pool")
 
         # initialize a list of dummy instances
@@ -192,7 +197,7 @@ class LocalMapdlPool:
         self,
         func,
         iterable=None,
-        progress_bar=True,
+        progress_bar=False,
         close_when_finished=False,
         timeout=None,
         wait=True,
@@ -253,7 +258,7 @@ class LocalMapdlPool:
                 completed_indices.append(index)
                 return mapdl.parameters.routine
         >>> inputs = [(examples.vmfiles['vm%d' % i], i) for i in range(1, 10)]
-        >>> output = pool.map(func, inputs, progress_bar=True, wait=True)
+        >>> output = pool.map(func, inputs, progress_bar=False, wait=True)
         ['Begin level',
          'Begin level',
          'Begin level',
@@ -280,6 +285,12 @@ class LocalMapdlPool:
 
         pbar = None
         if progress_bar:
+            if not _HAS_TQDM:
+                raise ModuleNotFoundError(
+                    f"To use the keyword argument 'progress_bar', you need to have installed the 'tqdm' package. "
+                    "To avoid this message you can set 'progress_bar=False'."
+                )
+
             pbar = tqdm(total=n, desc="MAPDL Running")
 
         @threaded_daemon
@@ -378,7 +389,7 @@ class LocalMapdlPool:
         self,
         files,
         clear_at_start=True,
-        progress_bar=True,
+        progress_bar=False,
         close_when_finished=False,
         timeout=None,
         wait=True,


### PR DESCRIPTION
As the title.

I'm not removing ``tqdm`` from the toml file. But it should be possible. Since ``tqdm`` is not a very heavy package I would keep it, but since the functionality it provides is just sugar candy, I would. #FeedBackIsAppreciated
