### PR TITLE
Delete the temporary working directory only in temp

### DIFF
--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -983,6 +983,7 @@ def launch_mapdl(
     ip=None,
     clear_on_connect=True,
     log_apdl=None,
+    remove_temp_files=False,
     verbose_mapdl=False,
     license_server_check=True,
     license_type=None,
@@ -1524,7 +1525,7 @@ def launch_mapdl(
                 cleanup_on_exit=cleanup_on_exit,
                 loglevel=loglevel,
                 set_no_abort=set_no_abort,
-                remove_temp_files=kwargs.pop("remove_temp_files", False),
+                remove_temp_files=remove_temp_files,
                 log_apdl=log_apdl,
                 **start_parm,
             )

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1098,8 +1098,8 @@ def launch_mapdl(
 
     remove_temp_files : bool, optional
         When ``run_location`` is ``None``, this launcher creates a new MAPDL
-        working directory within the temporary user directory, obtainable with
-        ``tempfile.gettempdir()``, for MAPDL files. When this parameter is
+        working directory within the user temporary directory, obtainable with
+        ``tempfile.gettempdir()``. When this parameter is
         ``True``, this directory will be deleted when MAPDL is exited. Default
         ``False``.
 

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1096,7 +1096,11 @@ def launch_mapdl(
         ``log_apdl='pymapdl_log.txt'``). By default this is disabled.
 
     remove_temp_files : bool, optional
-        Removes temporary files on exit.  Default ``False``.
+        When ``run_location`` is ``None``, this launcher creates a new MAPDL
+        working directory within the temporary user directory, obtainable with
+        ``tempfile.gettempdir()``, for MAPDL files. When this parameter is
+        ``True``, this directory will be deleted when MAPDL is exited. Default
+        ``False``.
 
     verbose_mapdl : bool, optional
         Enable printing of all output when launching and running
@@ -1386,6 +1390,9 @@ def launch_mapdl(
     else:
         if not os.path.isdir(run_location):
             raise FileNotFoundError(f'"{run_location}" is not a valid directory')
+        if remove_temp_files:
+            LOG.info("`run_location` set. Disabling the removal of temporary files.")
+            remove_temp_files = False
 
     # verify no lock file and the mode is valid
     check_lock_file(run_location, jobname, override)

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -903,8 +903,8 @@ class _MapdlCore(Commands):
         self.finish(mute=True)
         self.save(database_file, mute=True)
 
-        # Exit and do not remove the temporary directory. This backwards
-        # compatibility with CONSOLE and CORBA
+        # Exit and do not remove the temporary directory. This is backwards
+        # compatible with CONSOLE and CORBA modes.
         remove_tmp = False
         if hasattr(self, "_remove_tmp"):
             remove_tmp = self._remove_tmp
@@ -938,7 +938,7 @@ class _MapdlCore(Commands):
         if inplace:
             warn(
                 "MAPDL GUI has been opened using 'inplace' kwarg. "
-                f"Hence the changes you do will overwrite the files in {run_dir}."
+                f"The changes you make will overwrite the files in {run_dir}."
             )
 
         call(

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -811,27 +811,26 @@ class _MapdlCore(Commands):
         return filename
 
     def open_gui(self, include_result=None, inplace=None):  # pragma: no cover
-        """Saves existing database and opens up the APDL GUI.
+        """Save the existing database and open it up in the MAPDL GUI.
 
         Parameters
         ----------
         include_result : bool, optional
-            Allow the result file to be post processed in the GUI.
-            It is ignored if 'inplace' is ``True``.
-            By default, it is ``True``.
+            Allow the result file to be post processed in the GUI.  It is
+            ignored if ``inplace`` is ``True``.  By default, ``True``.
 
         inplace : bool, optional
-            Open the GUI on the current working directory, instead of create
-            a new temporary directory and copy the results files over there.
-            If ``True``, it ignores 'include_result' kwarg.
-            By default, it is ``False``.
+            Open the GUI on the current MAPDL working directory, instead of
+            creating a new temporary directory and coping the results files
+            over there.  If ``True``, ignores ``include_result`` parameter.  By
+            default, this ``False``.
 
         Examples
         --------
         >>> from ansys.mapdl.core import launch_mapdl
         >>> mapdl = launch_mapdl()
 
-        Create a square area using keypoints
+        Create a square area using keypoints.
 
         >>> mapdl.prep7()
         >>> mapdl.k(1, 0, 0, 0)
@@ -844,11 +843,11 @@ class _MapdlCore(Commands):
         >>> mapdl.l(4, 1)
         >>> mapdl.al(1, 2, 3, 4)
 
-        Open up the gui
+        Open up the gui.
 
         >>> mapdl.open_gui()
 
-        Resume where you left off
+        Resume where you left off.
 
         >>> mapdl.et(1, 'MESH200', 6)
         >>> mapdl.amesh('all')
@@ -859,7 +858,7 @@ class _MapdlCore(Commands):
 
         if not self._local:
             raise RuntimeError(
-                "``open_gui`` can only be called from a local " "MAPDL instance"
+                "``open_gui`` can only be called from a local MAPDL instance."
             )
 
         if inplace and include_result:
@@ -891,7 +890,7 @@ class _MapdlCore(Commands):
                 rmtree(run_dir)
             os.mkdir(run_dir)
 
-        database_file = os.path.join(run_dir, "%s.db" % name)
+        database_file = os.path.join(run_dir, f"{name}.db")
         if os.path.isfile(database_file) and not inplace:
             os.remove(database_file)
 
@@ -903,6 +902,13 @@ class _MapdlCore(Commands):
         # finish, save and exit the server
         self.finish(mute=True)
         self.save(database_file, mute=True)
+
+        # Exit and do not remove the temporary directory. This backwards
+        # compatibility with CONSOLE and CORBA
+        remove_tmp = False
+        if hasattr(self, "_remove_tmp"):
+            remove_tmp = self._remove_tmp
+        self._remove_tmp = False
         self.exit()
 
         # copy result file to temp directory
@@ -913,7 +919,7 @@ class _MapdlCore(Commands):
                     copyfile(resultfile, tmp_resultfile)
 
         # write temporary input file
-        start_file = os.path.join(run_dir, "start%s.ans" % version)
+        start_file = os.path.join(run_dir, f"start{version}.ans")
         with open(start_file, "w") as f:
             f.write("RESUME\n")
 
@@ -931,7 +937,7 @@ class _MapdlCore(Commands):
 
         if inplace:
             warn(
-                "MAPDL GUI is opened using 'inplace' kwarg."
+                "MAPDL GUI has been opened using 'inplace' kwarg. "
                 f"Hence the changes you do will overwrite the files in {run_dir}."
             )
 
@@ -951,7 +957,9 @@ class _MapdlCore(Commands):
         # reattach to a new session and reload database
         self._launch(self._start_parm)
         self.resume(database_file, mute=True)
-        self.save()
+
+        # restore remove tmp state
+        self._remove_tmp = remove_tmp
 
     def _cache_routine(self):
         """Cache the current routine."""

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -99,8 +99,8 @@ def get_file_chunks(filename, progress_bar=False):
         if not _HAS_TQDM:  # pragma: no cover
             raise ModuleNotFoundError(
                 "To use the keyword argument 'progress_bar', you need to have "
-                "installed the 'tqdm' package. "
-                "To avoid this message you can set `progress_bar=False`."
+                "installed the `tqdm` package. "
+                "To avoid this message set `progress_bar=False`."
             )
 
         n_bytes = os.path.getsize(filename)

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -855,7 +855,8 @@ class MapdlGrpc(_MapdlCore):
     def _remove_temp_files(self):
         """Removes the temporary directory created by the launcher.
 
-        This only runs if MAPDL is within the temporary directory.
+        This only runs if the current working directory of MAPDL is within the
+        user temporary directory.
 
         """
         if self._remove_tmp and self._local:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -868,7 +868,7 @@ class MapdlGrpc(_MapdlCore):
             else:
                 self._log.debug(
                     "MAPDL working directory is not in the temporary directory '%s'"
-                    ", not removing the MAPDL working directory."
+                    ", not removing the MAPDL working directory.", tmp_dir
                 )
 
     def _kill(self):

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -98,7 +98,7 @@ def get_file_chunks(filename, progress_bar=False):
     if progress_bar:
         if not _HAS_TQDM:  # pragma: no cover
             raise ModuleNotFoundError(
-                f"To use the keyword argument 'progress_bar', you need to have "
+                "To use the keyword argument 'progress_bar', you need to have "
                 "installed the 'tqdm' package. "
                 "To avoid this message you can set `progress_bar=False`."
             )
@@ -862,13 +862,14 @@ class MapdlGrpc(_MapdlCore):
             path = self.directory
             tmp_dir = tempfile.gettempdir()
             ans_temp_dir = os.path.join(tmp_dir, "ansys_")
-            if path.startswith(tempfile.gettempdir()):
+            if path.startswith(ans_temp_dir):
                 self._log.debug("Removing the MAPDL temporary directory %s", path)
                 shutil.rmtree(path, ignore_errors=True)
             else:
                 self._log.debug(
                     "MAPDL working directory is not in the temporary directory '%s'"
-                    ", not removing the MAPDL working directory.", tmp_dir
+                    ", not removing the MAPDL working directory.",
+                    tmp_dir,
                 )
 
     def _kill(self):

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -70,7 +70,11 @@ class LocalMapdlPool:
         Restarts any failed instances in the pool.
 
     remove_temp_files : bool, optional
-        Removes all temporary files on exit.  Default ``True``.
+        This launcher creates a new MAPDL working directory for each instance
+        of MAPDL within the temporary user directory, obtainable with
+        ``tempfile.gettempdir()``, for MAPDL files. When this parameter is
+        ``True``, this directory will be deleted when MAPDL is exited. Default
+        ``False``.
 
     **kwargs : dict, optional
         See :func:`ansys.mapdl.core.launch_mapdl` for a complete

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -243,6 +243,26 @@ def test_license_type_additional_switch():
 
 
 @pytest.mark.skipif(not valid_versions, reason="Requires MAPDL installed.")
+def test_remove_temp_files():
+    """Ensure the working directory is removed when run_location is not set."""
+    mapdl = launch_mapdl(remove_temp_files=True)
+    path = mapdl.directory
+    mapdl.exit()
+    assert not os.path.isdir(path)
+
+
+@pytest.mark.skipif(not valid_versions, reason="Requires MAPDL installed.")
+def test_remove_temp_files_fail(tmpdir):
+    """Ensure the working directory is not removed when the cwd is changed."""
+    mapdl = launch_mapdl(remove_temp_files=True)
+    assert os.path.isdir(str(tmpdir))
+    mapdl.cwd(str(tmpdir))
+    path = mapdl.directory
+    mapdl.exit()
+    assert os.path.isdir(path)
+
+
+@pytest.mark.skipif(not valid_versions, reason="Requires MAPDL installed.")
 @pytest.mark.parametrize(
     "exe_loc",
     [


### PR DESCRIPTION
Resolves #1314.

This PR modifies the behavior of ``remove_temp_files=True`` to only delete the MAPDL working directory when MAPDL is launched with ``run_location`` unset and the MAPDL current working directory remains as a sub-directory within the user temporary directory.

Ideally we'd track the files created by MAPDL and just delete those, but I don't have a way of getting an exhaustive list of files created by MAPDL. This seems to be a good compromise between cleaning unused files and not deleting user files should ``run_location`` be specified.
