### PR TITLE
Fixing equal sign in comments and title.

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2428,7 +2428,7 @@ class _MapdlCore(Commands):
             # We are storing a parameter.
             param_name = command.split("=")[0].strip()
 
-            if "'" not in param_name or '"' not in param_name:
+            if "/COM" not in cmd_ and "/TITLE" not in cmd_:
                 # Edge case. `\title, 'par=1234' `
                 self._check_parameter_name(param_name)
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1374,3 +1374,9 @@ def test_plot_empty_mesh(mapdl, cleared):
 
     with pytest.warns(UserWarning):
         mapdl.eplot(vtk=True)
+
+
+def test_equal_in_comments_and_title(mapdl):
+    mapdl.com("=====")
+    mapdl.title("This is = ")
+    mapdl.title("This is '=' ")


### PR DESCRIPTION
Added also unit tests.

Using ``=`` in ``mapdl.com`` was raising issues.