### PR TITLE
Removing ``scooby`` dependency

### DIFF
--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -50,7 +50,7 @@ class Plain_Report:
         Base class for a plain report.
 
 
-        Based on package "scooby" (https://github.com/banesullivan/scooby)
+        Based on `scooby <https://github.com/banesullivan/scooby>`_ package.
 
         Parameters
         ----------

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -72,6 +72,8 @@ class Plain_Report:
         from importlib.metadata import PackageNotFoundError
         from importlib.metadata import version as get_lib_version
 
+        package = package.replace(".", "-")
+
         try:
             return get_lib_version(package)
         except PackageNotFoundError:

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -16,6 +16,7 @@ import numpy as np
 import scooby
 
 from ansys.mapdl import core as pymapdl
+from ansys.mapdl.core import _HAS_PYVISTA
 
 # path of this module
 MODULE_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))
@@ -86,7 +87,7 @@ class Report(scooby.Report):
 
         # Information about the GPU - bare except in case there is a rendering
         # bug that the user is trying to report.
-        if gpu:
+        if gpu and _HAS_PYVISTA:
             from pyvista.utilities.errors import GPUInfo
 
             try:

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -183,7 +183,6 @@ class Report(base_report_class):
             extra_meta = ("GPU Details", "None")
 
         super().__init__(
-            self,
             additional=additional,
             core=core,
             optional=optional,

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -118,7 +118,7 @@ class Plain_Report:
 
 if _HAS_SCOOBY:
     base_report_class = scooby.Report
-else:
+else:  # pragma: no cover
     base_report_class = Plain_Report
 
 

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -45,7 +45,7 @@ def get_ansys_bin(rver):
 
 
 class Plain_Report:
-    def __init__(self, core, optional, additional, **kwargs):
+    def __init__(self, core, optional=None, additional=None, **kwargs):
         """
         Base class for a plain report.
 
@@ -179,7 +179,7 @@ class Report(base_report_class):
 
             try:
                 extra_meta = [(t[1], t[0]) for t in GPUInfo().get_info()]
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 extra_meta = ("GPU Details", f"Error: {e.message}")
         else:
             extra_meta = ("GPU Details", "None")

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -13,10 +13,17 @@ from threading import Thread
 import weakref
 
 import numpy as np
-import scooby
 
 from ansys.mapdl import core as pymapdl
-from ansys.mapdl.core import _HAS_PYVISTA
+from ansys.mapdl.core import _HAS_PYVISTA, LOG
+
+try:
+    import scooby
+
+    _HAS_SCOOBY = True
+except ModuleNotFoundError:  # pragma: no cover
+    LOG.debug("The module 'scooby' is not installed.")
+    _HAS_SCOOBY = False
 
 # path of this module
 MODULE_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))
@@ -37,7 +44,85 @@ def get_ansys_bin(rver):
     return mapdlbin
 
 
-class Report(scooby.Report):
+class Plain_Report:
+    def __init__(self, core, optional, additional, **kwargs):
+        """
+        Base class for a plain report.
+
+
+        Based on package "scooby" (https://github.com/banesullivan/scooby)
+
+        Parameters
+        ----------
+        additional : iter[str]
+            List of packages or package names to add to output information.
+        core : iter[str]
+            The core packages to list first.
+        optional : iter[str]
+            A list of packages to list if they are available. If not available,
+            no warnings or error will be thrown.
+        """
+
+        self.additional = additional
+        self.core = core
+        self.optional = optional
+        self.kwargs = kwargs
+
+    def get_version(self, package):
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as get_lib_version
+
+        try:
+            return get_lib_version(package)
+        except PackageNotFoundError:
+            return "Package not found"
+
+    def __repr__(self):
+        header = ["\n", "Packages Requirements", "*********************"]
+
+        core = ["\nCore packages", "-------------"]
+        core.extend(
+            [
+                f"{each.ljust(20)}: {self.get_version(each)}"
+                for each in self.core
+                if self.get_version(each)
+            ]
+        )
+
+        if self.optional:
+            optional = ["\nOptional packages", "-----------------"]
+            optional.extend(
+                [
+                    f"{each.ljust(20)}: {self.get_version(each)}"
+                    for each in self.optional
+                    if self.get_version(each)
+                ]
+            )
+        else:
+            optional = [""]
+
+        if self.additional:
+            additional = ["\nAdditional packages", "-----------------"]
+            additional.extend(
+                [
+                    f"{each.ljust(20)}: {self.get_version(each)}"
+                    for each in self.additional
+                    if self.get_version(each)
+                ]
+            )
+        else:
+            additional = [""]
+
+        return "\n".join(header + core + optional + additional)
+
+
+if _HAS_SCOOBY:
+    base_report_class = scooby.Report
+else:
+    base_report_class = Plain_Report
+
+
+class Report(base_report_class):
     """A class for custom scooby.Report."""
 
     def __init__(self, additional=None, ncol=3, text_width=80, sort=False, gpu=True):
@@ -60,7 +145,7 @@ class Report(scooby.Report):
 
         gpu : bool
             Gather information about the GPU. Defaults to ``True`` but if
-            experiencing renderinng issues, pass ``False`` to safely generate
+            experiencing rendering issues, pass ``False`` to safely generate
             a report.
 
         """
@@ -92,12 +177,12 @@ class Report(scooby.Report):
 
             try:
                 extra_meta = [(t[1], t[0]) for t in GPUInfo().get_info()]
-            except:
-                extra_meta = ("GPU Details", "error")
+            except Exception as e:
+                extra_meta = ("GPU Details", f"Error: {e.message}")
         else:
             extra_meta = ("GPU Details", "None")
 
-        scooby.Report.__init__(
+        super().__init__(
             self,
             additional=additional,
             core=core,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -117,9 +117,9 @@ def test_info_stitle(mapdl):
 def test_plain_report():
     from ansys.mapdl.core.misc import Plain_Report
 
-    core = ["numpy", "grpc"]
+    core = ["numpy", "ansys.mapdl.reader"]
     optional = ["pyvista", "tqdm"]
-    additional = ["sys", "ger"]
+    additional = ["scipy", "ger"]
 
     report = Plain_Report(core=core, optional=optional, additional=additional)
     rep_str = report.__repr__()
@@ -129,7 +129,7 @@ def test_plain_report():
 
     # There should be only one package not found ("ger")
     assert "Package not found" in rep_str
-    _rep_str = rep_str.replace("Package not found", "", count=1)
+    _rep_str = rep_str.replace("Package not found", "", 1)
     assert "Package not found" not in _rep_str
 
     assert "\n" in rep_str

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -138,3 +138,22 @@ def test_plain_report():
     assert "Core packages" in rep_str
     assert "Optional packages" in rep_str
     assert "Additional packages" in rep_str
+
+
+def test_plain_report_no_options():
+    from ansys.mapdl.core.misc import Plain_Report
+
+    core = ["numpy", "ansys.mapdl.reader"]
+
+    report = Plain_Report(core=core)
+    rep_str = report.__repr__()
+
+    for each in core:
+        assert each in rep_str
+
+    assert "\n" in rep_str
+    assert len(rep_str.splitlines()) > 3
+
+    assert "Core packages" in rep_str
+    assert "Optional packages" not in rep_str
+    assert "Additional packages" not in rep_str

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -112,3 +112,29 @@ def test_info_stitle(mapdl):
 
     info.stitles = None
     assert not info.stitles
+
+
+def test_plain_report():
+    from ansys.mapdl.core.misc import Plain_Report
+
+    core = ["numpy", "grpc"]
+    optional = ["pyvista", "tqdm"]
+    additional = ["sys", "ger"]
+
+    report = Plain_Report(core=core, optional=optional, additional=additional)
+    rep_str = report.__repr__()
+
+    for each in core + optional + additional:
+        assert each in rep_str
+
+    # There should be only one package not found ("ger")
+    assert "Package not found" in rep_str
+    _rep_str = rep_str.replace("Package not found", "", count=1)
+    assert "Package not found" not in _rep_str
+
+    assert "\n" in rep_str
+    assert len(rep_str.splitlines()) > 3
+
+    assert "Core packages" in rep_str
+    assert "Optional packages" in rep_str
+    assert "Additional packages" in rep_str


### PR DESCRIPTION
Instead of enforcing ``scooby``, I'm getting a basic template. I think this makes sense because of:

* Reduces the package dependencies (and package size)
* Most of the heavy lifting is done in ``mapdl_info``, which is still used; and when ``gpu`` is equal ``True`` which requires ``Pyvista``, which install ``scooby``. Since we do not want to depend on ``Pyvista``, I think this makes sense.

Close #1086 