### PR TITLE
add save_ansys_path to our docs

### DIFF
--- a/doc/source/api/helper.rst
+++ b/doc/source/api/helper.rst
@@ -9,7 +9,6 @@ or automating other tasks.
 
 .. autosummary::
    :toctree: _autosummary
-
    
    launch_mapdl
    convert_apdl_block
@@ -18,4 +17,4 @@ or automating other tasks.
    change_default_ansys_path
    find_ansys
    close_all_local_instances
-
+   save_ansys_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-mapdl-core"
 version = "0.64.dev0"
-description = "A Python wrapper for Ansys mapdl core"
+description = "A Python wrapper for Ansys MAPDL."
 readme = "README.rst"
 requires-python = ">=3.7"
 license = {file = "LICENSE"}
@@ -44,7 +44,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",  # requires custom VTK wheels
+    "Programming Language :: Python :: 3.10",
 ]
 
 [tool.flit.module]

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -35,6 +35,7 @@ from ansys.mapdl.core.launcher import (
     find_ansys,
     get_ansys_path,
     launch_mapdl,
+    save_ansys_path,
 )
 from ansys.mapdl.core.mapdl_grpc import MapdlGrpc as Mapdl
 from ansys.mapdl.core.misc import Information, Report, _check_has_ansys

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -812,7 +812,7 @@ def save_ansys_path(exe_loc=None):  # pragma: no cover
     You can change the default ``exe_loc`` either by modifying the mentioned
     ``config.txt`` file or by executing:
 
-    >>> from ansys.mapdl.core.launcher import save_ansys_path
+    >>> from ansys.mapdl.core import save_ansys_path
     >>> save_ansys_path('/new/path/to/executable')
 
     """

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -773,11 +773,12 @@ def change_default_ansys_path(exe_loc):
 
 
 def save_ansys_path(exe_loc=None):  # pragma: no cover
-    """Find ANSYS path or query user.
+    """Find MAPDL's path or query user.
 
     If no ``exe_loc`` argument is supplied, this function attempt
     to obtain the MAPDL executable from (and in order):
-    - The default ansys paths (i.e. 'C:/Program Files/Ansys Inc/vXXX/ansys/bin/ansysXXX')
+
+    - The default ansys paths (i.e. ``'C:/Program Files/Ansys Inc/vXXX/ansys/bin/ansysXXX'``)
     - The configuration file
     - User input
 
@@ -787,7 +788,7 @@ def save_ansys_path(exe_loc=None):  # pragma: no cover
     Parameters
     ----------
     exe_loc : str, optional
-        Path of the MAPDL executable ('ansysXXX'), by default None
+        Path of the MAPDL executable ('ansysXXX'), by default ``None``.
 
     Returns
     -------
@@ -804,15 +805,15 @@ def save_ansys_path(exe_loc=None):  # pragma: no cover
         >>> import appdirs
         >>> import os
         >>> print(os.path.join(appdirs.user_data_dir("ansys_mapdl_core"), "config.txt"))
-        C:/Users/gayuso/AppData/Local/ansys_mapdl_core/ansys_mapdl_core/config.txt
+        C:/Users/user/AppData/Local/ansys_mapdl_core/ansys_mapdl_core/config.txt
 
+    Examples
+    --------
     You can change the default ``exe_loc`` either by modifying the mentioned
-    ``config.txt`` file or by executing this function:
+    ``config.txt`` file or by executing:
 
-    .. code:: python
-
-       >>> from ansys.mapdl.core.launcher import save_ansys_path
-       >>> save_ansys_path('/new/path/to/executable')
+    >>> from ansys.mapdl.core.launcher import save_ansys_path
+    >>> save_ansys_path('/new/path/to/executable')
 
     """
     if exe_loc is None:


### PR DESCRIPTION
Add ``save_ansys_path`` to our docs and also expose it at the root module level. Seems like it should be both documented and more accessible.
