### PR TITLE
Improvements to ``open_gui``

### DIFF
--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -75,11 +75,18 @@ class LockFileException(RuntimeError):
         RuntimeError.__init__(self, msg)
 
 
-class LicenseServerConnectionError(RuntimeError):
-    """Error when the license server is not available."""
+class MapdlDidNotStart(RuntimeError):
+    """Error when the MAPDL process does not start"""
 
     def __init__(self, msg=""):
         RuntimeError.__init__(self, msg)
+
+
+class LicenseServerConnectionError(MapdlDidNotStart):
+    """Error when the license server is not available."""
+
+    def __init__(self, msg=""):
+        MapdlDidNotStart.__init__(self, msg)
 
 
 # handler for protect_grpc
@@ -144,3 +151,44 @@ def protect_grpc(func):
         return out
 
     return wrapper
+
+
+"""
+-2=caution
+-1=no label (used for u/i pop-ups) timed as a note message
+0=no label (used for u/i pop-ups)
+1=note,
+2=warning,
+3=error,
+4=fatal,
+"""
+
+
+class MapdlException(MapdlRuntimeError):
+    """General MAPDL exception."""
+
+    pass
+
+
+class MapdlError(MapdlException):
+    """General MAPDL Error"""
+
+    pass
+
+
+class MapdlWarning(MapdlException):
+    """General MAPDL warning"""
+
+    pass
+
+
+class MapdlNote(MapdlException):
+    """General MAPDL note"""
+
+    pass
+
+
+class MapdlInfo(MapdlException):
+    """General MAPDL info message"""
+
+    pass

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -22,7 +22,7 @@ import appdirs
 
 from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core import LOG
-from ansys.mapdl.core.errors import LockFileException, VersionError
+from ansys.mapdl.core.errors import LockFileException, MapdlDidNotStart, VersionError
 from ansys.mapdl.core.licensing import ALLOWABLE_LICENSES, LicenseChecker
 from ansys.mapdl.core.mapdl import _MapdlCore
 from ansys.mapdl.core.mapdl_grpc import MAX_MESSAGE_LENGTH, MapdlGrpc
@@ -496,9 +496,8 @@ def launch_grpc(
             ]
         )
         command = " ".join(command_parm)
-
+    LOG.info(f"Running in {ip}:{port} the following command: '{command}'")
     if verbose:
-        print(f"Running {command}")
         subprocess.Popen(command, shell=os.name != "nt", cwd=run_location)
     else:
         subprocess.Popen(
@@ -520,8 +519,12 @@ def launch_grpc(
         files = os.listdir(run_location)
         has_ans = any([filename for filename in files if ".err" in filename])
         if has_ans:
+            LOG.info(f"MAPDL session successfully started (Error file found)")
             break
         time.sleep(sleep_time)
+
+    if not has_ans:
+        raise MapdlDidNotStart(f"MAPDL failed to start (No err file generated)")
 
     return port, run_location
 


### PR DESCRIPTION
Change the name of the temporal database to the original db file name.

Added option to run ``open_gui`` from the working location. By default, this is not the case.

Close #1266 