### PR TITLE
PyPIM integration

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,6 +72,8 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "pyvista": ("https://docs.pyvista.org/", None),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "pypim": ("https://pypim.docs.pyansys.com/", None),
 }
 
 suppress_warnings = ["label.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "ansys-api-mapdl==0.5.1",  # supports at least 2020R2 - 2022R1
     "ansys-corba; python_version < '3.9'",
     "ansys-mapdl-reader>=0.51.7",
+    "ansys-platform-instancemanagement~=0.2.0",
     "appdirs>=1.4.0",
     "grpcio>=1.30.0",  # tested up to grpcio==1.35
     "importlib-metadata >=4.0",

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -531,7 +531,7 @@ def launch_remote_mapdl(
 
     Parameters
     ----------
-    version: str, optional
+    version : str, optional
         The MAPDL version to run, in the 3 digits format, such as "212".
 
         If unspecified, the version will be chosen by the server.

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1247,6 +1247,12 @@ def launch_mapdl(
         port = int(os.environ.get("PYMAPDL_PORT", MAPDL_DEFAULT_PORT))
         check_valid_port(port)
 
+    # Start MAPDL with PyPIM if the environment is configured for it
+    # and the user did not pass a directive on how to launch it.
+    if pypim.is_configured() and exec_file is None:
+        LOG.info("Starting MAPDL remotely. The startup configuration will be ignored.")
+        return launch_remote_mapdl(cleanup_on_exit=cleanup_on_exit)
+
     # connect to an existing instance if enabled
     if start_instance is None:
         start_instance = check_valid_start_instance(
@@ -1306,12 +1312,6 @@ def launch_mapdl(
         if clear_on_connect:
             mapdl.clear()
         return mapdl
-
-    if pypim.is_configured() and exec_file is None:
-        # Start MAPDL with PyPIM if the environment is configured for it
-        # and the user did not pass a directive on how to launch it.
-        LOG.info("Starting MAPDL remotely. The startup configuration will be ignored.")
-        return launch_remote_mapdl(cleanup_on_exit=cleanup_on_exit)
 
     # verify executable
     if exec_file is None:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -221,6 +221,15 @@ class MapdlGrpc(_MapdlCore):
         Print the command ``/COM`` arguments to the standard output.
         Default ``False``.
 
+    channel : grpc.Channel, optional
+        gRPC channel to use for the connection. Can be used as an
+        alternative to the ``ip`` and ``port`` parameters.
+
+    remote_instance : ansys.platform.instancemanagement.Instance
+        The corresponding remote instance when MAPDL is launched through
+        PyPIM. This instance will be deleted when calling
+        :func:`Mapdl.exit <ansys.mapdl.core.Mapdl.exit>`.
+
     Examples
     --------
     Connect to an instance of MAPDL already running on locally on the
@@ -269,10 +278,12 @@ class MapdlGrpc(_MapdlCore):
         remove_temp_files=False,
         print_com=False,
         channel=None,
+        remote_instance=None,
         **kwargs,
     ):
         """Initialize connection to the mapdl server"""
         self.__distributed = None
+        self._remote_instance = remote_instance
 
         if channel is not None:
             if ip is not None or port is not None:
@@ -814,6 +825,9 @@ class MapdlGrpc(_MapdlCore):
         self._kill()  # sets self._exited = True
         self._close_process()
         self._remove_lock_file()
+
+        if self._remote_instance:
+            self._remote_instance.delete()
 
         if self._remove_tmp and self._local:
             self._log.debug("Removing local temporary files")

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -827,7 +827,8 @@ class MapdlGrpc(_MapdlCore):
         self._remove_lock_file()
 
         if self._remote_instance:
-            self._remote_instance.delete()
+            # No cover: The CI is working with a single MAPDL instance
+            self._remote_instance.delete()  # pragma: no cover
 
         if self._remove_tmp and self._local:
             self._log.debug("Removing local temporary files")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,10 +1,7 @@
 """Test the mapdl launcher"""
 import os
-from unittest.mock import create_autospec
 import weakref
 
-import ansys.platform.instancemanagement as pypim
-import grpc
 import pytest
 
 from ansys.mapdl import core as pymapdl
@@ -19,7 +16,6 @@ from ansys.mapdl.core.launcher import (
     warn_uncommon_executable_path,
 )
 from ansys.mapdl.core.licensing import LICENSES
-from ansys.mapdl.core.mapdl_grpc import MAX_MESSAGE_LENGTH
 from ansys.mapdl.core.misc import get_ansys_bin
 
 try:
@@ -303,59 +299,3 @@ def test_warn_uncommon_executable_path():
         UserWarning, match="does not match the usual ansys executable path style"
     ):
         warn_uncommon_executable_path("")
-
-
-def test_launch_remote_instance(monkeypatch, mapdl):
-    # Create a mock pypim pretenting it is configured and returning a channel to an already running mapdl
-    mock_instance = pypim.Instance(
-        definition_name="definitions/fake-mapdl",
-        name="instances/fake-mapdl",
-        ready=True,
-        status_message=None,
-        services={"grpc": pypim.Service(uri=mapdl._channel_str, headers={})},
-    )
-    pim_channel = grpc.insecure_channel(
-        mapdl._channel_str,
-        options=[
-            ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
-        ],
-    )
-    mock_instance.wait_for_ready = create_autospec(mock_instance.wait_for_ready)
-    mock_instance.build_grpc_channel = create_autospec(
-        mock_instance.build_grpc_channel, return_value=pim_channel
-    )
-    mock_instance.delete = create_autospec(mock_instance.delete)
-
-    mock_client = pypim.Client(channel=grpc.insecure_channel("localhost:12345"))
-    mock_client.create_instance = create_autospec(
-        mock_client.create_instance, return_value=mock_instance
-    )
-
-    mock_connect = create_autospec(pypim.connect, return_value=mock_client)
-    mock_is_configured = create_autospec(pypim.is_configured, return_value=True)
-    monkeypatch.setattr(pypim, "connect", mock_connect)
-    monkeypatch.setattr(pypim, "is_configured", mock_is_configured)
-
-    # Start MAPDL with launch_mapdl
-    # Note: This is mocking to start MAPDL, but actually reusing the common one
-    # Thus cleanup_on_exit is set to false
-    mapdl = launch_mapdl(cleanup_on_exit=False)
-
-    # Assert: pymapdl went through the pypim workflow
-    assert mock_is_configured.called
-    assert mock_connect.called
-    mock_client.create_instance.assert_called_with(
-        product_name="mapdl", product_version=None
-    )
-    assert mock_instance.wait_for_ready.called
-    mock_instance.build_grpc_channel.assert_called_with(
-        options=[
-            ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
-        ]
-    )
-
-    # And it connected using the channel created by PyPIM
-    assert mapdl._channel == pim_channel
-
-    # and it kept track of the instance to be able to delete it
-    assert mapdl._remote_instance == mock_instance

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -1,0 +1,64 @@
+"""Test the PyPIM integration."""
+from unittest.mock import create_autospec
+
+import ansys.platform.instancemanagement as pypim
+import grpc
+
+from ansys.mapdl.core.launcher import launch_mapdl
+from ansys.mapdl.core.mapdl_grpc import MAX_MESSAGE_LENGTH
+
+
+def test_launch_remote_instance(monkeypatch, mapdl):
+    # Create a mock pypim pretenting it is configured and returning a channel to an already running mapdl
+    mock_instance = pypim.Instance(
+        definition_name="definitions/fake-mapdl",
+        name="instances/fake-mapdl",
+        ready=True,
+        status_message=None,
+        services={"grpc": pypim.Service(uri=mapdl._channel_str, headers={})},
+    )
+    pim_channel = grpc.insecure_channel(
+        mapdl._channel_str,
+        options=[
+            ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
+        ],
+    )
+    mock_instance.wait_for_ready = create_autospec(mock_instance.wait_for_ready)
+    mock_instance.build_grpc_channel = create_autospec(
+        mock_instance.build_grpc_channel, return_value=pim_channel
+    )
+    mock_instance.delete = create_autospec(mock_instance.delete)
+
+    mock_client = pypim.Client(channel=grpc.insecure_channel("localhost:12345"))
+    mock_client.create_instance = create_autospec(
+        mock_client.create_instance, return_value=mock_instance
+    )
+
+    mock_connect = create_autospec(pypim.connect, return_value=mock_client)
+    mock_is_configured = create_autospec(pypim.is_configured, return_value=True)
+    monkeypatch.setattr(pypim, "connect", mock_connect)
+    monkeypatch.setattr(pypim, "is_configured", mock_is_configured)
+
+    # Start MAPDL with launch_mapdl
+    # Note: This is mocking to start MAPDL, but actually reusing the common one
+    # Thus cleanup_on_exit is set to false
+    mapdl = launch_mapdl(cleanup_on_exit=False)
+
+    # Assert: pymapdl went through the pypim workflow
+    assert mock_is_configured.called
+    assert mock_connect.called
+    mock_client.create_instance.assert_called_with(
+        product_name="mapdl", product_version=None
+    )
+    assert mock_instance.wait_for_ready.called
+    mock_instance.build_grpc_channel.assert_called_with(
+        options=[
+            ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
+        ]
+    )
+
+    # And it connected using the channel created by PyPIM
+    assert mapdl._channel == pim_channel
+
+    # and it kept track of the instance to be able to delete it
+    assert mapdl._remote_instance == mock_instance


### PR DESCRIPTION
This PR integrates [PyPIM](https://pypim.docs.pyansys.com/) in the `launch_mapdl` function. The intention is that a caller using `pymapdl.launch_mapdl()` without specific instructions on how to launch it will be redirected to using a remote instance when this is running in a pre-configured environment. This is the workflow targeted in the internal Ansys Lab.

This method will use PyPIM under the condition that:
 - PyPIM is configured: See [pypim doc](https://pypim.docs.pyansys.com/api/index.html#ansys.platform.instancemanagement.connect)
 - The user did not pass a specific executable path. In that situation, we assume that the caller have specific requirements

In this workflow, most of the configuration (arguments, ...) is ignored. While some of these configuration may be reintroduced later, the initial version of PIM delegates all the control server side.
