### PR TITLE
Making PIM package lazy

### DIFF
--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -15,7 +15,7 @@ try:
     import ansys.platform.instancemanagement as pypim
 
     _HAS_PIM = True
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     _HAS_PIM = False
 
 import appdirs
@@ -553,7 +553,7 @@ def launch_remote_mapdl(
     ansys.mapdl.core.mapdl._MapdlCore
         An instance of Mapdl.
     """
-    if not _HAS_PIM:
+    if not _HAS_PIM:  # pragma: no cover
         raise ModuleNotFoundError(
             "The package 'ansys-platform-instancemanagement' is required to use this function."
         )

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -11,7 +11,13 @@ import tempfile
 import time
 import warnings
 
-import ansys.platform.instancemanagement as pypim
+try:
+    import ansys.platform.instancemanagement as pypim
+
+    _HAS_PIM = True
+except ModuleNotFoundError:
+    _HAS_PIM = False
+
 import appdirs
 
 from ansys.mapdl import core as pymapdl
@@ -27,6 +33,7 @@ from ansys.mapdl.core.misc import (
     create_temp_dir,
     is_float,
     random_string,
+    requires_package,
     threaded,
 )
 
@@ -520,6 +527,7 @@ def launch_grpc(
     return port, run_location
 
 
+@requires_package("ansys-platform-instancemanagement")
 def launch_remote_mapdl(
     version=None,
     cleanup_on_exit=True,
@@ -1249,9 +1257,12 @@ def launch_mapdl(
 
     # Start MAPDL with PyPIM if the environment is configured for it
     # and the user did not pass a directive on how to launch it.
-    if pypim.is_configured() and exec_file is None:
-        LOG.info("Starting MAPDL remotely. The startup configuration will be ignored.")
-        return launch_remote_mapdl(cleanup_on_exit=cleanup_on_exit)
+    if _HAS_PIM:
+        if pypim.is_configured() and exec_file is None:
+            LOG.info(
+                "Starting MAPDL remotely. The startup configuration will be ignored."
+            )
+            return launch_remote_mapdl(cleanup_on_exit=cleanup_on_exit)
 
     # connect to an existing instance if enabled
     if start_instance is None:

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -33,7 +33,6 @@ from ansys.mapdl.core.misc import (
     create_temp_dir,
     is_float,
     random_string,
-    requires_package,
     threaded,
 )
 
@@ -527,7 +526,6 @@ def launch_grpc(
     return port, run_location
 
 
-@requires_package("ansys-platform-instancemanagement")
 def launch_remote_mapdl(
     version=None,
     cleanup_on_exit=True,
@@ -555,6 +553,11 @@ def launch_remote_mapdl(
     ansys.mapdl.core.mapdl._MapdlCore
         An instance of Mapdl.
     """
+    if not _HAS_PIM:
+        raise ModuleNotFoundError(
+            "The package 'ansys-platform-instancemanagement' is required to use this function."
+        )
+
     pim = pypim.connect()
     instance = pim.create_instance(product_name="mapdl", product_version=version)
     instance.wait_for_ready()

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1257,12 +1257,9 @@ def launch_mapdl(
 
     # Start MAPDL with PyPIM if the environment is configured for it
     # and the user did not pass a directive on how to launch it.
-    if _HAS_PIM:
-        if pypim.is_configured() and exec_file is None:
-            LOG.info(
-                "Starting MAPDL remotely. The startup configuration will be ignored."
-            )
-            return launch_remote_mapdl(cleanup_on_exit=cleanup_on_exit)
+    if _HAS_PIM and exec_file is None and pypim.is_configured():
+        LOG.info("Starting MAPDL remotely. The startup configuration will be ignored.")
+        return launch_remote_mapdl(cleanup_on_exit=cleanup_on_exit)
 
     # connect to an existing instance if enabled
     if start_instance is None:


### PR DESCRIPTION
This PR makes pymapdl to be able to work without PIM package. However, it is still in the requirements. 

You should want to work without PIM when doing development.

Close #1150 