### PR TITLE
Removing pyvista dependency

### DIFF
--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -12,7 +12,13 @@ LOG.debug("Loaded logging module as LOG")
 _LOCAL_PORTS = []
 
 # Per contract with Sphinx-Gallery, this method must be available at top level
-from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper
+try:
+    from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper
+
+    _HAS_PYVISTA = True
+except ModuleNotFoundError:  # pragma: no cover
+    LOG.debug("The module 'Pyvista' is not installed.")
+    _HAS_PYVISTA = False
 
 try:
     import importlib.metadata as importlib_metadata

--- a/src/ansys/mapdl/core/_commands/preproc/elements.py
+++ b/src/ansys/mapdl/core/_commands/preproc/elements.py
@@ -1,9 +1,7 @@
 from typing import Optional, Union
-import warnings
 
 from ansys.mapdl.core._commands.parse import parse_e
 from ansys.mapdl.core.mapdl_types import MapdlFloat, MapdlInt
-from ansys.mapdl.core.plotting import general_plotter
 
 
 class Elements:
@@ -1233,74 +1231,29 @@ class Elements:
         """
         return self.run(f"ENSYM,{iinc},,{ninc},{iel1},{iel2},{ieinc}", **kwargs)
 
-    def eplot(self, show_node_numbering=False, vtk=None, **kwargs):
+    def eplot(self, **kwargs):
         """Plots the currently selected elements.
 
         APDL Command: EPLOT
 
-        .. note::
-            PyMAPDL plotting commands with ``vtk=True`` ignore any
-            values set with the ``PNUM`` command.
-
-        Parameters
-        ----------
-        vtk : bool, optional
-            Plot the currently selected elements using ``pyvista``.
-            Defaults to current ``use_vtk`` setting.
-
-        show_node_numbering : bool, optional
-            Plot the node numbers of surface nodes.
-
-        **kwargs
-            See ``help(ansys.mapdl.core.plotter.general_plotter)`` for more
-            keyword arguments related to visualizing using ``vtk``.
-
-        Examples
-        --------
-        >>> mapdl.clear()
-        >>> mapdl.prep7()
-        >>> mapdl.block(0, 1, 0, 1, 0, 1)
-        >>> mapdl.et(1, 186)
-        >>> mapdl.esize(0.1)
-        >>> mapdl.vmesh('ALL')
-        >>> mapdl.vgen(2, 'all')
-        >>> mapdl.eplot(show_edges=True, smooth_shading=True,
-                        show_node_numbering=True)
-
-        Save a screenshot to disk without showing the plot
-
-        >>> mapdl.eplot(background='w', show_edges=True, smooth_shading=True,
-                        window_size=[1920, 1080], savefig='screenshot.png',
-                        off_screen=True)
+        Notes
+        ------
+        Produces an element display of the selected elements. In full
+        graphics, only those elements faces with all of their corresponding
+        nodes selected are plotted. In PowerGraphics, all element faces of the selected
+        element set are plotted irrespective of the nodes selected. However,
+        for both full graphics and Power Graphics, adjacent or otherwise
+        duplicated faces of 3-D solid elements will not be displayed in an attempt
+        to eliminate plotting of interior facets. See the ``DSYS`` command for display
+        coordinate system issues.
+        This command will display curvature in midside node elements when PowerGraphics is activated
+        [``/GRAPHICS ,POWER``] and ``/EFACET,2`` or ``/EFACET,4`` are enabled. (To display
+        curvature, two facets per edge is recommended [``/EFACET,2``]). When you specify ``/EFACET,1``,
+        PowerGraphics does not display midside nodes. ``/EFACET`` has no effect on EPLOT for non-midside
+        node elements.
+        This command is valid in any processor.
 
         """
-        if vtk is None:
-            vtk = self._use_vtk
-
-        if vtk:
-            kwargs.setdefault("title", "MAPDL Element Plot")
-            if not self._mesh.n_elem:
-                warnings.warn("There are no elements to plot.")
-                return general_plotter([], [], [], **kwargs)
-
-            # TODO: Consider caching the surface
-            esurf = self.mesh._grid.linear_copy().extract_surface().clean()
-            kwargs.setdefault("show_edges", True)
-
-            # if show_node_numbering:
-            labels = []
-            if show_node_numbering:
-                labels = [{"points": esurf.points, "labels": esurf["ansys_node_num"]}]
-
-            return general_plotter(
-                [{"mesh": esurf, "style": kwargs.pop("style", "surface")}],
-                [],
-                labels,
-                **kwargs,
-            )
-
-        # otherwise, use MAPDL plotter
-        self._enable_interactive_plotting()
         return self.run("EPLOT")
 
     def eread(self, fname: str = "", ext: str = "", **kwargs) -> Optional[str]:

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -154,7 +154,7 @@ class _MapdlCore(Commands):
 
         if _HAS_PYVISTA:
             self._use_vtk = use_vtk
-        else:
+        else:  # pragma: no cover
             if use_vtk:
                 raise ModuleNotFoundError(
                     f"Using the keyword argument 'use_vtk' requires having Pyvista installed."

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -985,7 +985,7 @@ class _MapdlCore(Commands):
             if _HAS_PYVISTA:
                 # lazy import here to avoid top level import
                 import pyvista as pv
-            else:
+            else:  # pragma: no cover
                 raise ModuleNotFoundError(
                     f"Using the keyword argument 'vtk' requires having Pyvista installed."
                 )

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -135,7 +135,7 @@ class _MapdlCore(Commands):
     def __init__(
         self,
         loglevel="DEBUG",
-        use_vtk=None,
+        use_vtk=True,
         log_apdl=None,
         log_file=False,
         local=True,

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -981,7 +981,8 @@ class _MapdlCore(Commands):
         """
         if vtk is None:
             vtk = self._use_vtk
