### PR TITLE
Adding 'AWP_ROOT' var to get_ansys_bin

### DIFF
--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -19,7 +19,7 @@ MODULE_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))
 
 def get_ansys_bin(rver):
     """Identify the ansys executable based on the release version (e.g. "201")"""
-    if os.name == "nt":
+    if os.name == "nt":  # pragma: no cover
         program_files = os.getenv("PROGRAMFILES", os.path.join("c:\\", "Program Files"))
         ans_root = os.getenv(
             f"AWP_ROOT{rver}", os.path.join(program_files, "ANSYS Inc", f"v{rver}")

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -20,15 +20,14 @@ MODULE_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))
 def get_ansys_bin(rver):
     """Identify the ansys executable based on the release version (e.g. "201")"""
     if os.name == "nt":
-        ans_root = "c:/Program Files/ANSYS Inc/"
-        mapdlbin = os.path.join(
-            ans_root, "v%s" % rver, "ansys", "bin", "winx64", "ANSYS%s.exe" % rver
+        program_files = os.getenv("PROGRAMFILES", os.path.join("c:\\", "Program Files"))
+        ans_root = os.getenv(
+            f"AWP_ROOT{rver}", os.path.join(program_files, "ANSYS Inc", f"v{rver}")
         )
+        mapdlbin = os.path.join(ans_root, "ansys", "bin", "winx64", f"ANSYS{rver}.exe")
     else:
-        ans_root = "/usr/ansys_inc"
-        mapdlbin = os.path.join(
-            ans_root, "v%s" % rver, "ansys", "bin", "ansys%s" % rver
-        )
+        ans_root = os.getenv(f"AWP_ROOT{rver}", os.path.join("/", "usr", "ansys_inc"))
+        mapdlbin = os.path.join(*ans_root, f"v{rver}", "ansys", "bin", f"ansys{rver}")
 
     return mapdlbin
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,6 +7,7 @@ from ansys.mapdl.core.misc import (
     check_valid_ip,
     check_valid_port,
     check_valid_start_instance,
+    get_ansys_bin,
 )
 
 
@@ -62,3 +63,8 @@ def test_check_valid_port(port):
 )
 def test_check_valid_start_instance(start_instance):
     check_valid_start_instance(start_instance)
+
+
+def test_get_ansys_bin(mapdl):
+    rver = mapdl.__str__().splitlines()[1].split(":")[1].strip().replace(".", "")
+    assert isinstance(get_ansys_bin(rver), str)


### PR DESCRIPTION
Close #1062 by implementing ``AWP_ROOT{ver}`` env var.