### PR TITLE
Adding contain and iter methods.

### DIFF
--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -332,6 +332,12 @@ class Parameters:
         else:
             self._set_parameter(key, value)
 
+    def __contains__(self, key):
+        return key in self._parm.keys()
+
+    def __iter__(self):
+        yield from self._parm.keys()
+
     @supress_logging
     def _set_parameter(self, name, value):
         """Set a single parameter within MAPDL
@@ -578,6 +584,10 @@ def interp_star_status(status):
     """
     parameters = {}
     st = status.find("NAME                              VALUE")
+
+    if st == -1:
+        return {}
+
     for line in status[st + 80 :].splitlines():
         items = line.split()
         if not items:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -186,3 +186,15 @@ def test_parameters_name(mapdl, func, par_name):
         # Avoiding check if indexing or starting and ending with _.
         assert mapdl.parameters[par_name]
         assert isinstance(mapdl.parameters[par_name], float)
+
+
+def test_contain_iter(mapdl, cleared):
+    mapdl.clear()  # to check that #1107 is solved
+    mapdl.parameters["TWO"] = 2.0
+    assert 2.0 == mapdl.parameters["TWO"]
+    assert "TWO" in mapdl.parameters
+
+    # iter
+    mapdl.parameters["THREE"] = 3.0
+    assert hasattr(mapdl.parameters, "__iter__")
+    assert sorted(["TWO", "THREE"]) == [each for each in mapdl.parameters]


### PR DESCRIPTION
This PR does two things:

- Add a scape to ``interp_status`` for the edge case there is no parameters defined. Close #1107 

- Implement ``__contain__`` and ``__iter__`` methods. This way now we can do:
  Because of the ``__contain__``:
```py
>>> mapdl.parameters['TWO'] = 2.0
>>> "TWO" in mapdl.parameters
True
>>> "THREE" in mapdl.parameters
False
```
  Because of the ``__iter__``:
```
>>> for each in mapdl.parameters:
>>>     print(each)
"TWO"
```
  Simple things, that I believe they will be useful.