-        elif vtk is True:
+
+        if vtk is True:
             if _HAS_PYVISTA:
                 # lazy import here to avoid top level import
                 import pyvista as pv

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2454,7 +2454,8 @@ class _MapdlCore(Commands):
                 # Edge case. `\title, 'par=1234' `
                 self._check_parameter_name(param_name)
 
-        text = self._run(command, mute=mute, **kwargs)
+        verbose = kwargs.get("verbose", False)
+        text = self._run(command, verbose=verbose, mute=mute)
 
         if mute:
             return

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -64,10 +64,8 @@ class Report(scooby.Report):
         core = [
             "matplotlib",
             "numpy",
-            "pyvista",
             "appdirs",
             "tqdm",
-            "pyiges",
             "scipy",
             "grpc",  # grpcio
             "ansys.api.mapdl.v0",  # ansys-api-mapdl-v0
@@ -79,7 +77,7 @@ class Report(scooby.Report):
             core.extend(["pexpect"])
 
         # Optional packages
-        optional = ["matplotlib"]
+        optional = ["matplotlib", "pyvista", "pyiges"]
         if sys.version_info[1] < 9:
             optional.append("ansys_corba")
 

--- a/src/ansys/mapdl/core/plotting.py
+++ b/src/ansys/mapdl/core/plotting.py
@@ -1,6 +1,5 @@
 """Plotting helper for MAPDL using pyvista"""
 import numpy as np
-import pyvista as pv
 
 from ansys.mapdl.core.misc import unique_rows
 
@@ -212,6 +211,9 @@ def general_plotter(
                     off_screen=True)
 
     """
+    # Lazy import
+    import pyvista as pv
+
     if notebook:
         off_screen = True
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1366,3 +1366,6 @@ def test_mpfunctions(mapdl, cube_solve, capsys):
 def test_plot_empty_mesh(mapdl, cleared):
     with pytest.warns(UserWarning):
         mapdl.nplot(vtk=True)
+
+    with pytest.warns(UserWarning):
+        mapdl.eplot(vtk=True)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -348,22 +348,22 @@ def test_invalid_input(mapdl):
 
 
 @skip_no_xserver
-def test_kplot(cleared, mapdl, tmpdir):
+@pytest.mark.parametrize("vtk", [True, False, None])
+def test_kplot(cleared, mapdl, tmpdir, vtk):
     mapdl.k("", 0, 0, 0)
     mapdl.k("", 1, 0, 0)
     mapdl.k("", 1, 1, 0)
     mapdl.k("", 0, 1, 0)
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
-    cpos = mapdl.kplot(savefig=filename)
+    cpos = mapdl.kplot(vtk=vtk, savefig=filename)
     assert cpos is None
     assert os.path.isfile(filename)
 
-    mapdl.kplot(vtk=False)  # make sure legacy still works
-
 
 @skip_no_xserver
-def test_aplot(cleared, mapdl):
+@pytest.mark.parametrize("vtk", [True, False, None])
+def test_aplot(cleared, mapdl, vtk):
     k0 = mapdl.k("", 0, 0, 0)
     k1 = mapdl.k("", 1, 0, 0)
     k2 = mapdl.k("", 1, 1, 0)
@@ -374,17 +374,14 @@ def test_aplot(cleared, mapdl):
     l3 = mapdl.l(k3, k0)
     mapdl.al(l0, l1, l2, l3)
     mapdl.aplot(show_area_numbering=True)
-    mapdl.aplot(color_areas=True, show_lines=True, show_line_numbering=True)
+    mapdl.aplot(color_areas=vtk, show_lines=True, show_line_numbering=True)
 
     mapdl.aplot(quality=100)
     mapdl.aplot(quality=-1)
 
-    # and legacy as well
-    mapdl.aplot(vtk=False)
-
 
 @skip_no_xserver
-@pytest.mark.parametrize("vtk", [True, False])
+@pytest.mark.parametrize("vtk", [True, False, None])
 def test_vplot(cleared, mapdl, vtk):
     mapdl.block(0, 1, 0, 1, 0, 1)
     mapdl.vplot(vtk=vtk, color_areas=True)
@@ -425,7 +422,8 @@ def test_lines(cleared, mapdl):
 
 
 @skip_no_xserver
-def test_lplot(cleared, mapdl, tmpdir):
+@pytest.mark.parametrize("vtk", [True, False, None])
+def test_lplot(cleared, mapdl, tmpdir, vtk):
     k0 = mapdl.k("", 0, 0, 0)
     k1 = mapdl.k("", 1, 0, 0)
     k2 = mapdl.k("", 1, 1, 0)
@@ -436,11 +434,9 @@ def test_lplot(cleared, mapdl, tmpdir):
     mapdl.l(k3, k0)
 
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
-    cpos = mapdl.lplot(show_keypoint_numbering=True, savefig=filename)
+    cpos = mapdl.lplot(vtk=vtk, show_keypoint_numbering=True, savefig=filename)
     assert cpos is None
     assert os.path.isfile(filename)
-
-    mapdl.lplot(vtk=False)  # make sure legacy still works
 
 
 @skip_in_cloud
@@ -581,12 +577,13 @@ def test_enum(mapdl, make_block):
 
 
 @pytest.mark.parametrize("nnum", [True, False])
+@pytest.mark.parametrize("vtk", [True, False, None])
 @skip_no_xserver
-def test_nplot_vtk(cleared, mapdl, nnum):
+def test_nplot_vtk(cleared, mapdl, nnum, vtk):
     mapdl.n(1, 0, 0, 0)
     mapdl.n(11, 10, 0, 0)
     mapdl.fill(1, 11, 9)
-    mapdl.nplot(vtk=True, nnum=nnum, background="w", color="k")
+    mapdl.nplot(vtk=vtk, nnum=nnum, background="w", color="k")
 
 
 @skip_no_xserver
@@ -705,10 +702,12 @@ def test_builtin_parameters(mapdl, cleared):
 
 
 @skip_no_xserver
-def test_eplot(mapdl, make_block):
+@pytest.mark.parametrize("vtk", [True, False, None])
+def test_eplot(mapdl, make_block, vtk):
     init_elem = mapdl.mesh.n_elem
     mapdl.aplot()  # check aplot and verify it doesn't mess up the element plotting
     mapdl.eplot(show_node_numbering=True, background="w", color="b")
+    mapdl.eplot(vtk=vtk, show_node_numbering=True, background="w", color="b")
     mapdl.aplot()  # check aplot and verify it doesn't mess up the element plotting
     assert mapdl.mesh.n_elem == init_elem
 
@@ -1360,3 +1359,8 @@ def test_mpfunctions(mapdl, cube_solve, capsys):
     # Test suppliying a dir path when in remote
     with pytest.raises(IOError):
         mapdl.mpwrite("/test_dir/test", "mp")
+
+
+def test_plot_empty_mesh(mapdl, cleared):
+    with pytest.warns(UserWarning):
+        mapdl.nplot(vtk=True)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -358,7 +358,8 @@ def test_kplot(cleared, mapdl, tmpdir, vtk):
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl.kplot(vtk=vtk, savefig=filename)
     assert cpos is None
-    assert os.path.isfile(filename)
+    if vtk:
+        assert os.path.isfile(filename)
 
 
 @skip_no_xserver
@@ -436,7 +437,8 @@ def test_lplot(cleared, mapdl, tmpdir, vtk):
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.png"))
     cpos = mapdl.lplot(vtk=vtk, show_keypoint_numbering=True, savefig=filename)
     assert cpos is None
-    assert os.path.isfile(filename)
+    if vtk:
+        assert os.path.isfile(filename)
 
 
 @skip_in_cloud


### PR DESCRIPTION
Solves #1011 

Now, Pyvista and pyiges are lazy imported. 

Pyvista is made totally avoidable to install too. However, I did not remove pyvista from the toml file. But I'm open to discuss if we should or not.