### PR TITLE
Adding missing package to report class

### DIFF
--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -155,10 +155,8 @@ class Report(base_report_class):
         # Mandatory packages
         core = [
             "ansys.mapdl.core",
-            "matplotlib",
             "numpy",
             "appdirs",
-            "tqdm",
             "scipy",
             "grpc",  # grpcio
             "ansys.api.mapdl.v0",  # ansys-api-mapdl-v0
@@ -170,7 +168,7 @@ class Report(base_report_class):
             core.extend(["pexpect"])
 
         # Optional packages
-        optional = ["matplotlib", "pyvista", "pyiges"]
+        optional = ["matplotlib", "pyvista", "pyiges", "tqdm"]
         if sys.version_info[1] < 9:
             optional.append("ansys_corba")
 

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -154,6 +154,7 @@ class Report(base_report_class):
         """
         # Mandatory packages
         core = [
+            "ansys.mapdl.core",
             "matplotlib",
             "numpy",
             "appdirs",


### PR DESCRIPTION
I believe we should include PyMAPDL (``ansys.mapdl.core``) in the core packages of the ``Report`` class.