### PR TITLE
Copy method updated to handle copying of complex ApdlMathObj

### DIFF
--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1219,6 +1219,9 @@ class ApdlMathObj:
     def copy(self):
         """Returns the name of the copy of this object"""
         name = id_generator()  # internal name of the new vector
+        info = self._mapdl._data_info(self.id)
+        dtype = ANSYS_VALUE_TYPE[info.stype]
+
         if self.type == ObjType.VEC:
             acmd = "*VEC"
         elif self.type == ObjType.DMAT:
@@ -1229,7 +1232,7 @@ class ApdlMathObj:
             raise TypeError(f"Copy aborted: Unknown obj type {self.type}")
 
         # APDLMath cmd to COPY vin to vout
-        self._mapdl.run(f"{acmd},{name},D,COPY,{self.id}", mute=True)
+        self._mapdl.run(f"{acmd},{name},{MYCTYPE[dtype]},COPY,{self.id}", mute=True)
         return name
 
     def _init(self, method):

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1583,8 +1583,13 @@ class AnsMat(ApdlMathObj):
         return objout
 
     def __getitem__(self, num):
+        """Return a vector from a given index."""
         name = id_generator()
-        self._mapdl.run(f"*VEC,{name},D,LINK,{self.id},{num+1}", mute=True)
+        info = self._mapdl._data_info(self.id)
+        dtype = ANSYS_VALUE_TYPE[info.stype]
+        self._mapdl.run(
+            f"*VEC,{name},{MYCTYPE[dtype]},LINK,{self.id},{num+1}", mute=True
+        )
         return AnsVec(name, self._mapdl)
 
     @property

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -527,6 +527,14 @@ def test_copy(mm):
     assert np.allclose(k, kcopy)
 
 
+def test_copy_complex(mm):
+    data_a = np.random.random(10) + np.random.random(10) * 1j
+    vec_a = mm.set_vec(data_a)
+    data_b = vec_a.copy().asarray()
+    assert data_b.dtype == data_a.dtype
+    assert np.allclose(data_a, data_b)
+
+
 def test_sparse_repr(mm):
     k = mm.stiff()
     assert "Sparse APDLMath Matrix" in repr(k)


### PR DESCRIPTION
Complex ApdlMathObj using the copy method , Copies the real part and skips imaginary part.
Example :

![image](https://user-images.githubusercontent.com/106647677/182780550-e22e374d-54d2-4285-80d9-f9041ef98782.png)

Using Fz0 = Fz.copy()
Returns only the real part

![image](https://user-images.githubusercontent.com/106647677/182780744-c289d3ea-73ea-4af0-aa68-9413a9cede8a.png)

