### PR TITLE
Adding exception when starting database in a non-valid MAPDL version

### DIFF
--- a/src/ansys/mapdl/core/database/database.py
+++ b/src/ansys/mapdl/core/database/database.py
@@ -205,7 +205,7 @@ class MapdlDb:
         --------
         >>> mapdl.db.start()
         """
-        if self._mapdl._server_version != (0, 4, 1):
+        if self._mapdl._server_version != (0, 4, 1):  # pragma: no cover
             from ansys.mapdl.core.errors import MapdlVersionError
 
             raise MapdlVersionError(

--- a/src/ansys/mapdl/core/database/database.py
+++ b/src/ansys/mapdl/core/database/database.py
@@ -205,6 +205,12 @@ class MapdlDb:
         --------
         >>> mapdl.db.start()
         """
+        if self._mapdl._server_version != (0, 4, 1):
+            from ansys.mapdl.core.errors import MapdlVersionError
+
+            raise MapdlVersionError(
+                "This version of MAPDL is not compatible with 'database' module."
+            )
 
         # only start if not already running
         is_running = self.active

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -191,3 +191,11 @@ class MapdlInfo(MapdlException):
 
     def __init__(self, msg=""):
         MapdlException.__init__(self, msg)
+
+
+class MapdlVersionError(MapdlException):
+
+    """Incompatible MAPDL version"""
+
+    def __init__(self, msg=""):
+        MapdlException.__init__(self, msg)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from ansys.mapdl.core.database import DBDef, MapdlDb
-from ansys.mapdl.core.errors import MapdlVersionError
 from ansys.mapdl.core.misc import random_string
 
 # We are skipping all these test until 0.5.X gets fixed.
@@ -225,17 +224,3 @@ def test_off_db(mapdl, db):
     assert not mapdl.db.active
     assert mapdl.db.nodes is None
     assert mapdl.db.elems is None
-
-
-@pytest.mark.parametrize(
-    "mapdl_version",
-    ((0, 4, 0), (0, 4, 1), (0, 4, 2), (0, 5, 0)),
-)
-def test_invalid_mapdl_version(mapdl, mapdl_version):
-    tmp_mapdl_version = mapdl._server_version
-    mapdl.__server_version = mapdl_version
-    with pytest.raises(MapdlVersionError):
-        mapdl.db.start()
-
-    mapdl.db.stop()
-    mapdl.__server_version = tmp_mapdl_version

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from ansys.mapdl.core.database import DBDef, MapdlDb
+from ansys.mapdl.core.errors import MapdlVersionError
 from ansys.mapdl.core.misc import random_string
 
 # We are skipping all these test until 0.5.X gets fixed.
@@ -224,3 +225,17 @@ def test_off_db(mapdl, db):
     assert not mapdl.db.active
     assert mapdl.db.nodes is None
     assert mapdl.db.elems is None
+
+
+@pytest.mark.parametrize(
+    "mapdl_version",
+    ((0, 4, 0), (0, 4, 1), (0, 4, 2), (0, 5, 0)),
+)
+def test_invalid_mapdl_version(mapdl, mapdl_version):
+    tmp_mapdl_version = mapdl._server_version
+    mapdl.__server_version = mapdl_version
+    with pytest.raises(MapdlVersionError):
+        mapdl.db.start()
+
+    mapdl.db.stop()
+    mapdl.__server_version = tmp_mapdl_version

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,6 +7,7 @@ from ansys.mapdl.core.errors import (
     MapdlInfo,
     MapdlNote,
     MapdlRuntimeError,
+    MapdlVersionError,
     MapdlWarning,
 )
 
@@ -91,7 +92,15 @@ def test_raise_output_errors(mapdl, response, expected_error):
 
 @pytest.mark.parametrize(
     "error_class",
-    [MapdlDidNotStart, MapdlException, MapdlError, MapdlWarning, MapdlNote, MapdlInfo],
+    [
+        MapdlDidNotStart,
+        MapdlException,
+        MapdlError,
+        MapdlWarning,
+        MapdlNote,
+        MapdlInfo,
+        MapdlVersionError,
+    ],
 )
 def test_exception_classes(error_class):
     message = "Exception message"


### PR DESCRIPTION
As requested in #1280 