### PR TITLE
Double precision parameter retrieving

### DIFF
--- a/src/ansys/mapdl/core/logging.py
+++ b/src/ansys/mapdl/core/logging.py
@@ -183,7 +183,7 @@ class PymapdlCustomAdapter(logging.LoggerAdapter):
         kwargs["extra"][
             "instance_name"
         ] = (
-            self.extra.get_name()
+            self.extra.name()
         )  # here self.extra is the argument pass to the log records.
         return msg, kwargs
 
@@ -476,7 +476,7 @@ class Logger:
             instance_logger = PymapdlCustomAdapter(
                 self._make_child_logger(name, level), mapdl_instance
             )
-        elif isinstance(name, None):
+        elif not name:
             instance_logger = PymapdlCustomAdapter(
                 self._make_child_logger("NO_NAMED_YET", level), mapdl_instance
             )

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -150,6 +150,7 @@ class _MapdlCore(Commands):
         **start_parm,
     ):
         """Initialize connection with MAPDL."""
+        self._name = None  # For naming the instance.
         self._show_matplotlib_figures = True  # for testing
         self._query = None
         self._exited = False
@@ -269,9 +270,12 @@ class _MapdlCore(Commands):
                 setattr(self, name, wrap_bc_listing_function(func))
 
     @property
-    def _name(self):  # pragma: no cover
-        """Implemented by child class"""
-        raise NotImplementedError("Implemented by child class")
+    def name(self):
+        raise NotImplementedError("Implemented by child classes.")
+
+    @name.setter
+    def name(self, name):
+        raise ValueError("The name of an instance cannot be changed.")
 
     @property
     def queries(self):

--- a/src/ansys/mapdl/core/mapdl_console.py
+++ b/src/ansys/mapdl/core/mapdl_console.py
@@ -235,6 +235,8 @@ class MapdlConsole(_MapdlCore):
                 self._log.debug("Killed process %d", self._process.pid)
 
     @property
-    def _name(self):
+    def name(self):
         """Instance unique identifier."""
-        return f"Console_PID_{self._process.pid}"
+        if not self._name:
+            self._name = f"Console_PID_{self._process.pid}"
+        return self._name

--- a/src/ansys/mapdl/core/mapdl_corba.py
+++ b/src/ansys/mapdl/core/mapdl_corba.py
@@ -401,8 +401,10 @@ class MapdlCorba(_MapdlCore):
         self._outfile = None
 
     @property
-    def _name(self):
+    def name(self):
         """Instance unique identifier."""
-        if hasattr(self, "_corba_key"):
-            return f"CORBA_PID_{self._corba_key}"
-        return f"CORBA_INSTANCE_{id(self)}"
+        if not self._name:
+            if hasattr(self, "_corba_key"):
+                self._name = f"CORBA_PID_{self._corba_key}"
+            self._name = f"CORBA_INSTANCE_{id(self)}"
+        return self._name

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2322,13 +2322,13 @@ class MapdlGrpc(_MapdlCore):
         super().cmatrix(symfac, condname, numcond, grndkey, capname, **kwargs)
 
     @property
-    def _name(self):
+    def name(self):
         """Instance unique identifier."""
-        if self._ip or self._port:
-            return f"GRPC_{self._ip}:{self._port}"
-        return f"GRPC_instance_{id(self)}"
-
-    def get_name(self):
+        if not self._name:
+            if self._ip or self._port:
+                self._name = f"GRPC_{self._ip}:{self._port}"
+            else:
+                self._name = f"GRPC_instance_{id(self)}"
         return self._name
 
     @property

--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -321,14 +321,17 @@ class Parameters:
             raise IndexError("%s not a valid parameter_name" % key)
 
         parm = parameters[key]
-        if parm["type"] in ["ARRAY", "TABLE"]:
+        if parm["type"] in ["ARRAY", "TABLE"]:  # Array case
             try:
                 return self._get_parameter_array(key, parm["shape"])
             except ValueError:
                 # allow a second attempt
                 return self._get_parameter_array(key, parm["shape"])
-
-        return parm["value"]
+        else:
+            if "grpc" in self._mapdl.name.lower():
+                return self._mapdl.scalar_param(key)
+            else:
+                return parm["value"]
 
     def __setitem__(self, key, value):
         """Set a parameter"""

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -138,9 +138,16 @@ def warns_in_cdread_error_log(mapdl):
 
 @pytest.mark.skip_grpc
 def test_internal_name_grpc(mapdl):
-    assert str(mapdl._ip) in mapdl._name
-    assert str(mapdl._port) in mapdl._name
-    assert "GRPC" in mapdl._name
+
+    assert str(mapdl._ip) in mapdl.name
+    assert str(mapdl._port) in mapdl.name
+    assert "GRPC" in mapdl.name
+
+    assert mapdl.name
+    assert mapdl.name == mapdl._name
+
+    with pytest.raises(AttributeError):
+        mapdl.name = "asfd"
 
 
 def test_jobname(mapdl, cleared):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -198,3 +198,29 @@ def test_contain_iter(mapdl, cleared):
     mapdl.parameters["THREE"] = 3.0
     assert hasattr(mapdl.parameters, "__iter__")
     assert sorted(["TWO", "THREE"]) == [each for each in mapdl.parameters]
+
+
+@pytest.mark.parametrize("number", [1 / 3, 1 / 7, 0.0181681816816816168168168])
+def test_double_parameter_get(mapdl, number):
+    # Running grpc method
+    mapdl.parameters["value"] = number
+
+    precision_single = 9
+    precision_double = 12
+    assert np.around(mapdl.parameters["value"], precision_single) == np.around(
+        number, precision_single
+    )
+    assert np.around(mapdl.parameters["value"], precision_double) == np.around(
+        number, precision_double
+    )
+
+    # to use the alternative method (single precision)
+    mapdl_name = mapdl._name
+    mapdl._name = "dummy"
+    assert np.around(mapdl.parameters["value"], precision_single) == np.around(
+        number, precision_single
+    )
+    assert np.around(mapdl.parameters["value"], precision_double) != np.around(
+        number, precision_double
+    )
+    mapdl._name = mapdl_name


### PR DESCRIPTION
Following the comments and suggestions from @clatapie, the gRPC methods are now default to obtain single parameters values. 

I also refactored the ``name`` parameter implementation.


A following PR should come implementing the same for arrays.