### PR TITLE
Fixing using ``clear_on_connect``

### DIFF
--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1318,7 +1318,7 @@ def launch_mapdl(
             return mapdl
 
     if not start_instance:
-        if clear_on_connect is None:
+        if clear_on_connect is None:  # pragma: no cover
             clear_on_connect = False
 
         mapdl = MapdlGrpc(

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1073,9 +1073,9 @@ def launch_mapdl(
         environment variable "PYMAPDL_IP=FALSE".
 
     clear_on_connect : bool, optional
-        Used only when ``start_instance`` is ``False``.  Defaults to
-        ``True``, giving you a fresh environment when connecting to
-        MAPDL.
+        Defaults to ``True``, giving you a fresh environment when
+        connecting to MAPDL. Except if ``start_instance`` is specified
+        then, it defaults to ``False``.
 
     log_apdl : str, optional
         Enables logging every APDL command to the local disk.  This
@@ -1318,7 +1318,10 @@ def launch_mapdl(
             return mapdl
 
     if not start_instance:
-        return MapdlGrpc(
+        if clear_on_connect is None:
+            clear_on_connect = False
+
+        mapdl = MapdlGrpc(
             ip=ip,
             port=port,
             cleanup_on_exit=False,


### PR DESCRIPTION
Fix the mapdl ``clear_on_connect`` argument defaults when ``start_instance`` is used.

Close #1270 