### PR TITLE
Download error page and helper

### DIFF
--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -43,3 +43,24 @@ Here are a series of examples using MAPDL with ``ansys-mapdl-core``.
 .. include:: extended_examples/index.rst
    :start-line: 2
 
+
+.. === DOWNLOAD EXAMPLES ===
+
+.. _ref_download_files:
+
+Download Example Files
+======================
+
+Each example should contain all the necessary resources to run each example.
+However in some cases, external files are needed. A link to those files is
+available at each example page.
+These links refers to the following GitHub repository where you can find all of them:
+
+`GitHub Example Data Repository <https://github.com/pyansys/example-data>`_
+
+If you find out a missing or broken link, please open an issue in
+Github (`PyMAPDL Issues <https://github.com/pyansys/pymapdl/issues>`_) 
+or email us at `PyAnsys Support <pyansys.support@ansys.com>`_. 
+
+
+

--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -51,7 +51,7 @@ Here are a series of examples using MAPDL with ``ansys-mapdl-core``.
 Download Example Files
 ======================
 
-Each example should contain all the necessary resources to run each example.
+Each example should contain all the necessary resources to run the example.
 However in some cases, external files are needed. A link to those files is
 available at each example page.
 These links refers to the following GitHub repository where you can find all of them:

--- a/src/ansys/mapdl/core/examples/downloads.py
+++ b/src/ansys/mapdl/core/examples/downloads.py
@@ -59,7 +59,7 @@ def _download_file(filename, directory=None):
     try:
         return _retrieve_file(url, filename)
     except Exception as e:  # Genering exception
-        raise Exception(
+        raise RuntimeError(
             "For the reason mentioned below, retrieving the file from internet failed.\n"
             "You can download this file from:\n"
             f"{url}\n"

--- a/src/ansys/mapdl/core/examples/downloads.py
+++ b/src/ansys/mapdl/core/examples/downloads.py
@@ -56,7 +56,17 @@ def _retrieve_file(url, filename):
 
 def _download_file(filename, directory=None):
     url = _get_file_url(filename, directory)
-    return _retrieve_file(url, filename)
+    try:
+        return _retrieve_file(url, filename)
+    except Exception as e:  # Genering exception
+        raise Exception(
+            "For the reason mentioned below, retrieving the file from internet failed.\n"
+            "You can download this file from:\n"
+            f"{url}\n"
+            "\n"
+            "The reported error message is:\n"
+            f"{str(e)}"
+        )
 
 
 def download_bracket():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -31,5 +31,5 @@ def test_download_example_data():
 
 def test_failed_download():
     filename = "non_existing_file"
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         _download_file(filename, directory=None)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,8 +1,10 @@
 import os
 import re
 
+import pytest
+
 from ansys.mapdl.core import examples
-from ansys.mapdl.core.examples.downloads import download_example_data
+from ansys.mapdl.core.examples.downloads import _download_file, download_example_data
 
 
 def test_load_verif():
@@ -25,3 +27,9 @@ def test_bracket(mapdl, cleared):
 def test_download_example_data():
     path = download_example_data("LatheCutter.anf", "geometry")
     assert os.path.exists(path)
+
+
+def test_failed_download():
+    filename = "non_existing_file"
+    with pytest.raises(Exception):
+        _download_file(filename, directory=None)


### PR DESCRIPTION
Adding download section:

![image](https://user-images.githubusercontent.com/28149841/180480997-772d1cb9-42f9-46f3-bb5d-9819458685a9.png)

And also adding a helper:
```py
def _download_file(filename, directory=None):
    url = _get_file_url(filename, directory)
    try:
        return _retrieve_file(url, filename)
    except Exception as e:  # Genering exception
        raise Exception(
            "For the reason mentioned below, retrieving the file from internet failed.\n"
            "You can download this file from:\n"
            f"{url}\n"
            "\n"
            "The reported error message is:\n"
            f"{str(e)}"
        )
```



Close #1156 