### PR TITLE
Timeout keyword argument not having effect

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -341,7 +341,7 @@ class MapdlGrpc(_MapdlCore):
             self._channel = channel
 
         # connect and validate to the channel
-        self._multi_connect()
+        self._multi_connect(timeout=timeout)
 
         # double check we have access to the local path if not
         # explicitly specified


### PR DESCRIPTION
It seems the keyword arg `timeout` is not being passed through.

Close #1188 