### PR TITLE
Mapdl.info property

### DIFF
--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -51,3 +51,37 @@ Latest 2021R1 and newer features
    mapdl_grpc.MapdlGrpc.math
    mapdl_grpc.MapdlGrpc.mute
    mapdl_grpc.MapdlGrpc.upload
+
+
+Mapdl Information Class
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: ansys.mapdl.core.misc
+
+.. autoclass:: ansys.mapdl.core.misc.Information
+
+.. autosummary::
+   :toctree: _autosummary
+
+   Information.product
+   Information.mapdl_version
+   Information.pymapdl_version
+   Information.products
+   Information.preprocessing_capabilities
+   Information.aux_capabilities
+   Information.solution_options
+   Information.post_capabilities
+   Information.title
+   Information.titles
+   Information.stitles
+   Information.units
+   Information.scratch_memory_status
+   Information.database_status
+   Information.config_values
+   Information.global_status
+   Information.job_information
+   Information.model_information
+   Information.boundary_condition_information
+   Information.routine_information
+   Information.solution_options_configuration
+   Information.load_step_options

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -30,6 +30,7 @@ from ansys.mapdl.core.commands import (
 from ansys.mapdl.core.errors import MapdlInvalidRoutineError, MapdlRuntimeError
 from ansys.mapdl.core.inline_functions import Query
 from ansys.mapdl.core.misc import (
+    Information,
     last_created,
     load_file,
     random_string,
@@ -189,6 +190,8 @@ class _MapdlCore(Commands):
         self._post = PostProcessing(self)
 
         self._wrap_listing_functions()
+
+        self._info = Information(self)
 
     @property
     def print_com(self):
@@ -559,27 +562,12 @@ class _MapdlCore(Commands):
 
     @supress_logging
     def __str__(self):
-        try:
-            if self._exited:
-                return "MAPDL exited"
-            stats = self.slashstatus("PROD")
-        except Exception:  # pragma: no cover
-            return "MAPDL exited"
+        return self.info.__str__()
 
-        st = stats.find("*** Products ***")
-        en = stats.find("*** PrePro")
-        product = "\n".join(stats[st:en].splitlines()[1:]).strip()
-
-        # get product version
-        stats = self.slashstatus("TITLE")
-        st = stats.find("RELEASE")
-        en = stats.find("INITIAL", st)
-        mapdl_version = stats[st:en].split("CUSTOMER")[0].strip()
-
-        info = [f"Product:         {product}"]
-        info.append(f"MAPDL Version:   {mapdl_version}")
-        info.append(f"PyMAPDL Version: {pymapdl.__version__}\n")
-        return "\n".join(info)
+    @property
+    def info(self):
+        """General information"""
+        return self._info
 
     @property
     def geometry(self):
@@ -2308,11 +2296,10 @@ class _MapdlCore(Commands):
             msg = f"{cmd_} is ignored: {INVAL_COMMANDS_SILENT[cmd_]}."
             self._log.info(msg)
 
-            # This very likely won't be recorded anywhere.
-
+            # This, very likely, won't be recorded anywhere.
             # But just in case, I'm adding info as /com
             command = (
-                f"/com, PyAnsys: {msg}"  # Using '!' makes the output of '_run' empty
+                f"/com, PyMAPDL: {msg}"  # Using '!' makes the output of '_run' empty
             )
 
         if command[:3].upper() in INVAL_COMMANDS:

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -471,6 +471,8 @@ class Information(dict):
             raise TypeError("Must be implemented from MAPDL class")
         self._mapdl_weakref = weakref.ref(mapdl)
         self.cached = False
+        self._stats = None
+        self._repr_keys = ["Product", "MAPDL Version", "PyMAPDL Version"]
 
     @property
     def _mapdl(self):
@@ -485,6 +487,7 @@ class Information(dict):
                 raise RuntimeError("Information class: MAPDL exited")
 
             stats = self._mapdl.slashstatus("PROD")
+            self._stats = stats
         except Exception:  # pragma: no cover
             raise RuntimeError("Information class: MAPDL exited")
 
@@ -503,6 +506,29 @@ class Information(dict):
         super().__setitem__("Product", product)
         super().__setitem__("MAPDL Version", mapdl_version)
         super().__setitem__("PyMAPDL Version", pymapdl.__version__)
+
+        # Getting extra information
+        super().__setitem__("Products", self.get_products())
+        super().__setitem__(
+            "Preprocessing capabilities", self.get_preprocessing_capabilities()
+        )
+        super().__setitem__("Aux capabilities", self.get_aux_capabilities())
+        super().__setitem__("Solution options", self.get_solution_options())
+        super().__setitem__("Post capabilities", self.get_post_capabilities())
+        super().__setitem__("Titles", self.get_titles())
+        super().__setitem__("Units", self.get_units())
+        super().__setitem__("Scratch memory status", self.get_scratch_memory_status())
+        super().__setitem__("Database status", self.get_database_status())
+        super().__setitem__("Config values", self.get_config_values())
+        super().__setitem__("Global status", self.get_global_status())
+        super().__setitem__("Job information", self.get_job_information())
+        super().__setitem__("Model information", self.get_model_information())
+        super().__setitem__(
+            "Boundary condition information", self.get_boundary_condition_information()
+        )
+        super().__setitem__("Routine information", self.get_routine_information())
+        super().__setitem__("Solution options", self.get_solution_options())
+        super().__setitem__("Load step options", self.get_load_step_options())
 
         self.cached = True
 
@@ -523,5 +549,99 @@ class Information(dict):
             [
                 f"{each_key}:".ljust(25) + f"{each_value}".ljust(25)
                 for each_key, each_value in self.items()
+                if each_key in self._repr_keys
             ]
         )
+
+    def _get_between(self, init_string, end_string=None):
+        st = self._stats.find(init_string)
+        if not end_string:
+            en = -1
+        else:
+            en = self._stats.find(end_string)
+        return "\n".join(self._stats[st:en].splitlines()[1:]).strip()
+
+    def get_products(self):
+        init_ = "*** Products ***"
+        end_string = "*** PreProcessing Capabilities ***"
+        return self._get_between(init_, end_string)
+
+    def get_preprocessing_capabilities(self):
+        init_ = "*** PreProcessing Capabilities ***"
+        end_string = "*** Aux Capabilities ***"
+        return self._get_between(init_, end_string)
+
+    def get_aux_capabilities(self):
+        init_ = "*** Aux Capabilities ***"
+        end_string = "*** Solution Options ***"
+        return self._get_between(init_, end_string)
+
+    def get_solution_options(self):
+        init_ = "*** Solution Options ***"
+        end_string = "*** Post Capabilities ***"
+        return self._get_between(init_, end_string)
+
+    def get_post_capabilities(self):
+        init_ = "*** Post Capabilities ***"
+        end_string = "***** TITLES *****"
+        return self._get_between(init_, end_string)
+
+    def get_titles(self):
+        init_ = "***** TITLES *****"
+        end_string = "***** UNITS *****"
+        return self._get_between(init_, end_string)
+
+    def get_units(self):
+        init_ = "***** UNITS *****"
+        end_string = "***** SCRATCH MEMORY STATUS *****"
+        return self._get_between(init_, end_string)
+
+    def get_scratch_memory_status(self):
+        init_ = "***** SCRATCH MEMORY STATUS *****"
+        end_string = "*****    DATABASE STATUS    *****"
+        return self._get_between(init_, end_string)
+
+    def get_database_status(self):
+        init_ = "*****    DATABASE STATUS    *****"
+        end_string = "***** CONFIG VALUES *****"
+        return self._get_between(init_, end_string)
+
+    def get_config_values(self):
+        init_ = "***** CONFIG VALUES *****"
+        end_string = "G L O B A L   S T A T U S"
+        return self._get_between(init_, end_string)
+
+    def get_global_status(self):
+        init_ = "G L O B A L   S T A T U S"
+        end_string = "J O B   I N F O R M A T I O N"
+        return self._get_between(init_, end_string)
+
+    def get_job_information(self):
+        init_ = "J O B   I N F O R M A T I O N"
+        end_string = "M O D E L   I N F O R M A T I O N"
+        return self._get_between(init_, end_string)
+
+    def get_model_information(self):
+        init_ = "M O D E L   I N F O R M A T I O N"
+        end_string = "B O U N D A R Y   C O N D I T I O N   I N F O R M A T I O N"
+        return self._get_between(init_, end_string)
+
+    def get_boundary_condition_information(self):
+        init_ = "B O U N D A R Y   C O N D I T I O N   I N F O R M A T I O N"
+        end_string = "R O U T I N E   I N F O R M A T I O N"
+        return self._get_between(init_, end_string)
+
+    def get_routine_information(self):
+        init_ = "R O U T I N E   I N F O R M A T I O N"
+        end_string = None
+        return self._get_between(init_, end_string)
+
+    def get_solution_options(self):
+        init_ = "S O L U T I O N   O P T I O N S"
+        end_string = "L O A D   S T E P   O P T I O N S"
+        return self._get_between(init_, end_string)
+
+    def get_load_step_options(self):
+        init_ = "L O A D   S T E P   O P T I O N S"
+        end_string = None
+        return self._get_between(init_, end_string)

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -469,7 +469,7 @@ class Information(dict):
     def __init__(self, mapdl):
         from ansys.mapdl.core.mapdl import _MapdlCore  # lazy import
 
-        if not isinstance(mapdl, _MapdlCore):
+        if not isinstance(mapdl, _MapdlCore):  # pragma: no cover
             raise TypeError("Must be implemented from MAPDL class")
         self._mapdl_weakref = weakref.ref(mapdl)
         self.cached = False
@@ -483,13 +483,13 @@ class Information(dict):
         """We might need to do more calls if we implement properties
         that change over the MAPDL session."""
         try:
-            if self._mapdl._exited:
-                self._mapdl._log.debug("Information class: MAPDL exited")
-                return
+            if self._mapdl._exited:  # pragma: no cover
+                raise RuntimeError("Information class: MAPDL exited")
+
             stats = self._mapdl.slashstatus("PROD")
         except Exception:  # pragma: no cover
-            self._mapdl._log.debug("Information class: MAPDL exited")
-            return
+            raise RuntimeError("Information class: MAPDL exited")
+
         self._mapdl._log.debug("Information class: Getting info")
 
         st = stats.find("*** Products ***")
@@ -518,7 +518,7 @@ class Information(dict):
         raise ValueError("It is no allowed to modify 'mapdl.info' parameters.")
 
     def __repr__(self):
-        if not self.cached:
+        if not self.cached:  # pragma: no cover
             self._query()
 
         return "\n".join(

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -541,29 +541,11 @@ class Information:
         """Retrieve the product from the MAPDL instance."""
         return self._get_product()
 
-    @product.setter
-    def product(self, value):
-        """Set the value for the MAPDL Product
-
-        .. warning:: By default, you cannot change 'product' property.
-
-        """
-        raise ValueError("The property 'product' cannot be changed.")
-
     @property
     @update_information_first(False)
     def mapdl_version(self):
         """Retrieve the MAPDL version from the MAPDL instance."""
         return self._get_mapdl_version()
-
-    @mapdl_version.setter
-    def mapdl_version(self, value):
-        """Set the value for the MAPDL Version
-
-        .. warning:: By default, you cannot change 'mapdl_version' property.
-
-        """
-        raise ValueError("The property 'mapdl_version' cannot be changed")
 
     @property
     @update_information_first(False)
@@ -572,30 +554,12 @@ class Information:
         st = self._get_mapdl_version()
         return self._get_between("RELEASE", "BUILD", st).strip()
 
-    @mapdl_version_release.setter
-    def mapdl_version_release(self, value):
-        """Set the value for the MAPDL version release
-
-        .. warning:: By default, you cannot change 'mapdl_version_release' property.
-
-        """
-        raise ValueError("The property 'mapdl_version_release' cannot be changed")
-
     @property
     @update_information_first(False)
     def mapdl_version_build(self):
         """Retrieve the MAPDL version build from the MAPDL instance."""
         st = self._get_mapdl_version()
         return self._get_between("BUILD", "UPDATE", st).strip()
-
-    @mapdl_version_build.setter
-    def mapdl_version_build(self, value):
-        """Set the value for the MAPDL Mapdl Version Build
-
-        .. warning:: By default, you cannot change 'mapdl_version_build' property.
-
-        """
-        raise ValueError("The property 'mapdl_version_build' cannot be changed")
 
     @property
     @update_information_first(False)
@@ -604,29 +568,11 @@ class Information:
         st = self._get_mapdl_version()
         return self._get_between("UPDATE", "", st).strip()
 
-    @mapdl_version_update.setter
-    def mapdl_version_update(self, value):
-        """Set the value for the MAPDL Mapdl Version Update
-
-        .. warning:: By default, you cannot change 'mapdl_version_update' property.
-
-        """
-        raise ValueError("The property 'mapdl_version_update' cannot be changed")
-
     @property
     @update_information_first(False)
     def pymapdl_version(self):
         """Retrieve the PyMAPDL version from the MAPDL instance."""
         return self._get_pymapdl_version()
-
-    @pymapdl_version.setter
-    def pymapdl_version(self, value):
-        """Set the value for the MAPDL PyMAPDL Version
-
-        .. warning:: By default, you cannot change 'pymapdl_version' property.
-
-        """
-        raise ValueError("The property 'pymapdl_version' cannot be changed")
 
     @property
     @update_information_first(False)
@@ -634,29 +580,11 @@ class Information:
         """Retrieve the products from the MAPDL instance."""
         return self._get_products()
 
-    @products.setter
-    def products(self, value):
-        """Set the value for the MAPDL Products
-
-        .. warning:: By default, you cannot change 'products' property.
-
-        """
-        raise ValueError("The property 'products' cannot be changed")
-
     @property
     @update_information_first(False)
     def preprocessing_capabilities(self):
         """Retrieve the preprocessing capabilities from the MAPDL instance."""
         return self._get_preprocessing_capabilities()
-
-    @preprocessing_capabilities.setter
-    def preprocessing_capabilities(self, value):
-        """Set the value for the MAPDL Preprocessing Capabilities
-
-        .. warning:: By default, you cannot change 'preprocessing_capabilities' property.
-
-        """
-        raise ValueError("The property 'preprocessing_capabilities' cannot be changed")
 
     @property
     @update_information_first(False)
@@ -664,29 +592,11 @@ class Information:
         """Retrieve the aux capabilities from the MAPDL instance."""
         return self._get_aux_capabilities()
 
-    @aux_capabilities.setter
-    def aux_capabilities(self, value):
-        """Set the value for the MAPDL Aux Capabilities
-
-        .. warning:: By default, you cannot change 'aux_capabilities' property.
-
-        """
-        raise ValueError("The property 'aux_capabilities' cannot be changed")
-
     @property
     @update_information_first(True)
     def solution_options(self):
         """Retrieve the solution options from the MAPDL instance."""
         return self._get_solution_options()
-
-    @solution_options.setter
-    def solution_options(self, value):
-        """Set the value for the MAPDL Solution Options
-
-        .. warning:: By default, you cannot change 'solution_options' property.
-
-        """
-        raise ValueError("The property 'solution_options' cannot be changed")
 
     @property
     @update_information_first(False)
@@ -694,31 +604,11 @@ class Information:
         """Retrieve the post capabilities from the MAPDL instance."""
         return self._get_post_capabilities()
 
-    @post_capabilities.setter
-    def post_capabilities(self, value):
-        """Set the value for the MAPDL Post Capabilities
-
-        .. warning:: By default, you cannot change 'post_capabilities' property.
-
-        """
-        raise ValueError("The property 'post_capabilities' cannot be changed")
-
     @property
     @update_information_first(True)
     def titles(self):
         """Retrieve the titles from the MAPDL instance."""
         return self._get_titles()
-
-    @titles.setter
-    def titles(self, value):
-        """Set the value for the MAPDL titles
-
-        .. warning:: By default, you cannot change 'titles' property.
-
-        """
-        raise ValueError(
-            "The property 'titles' cannot be changed. But you can change 'Mapdl.info.title'"
-        )
 
     @property
     @update_information_first(True)
@@ -728,25 +618,12 @@ class Information:
 
     @title.setter
     def title(self, title):
-        """Set the value for the MAPDL title"""
         return self._mapdl.title(title)
 
     @property
     @update_information_first(True)
     def stitles(self, i=None):
-        """Retrieve the stitle from the MAPDL instance.
-
-        If ``i`` is supplied, only retrieve the stitle number i.
-        Starting from 0 up to 3 (Python indexing).
-        """
-        if not i:
-            return self._get_stitles()
-        else:
-            return self._get_stitles()[i]
-
-    @stitles.setter
-    def stitles(self, stitle, i=None):
-        """Set the value for the MAPDL stitle.
+        """Retrieve or set the value for the MAPDL stitle (subtitles).
 
         If 'stitle' includes newline characters (`\\n`), then each line
         is assigned to one STITLE.
@@ -757,6 +634,13 @@ class Information:
 
         Starting from 0 up to 3 (Python indexing).
         """
+        if not i:
+            return self._get_stitles()
+        else:
+            return self._get_stitles()[i]
+
+    @stitles.setter
+    def stitles(self, stitle, i=None):
         if stitle is None:
             # Case to empty
             stitle = ["", "", "", ""]
@@ -781,27 +665,11 @@ class Information:
         else:
             self._mapdl.stitle(i, stitle)
 
-    def _get_stitles(self):
-        return [
-            re.search(f"SUBTITLE  {i}=(.*)", self._get_titles()).groups(1)[0].strip()
-            for i in range(1, 5)
-            if re.search(f"SUBTITLE  {i}=(.*)", self._get_titles())
-        ]
-
     @property
     @update_information_first(True)
     def units(self):
         """Retrieve the units from the MAPDL instance."""
         return self._get_units()
-
-    @units.setter
-    def units(self, value):
-        """Set the value for the MAPDL Units
-
-        .. warning:: By default, you cannot change 'units' property.
-
-        """
-        raise ValueError("The property 'units' cannot be changed")
 
     @property
     @update_information_first(True)
@@ -809,29 +677,11 @@ class Information:
         """Retrieve the scratch memory status from the MAPDL instance."""
         return self._get_scratch_memory_status()
 
-    @scratch_memory_status.setter
-    def scratch_memory_status(self, value):
-        """Set the value for the MAPDL Scratch Memory Status
-
-        .. warning:: By default, you cannot change 'scratch_memory_status' property.
-
-        """
-        raise ValueError("The property 'scratch_memory_status' cannot be changed")
-
     @property
     @update_information_first(True)
     def database_status(self):
         """Retrieve the database status from the MAPDL instance."""
         return self._get_database_status()
-
-    @database_status.setter
-    def database_status(self, value):
-        """Set the value for the MAPDL Database Status
-
-        .. warning:: By default, you cannot change 'database_status' property.
-
-        """
-        raise ValueError("The property 'database_status' cannot be changed")
 
     @property
     @update_information_first(True)
@@ -839,29 +689,11 @@ class Information:
         """Retrieve the config values from the MAPDL instance."""
         return self._get_config_values()
 
-    @config_values.setter
-    def config_values(self, value):
-        """Set the value for the MAPDL Config Values
-
-        .. warning:: By default, you cannot change 'config_values' property.
-
-        """
-        raise ValueError("The property 'config_values' cannot be changed")
-
     @property
     @update_information_first(True)
     def global_status(self):
         """Retrieve the global status from the MAPDL instance."""
         return self._get_global_status()
-
-    @global_status.setter
-    def global_status(self, value):
-        """Set the value for the MAPDL Global Status
-
-        .. warning:: By default, you cannot change 'global_status' property.
-
-        """
-        raise ValueError("The property 'global_status' cannot be changed")
 
     @property
     @update_information_first(True)
@@ -869,29 +701,11 @@ class Information:
         """Retrieve the job information from the MAPDL instance."""
         return self._get_job_information()
 
-    @job_information.setter
-    def job_information(self, value):
-        """Set the value for the MAPDL Job Information
-
-        .. warning:: By default, you cannot change 'job_information' property.
-
-        """
-        raise ValueError("The property 'job_information' cannot be changed")
-
     @property
     @update_information_first(True)
     def model_information(self):
         """Retrieve the model information from the MAPDL instance."""
         return self._get_model_information()
-
-    @model_information.setter
-    def model_information(self, value):
-        """Set the value for the MAPDL Model Information
-
-        .. warning:: By default, you cannot change 'model_information' property.
-
-        """
-        raise ValueError("The property 'model_information' cannot be changed")
 
     @property
     @update_information_first(True)
@@ -899,31 +713,11 @@ class Information:
         """Retrieve the boundary condition information from the MAPDL instance."""
         return self._get_boundary_condition_information()
 
-    @boundary_condition_information.setter
-    def boundary_condition_information(self, value):
-        """Set the value for the MAPDL Boundary Condition Information
-
-        .. warning:: By default, you cannot change 'boundary_condition_information' property.
-
-        """
-        raise ValueError(
-            "The method 'boundary_condition_information' cannot be changed"
-        )
-
     @property
     @update_information_first(True)
     def routine_information(self):
         """Retrieve the routine information from the MAPDL instance."""
         return self._get_routine_information()
-
-    @routine_information.setter
-    def routine_information(self, value):
-        """Set the value for the MAPDL Routine Information
-
-        .. warning:: By default, you cannot change 'routine_information' property.
-
-        """
-        raise ValueError("The property 'routine_information' cannot be changed")
 
     @property
     @update_information_first(True)
@@ -931,31 +725,11 @@ class Information:
         """Retrieve the solution options configuration from the MAPDL instance."""
         return self._get_solution_options_configuration()
 
-    @solution_options_configuration.setter
-    def solution_options_configuration(self, value):
-        """Set the value for the MAPDL Solution Options Configuration
-
-        .. warning:: By default, you cannot change 'solution_options_configuration' property.
-
-        """
-        raise ValueError(
-            "The method 'solution_options_configuration' cannot be changed"
-        )
-
     @property
     @update_information_first(True)
     def load_step_options(self):
         """Retrieve the load step options from the MAPDL instance."""
         return self._get_load_step_options()
-
-    @load_step_options.setter
-    def load_step_options(self, value):
-        """Set the value for the MAPDL Load Step Options
-
-        .. warning:: By default, you cannot change 'load_step_options' property.
-
-        """
-        raise ValueError("The property 'load_step_options' cannot be changed")
 
     def _get_between(self, init_string, end_string=None, string=None):
         if not string:
@@ -985,6 +759,13 @@ class Information:
         match = re.match(r"TITLE=(.*)$", self._get_titles())
         if match:
             return match.groups(1)[0].strip()
+
+    def _get_stitles(self):
+        return [
+            re.search(f"SUBTITLE  {i}=(.*)", self._get_titles()).groups(1)[0].strip()
+            for i in range(1, 5)
+            if re.search(f"SUBTITLE  {i}=(.*)", self._get_titles())
+        ]
 
     def _get_products(self):
         init_ = "*** Products ***"

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -431,11 +431,22 @@ def check_valid_start_instance(start_instance):
     return start_instance.lower() == "true"
 
 
-def requires_update(requires_update=False):
+def update_information_first(update=False):
+    """
+    Decorator to wrap :class:`Information <ansys.mapdl.core.misc.Information>`
+    methods to force update the fields when accessed.
+
+    Parameters
+    ----------
+    update : bool, optional
+        If ``True``, the class information is updated by calling ``/STATUS``
+        before accessing the methods. By default ``False``
+    """
+
     def decorator(function):
         @wraps(function)
         def wrapper(self, *args, **kwargs):
-            if requires_update or not self._stats:
+            if update or not self._stats:
                 self._update()
             return function(self, *args, **kwargs)
 
@@ -448,8 +459,8 @@ class Information:
     """
     This class provide some MAPDL information from ``/STATUS`` MAPDL command.
 
-    It is also the object that is called when you issue "print(mapdl)",
-    which means ``print`` calls "mapdl.info.__str__()".
+    It is also the object that is called when you issue ``print(mapdl)``,
+    which means ``print`` calls ``mapdl.info.__str__()``.
 
     Notes
     -----
@@ -494,7 +505,7 @@ class Information:
 
     @property
     def _mapdl(self):
-        """Return the weakly referenced instance of mapdl"""
+        """Return the weakly referenced MAPDL instance."""
         return self._mapdl_weakref()
 
     def _update(self):
@@ -525,218 +536,426 @@ class Information:
         )
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def product(self):
+        """Retrieve the product from the MAPDL instance."""
         return self._get_product()
 
     @product.setter
     def product(self, value):
-        raise ValueError("The method 'product' cannot be changed.")
+        """Set the value for the MAPDL Product
+
+        .. warning:: By default, you cannot change 'product' property.
+
+        """
+        raise ValueError("The property 'product' cannot be changed.")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def mapdl_version(self):
+        """Retrieve the MAPDL version from the MAPDL instance."""
         return self._get_mapdl_version()
 
     @mapdl_version.setter
     def mapdl_version(self, value):
-        raise ValueError("The method 'mapdl_version' cannot be changed")
+        """Set the value for the MAPDL Version
+
+        .. warning:: By default, you cannot change 'mapdl_version' property.
+
+        """
+        raise ValueError("The property 'mapdl_version' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def mapdl_version_release(self):
+        """Retrieve the MAPDL version release from the MAPDL instance."""
         st = self._get_mapdl_version()
         return self._get_between("RELEASE", "BUILD", st).strip()
 
     @mapdl_version_release.setter
     def mapdl_version_release(self, value):
-        raise ValueError("The method 'mapdl_version_release' cannot be changed")
+        """Set the value for the MAPDL version release
+
+        .. warning:: By default, you cannot change 'mapdl_version_release' property.
+
+        """
+        raise ValueError("The property 'mapdl_version_release' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def mapdl_version_build(self):
+        """Retrieve the MAPDL version build from the MAPDL instance."""
         st = self._get_mapdl_version()
         return self._get_between("BUILD", "UPDATE", st).strip()
 
     @mapdl_version_build.setter
     def mapdl_version_build(self, value):
-        raise ValueError("The method 'mapdl_version_build' cannot be changed")
+        """Set the value for the MAPDL Mapdl Version Build
+
+        .. warning:: By default, you cannot change 'mapdl_version_build' property.
+
+        """
+        raise ValueError("The property 'mapdl_version_build' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def mapdl_version_update(self):
+        """Retrieve the MAPDL version update from the MAPDL instance."""
         st = self._get_mapdl_version()
         return self._get_between("UPDATE", "", st).strip()
 
     @mapdl_version_update.setter
     def mapdl_version_update(self, value):
-        raise ValueError("The method 'mapdl_version_update' cannot be changed")
+        """Set the value for the MAPDL Mapdl Version Update
+
+        .. warning:: By default, you cannot change 'mapdl_version_update' property.
+
+        """
+        raise ValueError("The property 'mapdl_version_update' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def pymapdl_version(self):
+        """Retrieve the PyMAPDL version from the MAPDL instance."""
         return self._get_pymapdl_version()
 
     @pymapdl_version.setter
     def pymapdl_version(self, value):
-        raise ValueError("The method 'pymapdl_version' cannot be changed")
+        """Set the value for the MAPDL PyMAPDL Version
+
+        .. warning:: By default, you cannot change 'pymapdl_version' property.
+
+        """
+        raise ValueError("The property 'pymapdl_version' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def products(self):
+        """Retrieve the products from the MAPDL instance."""
         return self._get_products()
 
     @products.setter
     def products(self, value):
-        raise ValueError("The method 'products' cannot be changed")
+        """Set the value for the MAPDL Products
+
+        .. warning:: By default, you cannot change 'products' property.
+
+        """
+        raise ValueError("The property 'products' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def preprocessing_capabilities(self):
+        """Retrieve the preprocessing capabilities from the MAPDL instance."""
         return self._get_preprocessing_capabilities()
 
     @preprocessing_capabilities.setter
     def preprocessing_capabilities(self, value):
-        raise ValueError("The method 'preprocessing_capabilities' cannot be changed")
+        """Set the value for the MAPDL Preprocessing Capabilities
+
+        .. warning:: By default, you cannot change 'preprocessing_capabilities' property.
+
+        """
+        raise ValueError("The property 'preprocessing_capabilities' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def aux_capabilities(self):
+        """Retrieve the aux capabilities from the MAPDL instance."""
         return self._get_aux_capabilities()
 
     @aux_capabilities.setter
     def aux_capabilities(self, value):
-        raise ValueError("The method 'aux_capabilities' cannot be changed")
+        """Set the value for the MAPDL Aux Capabilities
+
+        .. warning:: By default, you cannot change 'aux_capabilities' property.
+
+        """
+        raise ValueError("The property 'aux_capabilities' cannot be changed")
 
     @property
-    @requires_update(True)
+    @update_information_first(True)
     def solution_options(self):
+        """Retrieve the solution options from the MAPDL instance."""
         return self._get_solution_options()
 
     @solution_options.setter
     def solution_options(self, value):
-        raise ValueError("The method 'solution_options' cannot be changed")
+        """Set the value for the MAPDL Solution Options
+
+        .. warning:: By default, you cannot change 'solution_options' property.
+
+        """
+        raise ValueError("The property 'solution_options' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(False)
     def post_capabilities(self):
+        """Retrieve the post capabilities from the MAPDL instance."""
         return self._get_post_capabilities()
 
     @post_capabilities.setter
     def post_capabilities(self, value):
-        raise ValueError("The method 'post_capabilities' cannot be changed")
+        """Set the value for the MAPDL Post Capabilities
+
+        .. warning:: By default, you cannot change 'post_capabilities' property.
+
+        """
+        raise ValueError("The property 'post_capabilities' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def titles(self):
+        """Retrieve the titles from the MAPDL instance."""
         return self._get_titles()
 
     @titles.setter
     def titles(self, value):
-        raise ValueError("The method 'titles' cannot be changed")
+        """Set the value for the MAPDL titles
+
+        .. warning:: By default, you cannot change 'titles' property.
+
+        """
+        raise ValueError(
+            "The property 'titles' cannot be changed. But you can change 'Mapdl.info.title'"
+        )
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
+    def title(self):
+        """Retrieve and set the title from the MAPDL instance."""
+        return self._mapdl.inquire("", "title")
+
+    @title.setter
+    def title(self, title):
+        """Set the value for the MAPDL title"""
+        return self._mapdl.title(title)
+
+    @property
+    @update_information_first(True)
+    def stitles(self, i=None):
+        """Retrieve the stitle from the MAPDL instance.
+
+        If ``i`` is supplied, only retrieve the stitle number i.
+        Starting from 0 up to 3 (Python indexing).
+        """
+        if not i:
+            return self._get_stitles()
+        else:
+            return self._get_stitles()[i]
+
+    @stitles.setter
+    def stitles(self, stitle, i=None):
+        """Set the value for the MAPDL stitle.
+
+        If 'stitle' includes newline characters (`\\n`), then each line
+        is assigned to one STITLE.
+
+        If 'stitle' is equals ``None``, the stitles are reset.
+
+        If ``i`` is supplied, only set the stitle number i.
+
+        Starting from 0 up to 3 (Python indexing).
+        """
+        if stitle is None:
+            # Case to empty
+            stitle = ["", "", "", ""]
+
+        if not isinstance(stitle, (str, list)):
+            raise ValueError("Only str or list are allowed for stitle")
+
+        if isinstance(stitle, str):
+            if "\n" in stitle:
+                stitle = stitle.splitlines()
+            else:
+                stitle = "\n".join(
+                    [stitle[ii : ii + 70] for ii in range(0, len(stitle), 70)]
+                )
+
+        if any([len(each) > 70 for each in stitle]):
+            raise ValueError("The number of characters per subtitle is limited to 70.")
+
+        if not i:
+            for each_index, each_stitle in zip(range(1, 5), stitle):
+                self._mapdl.stitle(each_index, each_stitle)
+        else:
+            self._mapdl.stitle(i, stitle)
+
+    def _get_stitles(self):
+        return [
+            re.search(f"SUBTITLE  {i}=(.*)", self._get_titles()).groups(1)[0].strip()
+            for i in range(1, 5)
+            if re.search(f"SUBTITLE  {i}=(.*)", self._get_titles())
+        ]
+
+    @property
+    @update_information_first(True)
     def units(self):
+        """Retrieve the units from the MAPDL instance."""
         return self._get_units()
 
     @units.setter
     def units(self, value):
-        raise ValueError("The method 'units' cannot be changed")
+        """Set the value for the MAPDL Units
+
+        .. warning:: By default, you cannot change 'units' property.
+
+        """
+        raise ValueError("The property 'units' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def scratch_memory_status(self):
+        """Retrieve the scratch memory status from the MAPDL instance."""
         return self._get_scratch_memory_status()
 
     @scratch_memory_status.setter
     def scratch_memory_status(self, value):
-        raise ValueError("The method 'scratch_memory_status' cannot be changed")
+        """Set the value for the MAPDL Scratch Memory Status
+
+        .. warning:: By default, you cannot change 'scratch_memory_status' property.
+
+        """
+        raise ValueError("The property 'scratch_memory_status' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def database_status(self):
+        """Retrieve the database status from the MAPDL instance."""
         return self._get_database_status()
 
     @database_status.setter
     def database_status(self, value):
-        raise ValueError("The method 'database_status' cannot be changed")
+        """Set the value for the MAPDL Database Status
+
+        .. warning:: By default, you cannot change 'database_status' property.
+
+        """
+        raise ValueError("The property 'database_status' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def config_values(self):
+        """Retrieve the config values from the MAPDL instance."""
         return self._get_config_values()
 
     @config_values.setter
     def config_values(self, value):
-        raise ValueError("The method 'config_values' cannot be changed")
+        """Set the value for the MAPDL Config Values
+
+        .. warning:: By default, you cannot change 'config_values' property.
+
+        """
+        raise ValueError("The property 'config_values' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def global_status(self):
+        """Retrieve the global status from the MAPDL instance."""
         return self._get_global_status()
 
     @global_status.setter
     def global_status(self, value):
-        raise ValueError("The method 'global_status' cannot be changed")
+        """Set the value for the MAPDL Global Status
+
+        .. warning:: By default, you cannot change 'global_status' property.
+
+        """
+        raise ValueError("The property 'global_status' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def job_information(self):
+        """Retrieve the job information from the MAPDL instance."""
         return self._get_job_information()
 
     @job_information.setter
     def job_information(self, value):
-        raise ValueError("The method 'job_information' cannot be changed")
+        """Set the value for the MAPDL Job Information
+
+        .. warning:: By default, you cannot change 'job_information' property.
+
+        """
+        raise ValueError("The property 'job_information' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def model_information(self):
+        """Retrieve the model information from the MAPDL instance."""
         return self._get_model_information()
 
     @model_information.setter
     def model_information(self, value):
-        raise ValueError("The method 'model_information' cannot be changed")
+        """Set the value for the MAPDL Model Information
+
+        .. warning:: By default, you cannot change 'model_information' property.
+
+        """
+        raise ValueError("The property 'model_information' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def boundary_condition_information(self):
+        """Retrieve the boundary condition information from the MAPDL instance."""
         return self._get_boundary_condition_information()
 
     @boundary_condition_information.setter
     def boundary_condition_information(self, value):
+        """Set the value for the MAPDL Boundary Condition Information
+
+        .. warning:: By default, you cannot change 'boundary_condition_information' property.
+
+        """
         raise ValueError(
             "The method 'boundary_condition_information' cannot be changed"
         )
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def routine_information(self):
+        """Retrieve the routine information from the MAPDL instance."""
         return self._get_routine_information()
 
     @routine_information.setter
     def routine_information(self, value):
-        raise ValueError("The method 'routine_information' cannot be changed")
+        """Set the value for the MAPDL Routine Information
+
+        .. warning:: By default, you cannot change 'routine_information' property.
+
+        """
+        raise ValueError("The property 'routine_information' cannot be changed")
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def solution_options_configuration(self):
+        """Retrieve the solution options configuration from the MAPDL instance."""
         return self._get_solution_options_configuration()
 
     @solution_options_configuration.setter
     def solution_options_configuration(self, value):
+        """Set the value for the MAPDL Solution Options Configuration
+
+        .. warning:: By default, you cannot change 'solution_options_configuration' property.
+
+        """
         raise ValueError(
             "The method 'solution_options_configuration' cannot be changed"
         )
 
     @property
-    @requires_update(False)
+    @update_information_first(True)
     def load_step_options(self):
+        """Retrieve the load step options from the MAPDL instance."""
         return self._get_load_step_options()
 
     @load_step_options.setter
     def load_step_options(self, value):
-        raise ValueError("The method 'load_step_options' cannot be changed")
+        """Set the value for the MAPDL Load Step Options
+
+        .. warning:: By default, you cannot change 'load_step_options' property.
+
+        """
+        raise ValueError("The property 'load_step_options' cannot be changed")
 
     def _get_between(self, init_string, end_string=None, string=None):
         if not string:

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -443,6 +443,11 @@ class Information(dict):
 
     The results are cached for later calls.
 
+    If you provide any of ``/STATUS`` arguments
+    (``"ALL"``, ``"TITLE"``, ``"UNITS"``, ``"MEM"``, ``"DB"``,
+     ``"CONFIG"``, ``"GLOBAL"``, ``"SOLU"``, or ``"PROD"``),
+    the return will be the raw MAPDL output form that command.
+
     Examples
     --------
     >>> mapdl.info
@@ -486,7 +491,7 @@ class Information(dict):
             if self._mapdl._exited:  # pragma: no cover
                 raise RuntimeError("Information class: MAPDL exited")
 
-            stats = self._mapdl.slashstatus("PROD")
+            stats = self._mapdl.slashstatus("ALL")
             self._stats = stats
         except Exception:  # pragma: no cover
             raise RuntimeError("Information class: MAPDL exited")
@@ -527,7 +532,9 @@ class Information(dict):
             "Boundary condition information", self.get_boundary_condition_information()
         )
         super().__setitem__("Routine information", self.get_routine_information())
-        super().__setitem__("Solution options", self.get_solution_options())
+        super().__setitem__(
+            "Solution options configuration", self.get_solution_options_configuration()
+        )
         super().__setitem__("Load step options", self.get_load_step_options())
 
         self.cached = True
@@ -535,6 +542,20 @@ class Information(dict):
     def __getitem__(self, key):
         if not self.cached:
             self._query()
+
+        # In case we are providing the args of "/STATUS"
+        if key.upper() in [
+            "ALL",
+            "TITLE",
+            "UNITS",
+            "MEM",
+            "DB",
+            "CONFIG",
+            "GLOBAL",
+            "SOLU",
+            "PROD",
+        ]:
+            return self._mapdl.slashstatus(key.upper())
 
         return super().__getitem__(key)
 
@@ -636,7 +657,7 @@ class Information(dict):
         end_string = None
         return self._get_between(init_, end_string)
 
-    def get_solution_options(self):
+    def get_solution_options_configuration(self):
         init_ = "S O L U T I O N   O P T I O N S"
         end_string = "L O A D   S T E P   O P T I O N S"
         return self._get_between(init_, end_string)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1360,3 +1360,12 @@ def test_mpfunctions(mapdl, cube_solve, capsys):
     # Test suppliying a dir path when in remote
     with pytest.raises(IOError):
         mapdl.mpwrite("/test_dir/test", "mp")
+
+
+def test_mapdl_str(mapdl, capfd):
+    print(mapdl)
+
+    out, _ = capfd.readouterr()
+    assert "Ansys" in out
+    assert "Product" in out
+    assert "MAPDL Version" in out

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1367,7 +1367,7 @@ def test_mapdl_str(mapdl, capfd):
     print(mapdl)
 
     out, _ = capfd.readouterr()
-    assert "Ansys" in out
+    assert "ansys" in out.lower()
     assert "Product" in out
     assert "MAPDL Version" in out
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1363,10 +1363,8 @@ def test_mpfunctions(mapdl, cube_solve, capsys):
         mapdl.mpwrite("/test_dir/test", "mp")
 
 
-def test_mapdl_str(mapdl, capfd):
-    print(mapdl)
-
-    out, _ = capfd.readouterr()
+def test_mapdl_str(mapdl):
+    out = str(mapdl)
     assert "ansys" in out.lower()
     assert "Product" in out
     assert "MAPDL Version" in out

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -67,37 +67,6 @@ def test_check_valid_start_instance(start_instance):
     check_valid_start_instance(start_instance)
 
 
-def test_info(mapdl, capfd):
-    info = mapdl.info
-
-    # Some versions have this in upper case??
-    assert "ansys" in info["Product"].lower()
-    assert "RELEASE" in info["MAPDL Version"]
-
-    assert "PyMAPDL" in mapdl.info.__repr__()
-
-    with pytest.raises(ValueError):
-        info["myvalue"] = 1234  # You cannot change info values
-
-    out, _ = capfd.readouterr()  # flushing
-    print(info)
-    out, _ = capfd.readouterr()
-
-    assert "ansys" in out.lower()
-    assert "Product" in out
-    assert "MAPDL Version" in out
-    assert "UPDATE" in out
-
-    for each_key in info:
-        assert len(info[each_key]) >= 9
-
-    # Checking mapping to /STATUS command
-    # The time line changes, as well as DB, so we only check first
-    # part
-    ind = info["ALL"].find("*****    DATABASE STATUS    *****")
-    assert info["ALL"][:ind] == mapdl.slashstatus("ALL")[:ind]
-
-
 def test_get_ansys_bin(mapdl):
     rver = mapdl.__str__().splitlines()[1].split(":")[1].strip().replace(".", "")
     assert isinstance(get_ansys_bin(rver), str)
@@ -108,6 +77,7 @@ def test_mapdl_info(mapdl, capfd):
     for attr, value in inspect.getmembers(info):
         if not attr.startswith("_"):
             assert isinstance(value, str)
+            assert len(value) >= 8
 
             with pytest.raises(ValueError):
                 setattr(info, attr, "any_value")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -86,6 +86,9 @@ def test_info(mapdl, capfd):
     assert "MAPDL Version" in out
     assert "UPDATE" in out
 
+    for each_key in info:
+        assert len(info[each_key]) > 10
+
 
 def test_get_ansys_bin(mapdl):
     rver = mapdl.__str__().splitlines()[1].split(":")[1].strip().replace(".", "")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -77,7 +77,6 @@ def test_mapdl_info(mapdl, capfd):
     for attr, value in inspect.getmembers(info):
         if not attr.startswith("_"):
             assert isinstance(value, str)
-            assert len(value) >= 8
 
             with pytest.raises(ValueError):
                 setattr(info, attr, "any_value")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -109,3 +109,6 @@ def test_info_stitle(mapdl):
 
     info.stitles = stitles
     assert stitles == info.stitles
+
+    info.stitles = None
+    assert not info.stitles

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -87,7 +87,13 @@ def test_info(mapdl, capfd):
     assert "UPDATE" in out
 
     for each_key in info:
-        assert len(info[each_key]) > 10
+        assert len(info[each_key]) >= 9
+
+    # Checking mapping to /STATUS command
+    # The time line changes, as well as DB, so we only check first
+    # part
+    ind = info["ALL"].find("*****    DATABASE STATUS    *****")
+    assert info["ALL"][:ind] == mapdl.slashstatus("ALL")[:ind]
 
 
 def test_get_ansys_bin(mapdl):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -82,12 +82,30 @@ def test_mapdl_info(mapdl, capfd):
                 setattr(info, attr, "any_value")
 
     assert "PyMAPDL" in mapdl.info.__repr__()
-
-    out, _ = capfd.readouterr()  # flushing
-    print(info)
-    out, _ = capfd.readouterr()
+    out = info.__str__()
 
     assert "ansys" in out.lower()
     assert "Product" in out
     assert "MAPDL Version" in out
     assert "UPDATE" in out
+
+
+def test_info_title(mapdl):
+    title = "this is my title"
+    mapdl.info.title = title
+    assert title == mapdl.info.title
+
+
+def test_info_stitle(mapdl):
+    info = mapdl.info
+
+    assert not info.stitles
+    stitles = ["asfd", "qwer", "zxcv", "jkl"]
+    info.stitles = "\n".join(stitles)
+
+    assert stitles == info.stitles
+
+    stitles = stitles[::-1]
+
+    info.stitles = stitles
+    assert stitles == info.stitles

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,6 @@
 """Small or misc tests that don't fit in other test modules"""
+import inspect
+
 import pytest
 from pyvista.plotting import system_supports_plotting
 
@@ -99,3 +101,24 @@ def test_info(mapdl, capfd):
 def test_get_ansys_bin(mapdl):
     rver = mapdl.__str__().splitlines()[1].split(":")[1].strip().replace(".", "")
     assert isinstance(get_ansys_bin(rver), str)
+
+
+def test_mapdl_info(mapdl, capfd):
+    info = mapdl.info
+    for attr, value in inspect.getmembers(info):
+        if not attr.startswith("_"):
+            assert isinstance(value, str)
+
+            with pytest.raises(ValueError):
+                setattr(info, attr, "any_value")
+
+    assert "PyMAPDL" in mapdl.info.__repr__()
+
+    out, _ = capfd.readouterr()  # flushing
+    print(info)
+    out, _ = capfd.readouterr()
+
+    assert "ansys" in out.lower()
+    assert "Product" in out
+    assert "MAPDL Version" in out
+    assert "UPDATE" in out

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -65,16 +65,24 @@ def test_check_valid_start_instance(start_instance):
     check_valid_start_instance(start_instance)
 
 
-def test_info(mapdl):
+def test_info(mapdl, capfd):
     info = mapdl.info
 
-    assert "ANSYS" in info["Product"]
+    assert "Ansys" in info["Product"]
     assert "RELEASE" in info["MAPDL Version"]
 
     assert "PyMAPDL" in mapdl.info.__repr__()
 
     with pytest.raises(ValueError):
         info["myvalue"] = 1234  # You cannot change info values
+
+    out, _ = capfd.readouterr()  # flushing
+    print(info)
+    out, _ = capfd.readouterr()
+
+    assert "Ansys" in out
+    assert "Product" in out
+    assert "MAPDL Version" in out
 
 
 def test_get_ansys_bin(mapdl):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -62,3 +62,15 @@ def test_check_valid_port(port):
 )
 def test_check_valid_start_instance(start_instance):
     check_valid_start_instance(start_instance)
+
+
+def test_info(mapdl):
+    info = mapdl.info
+
+    assert "Ansys" in info["Product"]
+    assert "RELEASE" in info["MAPDL Version"]
+
+    assert "PyMAPDL" in mapdl.info.__repr__()
+
+    with pytest.raises(ValueError):
+        info["myvalue"] = 1234  # You cannot change info values

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -68,7 +68,8 @@ def test_check_valid_start_instance(start_instance):
 def test_info(mapdl, capfd):
     info = mapdl.info
 
-    assert "Ansys" in info["Product"]
+    # Some versions have this in upper case??
+    assert "ansys" in info["Product"].lower()
     assert "RELEASE" in info["MAPDL Version"]
 
     assert "PyMAPDL" in mapdl.info.__repr__()
@@ -80,9 +81,10 @@ def test_info(mapdl, capfd):
     print(info)
     out, _ = capfd.readouterr()
 
-    assert "Ansys" in out
+    assert "ansys" in out.lower()
     assert "Product" in out
     assert "MAPDL Version" in out
+    assert "UPDATE" in out
 
 
 def test_get_ansys_bin(mapdl):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -68,7 +68,7 @@ def test_check_valid_start_instance(start_instance):
 def test_info(mapdl):
     info = mapdl.info
 
-    assert "Ansys" in info["Product"]
+    assert "ANSYS" in info["Product"]
     assert "RELEASE" in info["MAPDL Version"]
 
     assert "PyMAPDL" in mapdl.info.__repr__()
@@ -80,4 +80,3 @@ def test_info(mapdl):
 def test_get_ansys_bin(mapdl):
     rver = mapdl.__str__().splitlines()[1].split(":")[1].strip().replace(".", "")
     assert isinstance(get_ansys_bin(rver), str)
-

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -75,7 +75,7 @@ def test_get_ansys_bin(mapdl):
 def test_mapdl_info(mapdl, capfd):
     info = mapdl.info
     for attr, value in inspect.getmembers(info):
-        if not attr.startswith("_"):
+        if not attr.startswith("_") and attr not in ["title", "stitles"]:
             assert isinstance(value, str)
 
             with pytest.raises(ValueError):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -78,7 +78,7 @@ def test_mapdl_info(mapdl, capfd):
         if not attr.startswith("_") and attr not in ["title", "stitles"]:
             assert isinstance(value, str)
 
-            with pytest.raises(ValueError):
+            with pytest.raises(AttributeError):
                 setattr(info, attr, "any_value")
 
     assert "PyMAPDL" in mapdl.info.__repr__()


### PR DESCRIPTION
This class provide some MAPDL information in a "dict-like" manner.

  It is also the object that is called when you issue "print(mapdl)",
  which means it is called by "mapdl.__str__()".

  Notes
  -----
  You cannot directly modify the values of the keys.

  The results are cached for later calls.

  Examples
  --------
```
  >>> mapdl.info
  Product:             Ansys Mechanical Enterprise
  MAPDL Version:       21.2
  ansys.mapdl Version: 0.62.dev0

  >>> print(mapdl)
  Product:             Ansys Mechanical Enterprise
  MAPDL Version:       21.2
  ansys.mapdl Version: 0.62.dev0

  >>> mapdl.info['Product']
  'Ansys Mechanical Enterprise'

  >>> info = mapdl.info
  >>> info['MAPDL Version']
  'RELEASE  2021 R2           BUILD 21.2      UPDATE 20210601'
```