### PR TITLE
Cancel old ongoing workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ env:
   RESET_AUTOSUMMARY_CACHE: 3
   PACKAGE_NAME: PyMAPDL
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   stylecheck:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -2,6 +2,10 @@ name: "Pull Request Labeler"
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   labeler:


### PR DESCRIPTION
These lines of code will basically cancel pre-existing workflows once you upload new changes, and will avoid running unnecessary workflows. 

Use case:
* You commit and push some changes
* Workflow is triggered
* You find out a minor typo/change while the workflow is still running
* You commit and push the typo/change

In these circumstances, it is more than probable that you will have two workflows running on parallel, though you are not interested in the older one. This way, GitHub cancels the old workflow and just retains the new one.