### PR TITLE
`mapdl.input` not working in local and without fullpath

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1373,6 +1373,11 @@ class MapdlGrpc(_MapdlCore):
         fext = fname.split(".")[-1]
         ffullpath = os.path.join(fpath, fname)
 
+        # if there is no dirname, we are assuming the file is
+        # in the python working directory.
+        if not fpath:
+            fpath = os.getcwd()
+
         if os.path.exists(ffullpath) and self._local:
             return ffullpath
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1371,12 +1371,13 @@ class MapdlGrpc(_MapdlCore):
         fpath = os.path.dirname(fname)
         fname = os.path.basename(fname)
         fext = fname.split(".")[-1]
-        ffullpath = os.path.join(fpath, fname)
 
         # if there is no dirname, we are assuming the file is
         # in the python working directory.
         if not fpath:
             fpath = os.getcwd()
+
+        ffullpath = os.path.join(fpath, fname)
 
         if os.path.exists(ffullpath) and self._local:
             return ffullpath


### PR DESCRIPTION
this was failing:

```
mapdl.input('file.txt') # file.txt in os.getcwd()
```

Because we were passing to the /INPUT only the fname, not the full route. When the python working directory and MAPDL one are different, this will raise an error.

Now it should work.