### PR TITLE
no longer need to pin ansys-mapdl-reader req

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,4 @@ updates:
       - "Dependencies"
     ignore:
       - dependency-name: "vtk"
-      - dependency-name: "ansys-mapdl-reader"
       - dependency-name: "grpcio"


### PR DESCRIPTION
Disable dependabot restriction on `ansys-mapdl-reader`