### PR TITLE
Revert "Adding tags to documentation"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,6 @@ jobs:
           application_id: ${{ secrets.BOT_APPLICATION_ID }}
           application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
 
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-        with:
-          # Optionally strip `v` prefix
-          strip_v: false
-
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -229,14 +221,13 @@ jobs:
 
       - name: Deploy
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           repository-name: pyansys/pymapdl-docs
           token: ${{ steps.get_workflow_token.outputs.token }}
-          branch: gh-pages
-          folder: doc/build/html
-          clean: true
-          tag: ${{steps.tag.outputs.tag}}
+          BRANCH: gh-pages
+          FOLDER: doc/build/html
+          CLEAN: true
 
       - name: Build PDF Documentation
         working-directory: doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,9 +225,9 @@ jobs:
         with:
           repository-name: pyansys/pymapdl-docs
           token: ${{ steps.get_workflow_token.outputs.token }}
-          BRANCH: gh-pages
-          FOLDER: doc/build/html
-          CLEAN: true
+          branch: gh-pages
+          folder: doc/build/html
+          clean: true
 
       - name: Build PDF Documentation
         working-directory: doc

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -66,13 +66,13 @@ jobs:
           xvfb-run make -C doc html
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           repository-name: pyansys/pymapdl-dev-docs
           token: ${{ steps.get_workflow_token.outputs.token }}
-          branch: gh-pages
-          folder: doc/build/html
-          clean: true
+          BRANCH: gh-pages
+          FOLDER: doc/build/html
+          CLEAN: true
 
       - name: Notify if fail
         uses: skitionek/notify-microsoft-teams@master

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -70,9 +70,9 @@ jobs:
         with:
           repository-name: pyansys/pymapdl-dev-docs
           token: ${{ steps.get_workflow_token.outputs.token }}
-          BRANCH: gh-pages
-          FOLDER: doc/build/html
-          CLEAN: true
+          branch: gh-pages
+          folder: doc/build/html
+          clean: true
 
       - name: Notify if fail
         uses: skitionek/notify-microsoft-teams@master


### PR DESCRIPTION
Reverts pyansys/pymapdl#1282, seems to be failing:

```
remote: warning: See http://git.io/iEPt8g for more information.        
remote: warning: File PyMAPDL_documentation.zip is 57.69 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB        
remote: warning: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.        
To https://github.com/pyansys/pymapdl-docs.git
   b24e07b..24a7cca  github-pages-deploy-action/mpcapw5fe -> gh-pages
Changes committed to the gh-pages branch… 📦
Adding 'v0.63.1' tag to the commit…
/usr/bin/git tag v0.63.1
fatal: tag 'v0.63.1' already exists
Running post deployment cleanup jobs… 🗑️
/usr/bin/git checkout -B github-pages-deploy-action/mpcapw5fe
Reset branch 'github-pages-deploy-action/mpcapw5fe'
/usr/bin/chmod -R +rw github-pages-deploy-action-temp-deployment-folder
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
Error: The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 12
```