### PR TITLE
Bump PyPIM dependency version to ~=1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "ansys-api-mapdl==0.5.1",  # supports at least 2020R2 - 2022R1
     "ansys-corba; python_version < '3.9'",
     "ansys-mapdl-reader>=0.51.7",
-    "ansys-platform-instancemanagement~=0.2.0",
+    "ansys-platform-instancemanagement~=1.0",
     "appdirs>=1.4.0",
     "grpcio>=1.30.0",  # tested up to grpcio==1.35
     "importlib-metadata >=4.0",


### PR DESCRIPTION
This version doesn't contain any API breaking change or major feature, but starting from this version we will strictly follow semantic versioning.

This version dependencies will allow multiple PyAnsys libraries to depend on `~=1.something` while staying compatible together.
