### PR TITLE
Adding 'convert_apdl_block' to docs

### DIFF
--- a/doc/source/api/helper.rst
+++ b/doc/source/api/helper.rst
@@ -12,6 +12,7 @@ or automating other tasks.
 
    
    launch_mapdl
+   convert_apdl_block
    convert_script
    Information
    change_default_ansys_path


### PR DESCRIPTION
As the title.

Adding 'convert_apdl_block' to docs.

Closes #1185 