### PR TITLE
add remote and local cases for file

### DIFF
--- a/src/ansys/mapdl/core/_commands/post26_/setup.py
+++ b/src/ansys/mapdl/core/_commands/post26_/setup.py
@@ -415,30 +415,6 @@ class Setup:
         command = f"ESOL,{nvar},{elem},{node},{item},{comp},{name}"
         return self.run(command, **kwargs)
 
-    def file(self, fname="", ext="", **kwargs):
-        """Specifies the data file where results are to be found.
-
-        APDL Command: FILE
-
-        Parameters
-        ----------
-        fname
-            File name and directory path (248 characters maximum, including the
-            characters needed for the directory path).  An unspecified
-            directory path defaults to the working directory; in this case, you
-            can use all 248 characters for the file name.
-
-        ext
-            Filename extension (eight-character maximum).
-
-        Notes
-        -----
-        Specifies the ANSYS data file where the results are to be found for
-        postprocessing.
-        """
-        command = f"FILE,{fname},{ext}"
-        return self.run(command, **kwargs)
-
     def gapf(self, nvar="", num="", name="", **kwargs):
         """Defines the gap force data to be stored in a variable.
 

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2941,9 +2941,9 @@ class _MapdlCore(Commands):
     @supress_logging
     def directory(self, path):
         """Change the directory using ``Mapdl.cwd``"""
-        self.cwd(
-            path
-        )  # this has been wrapped in Mapdl to show a warning if the file does not exist.
+        # this has been wrapped in Mapdl to show a warning if the file does
+        # not exist.
+        self.cwd(path)
 
     @property
     def _lockfile(self):
@@ -3160,7 +3160,7 @@ class _MapdlCore(Commands):
 
     @wraps(Commands.cwd)
     def cwd(self, *args, **kwargs):
-        """Wraps cwd"""
+        """Wraps cwd."""
         returns_ = super().cwd(*args, **kwargs)
 
         if returns_:  # if successful, it should be none.
@@ -3601,3 +3601,55 @@ class _MapdlCore(Commands):
                     raise MapdlRuntimeError(
                         f"\n\nError in instance {self.name}\n\n" + error_message
                     )
+
+    def file(self, fname="", ext="", **kwargs):
+        """Specifies the data file where results are to be found.
+
+        APDL Command: FILE
+
+        Parameters
+        ----------
+        fname : str
+            File name and directory path (248 characters maximum, including the
+            characters needed for the directory path).  An unspecified
+            directory path defaults to the working directory; in this case, you
+            can use all 248 characters for the file name.
+
+        ext : str, default: "rst"
+            Filename extension (eight-character maximum). If ``fname`` has an
+            extension this is ignored.
+
+        Notes
+        -----
+        Specifies the Ansys data file where the results are to be found for
+        postprocessing.
+
+        Examples
+        --------
+        Load a result file that is outside of the current working directory.
+
+        >>> from ansys.mapdl.core import launch_mapdl
+        >>> mapdl = launch_mapdl()
+        >>> mapdl.post1()
+        >>> mapdl.file('/tmp/file.rst')
+
+        """
+        # MAPDL always adds the "rst" extension onto the name, even if already
+        # has one, so here we simply reconstruct it.
+        filename = pathlib.Path(fname + ext)
+
+        if not filename.exists():
+            # potential that the user is relying on the default "rst"
+            filename_rst = filename.parent / (filename.name + ".rst")
+            if not filename_rst.exists():
+                raise FileNotFoundError(f"Unable to locate {filename}")
+
+        return self._file(filename, **kwargs)
+
+    def _file(self, filename, **kwargs):
+        """Run the MAPDL ``file`` command with a proper filename."""
+        filename = pathlib.Path(filename)
+        ext = filename.suffix
+        fname = str(filename).replace(ext, "")
+        ext = ext.replace(".", "")
+        return self.run(f"FILE,{fname},{ext}", **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,19 @@ def pytest_configure(config):
 
 # Check if MAPDL is installed
 # NOTE: checks in this order to get the newest installed version
-valid_rver = ["221", "212", "211", "202", "201", "195", "194", "193", "192", "191"]
+valid_rver = [
+    "222",
+    "221",
+    "212",
+    "211",
+    "202",
+    "201",
+    "195",
+    "194",
+    "193",
+    "192",
+    "191",
+]
 EXEC_FILE = None
 for rver in valid_rver:
     if os.path.isfile(get_ansys_bin(rver)):

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1387,3 +1387,40 @@ def test_equal_in_comments_and_title(mapdl):
     mapdl.com("=====")
     mapdl.title("This is = ")
     mapdl.title("This is '=' ")
+
+
+@skip_in_cloud
+def test_file_command_local(mapdl, cube_solve, tmpdir):
+    rst_file = mapdl._result_file
+
+    # check for raise of non-exising file
+    with pytest.raises(FileNotFoundError):
+        mapdl.file("potato")
+
+    # change directory
+    mapdl.directory = str(tmpdir)
+    assert mapdl.directory == str(tmpdir)
+
+    mapdl.post1()
+    mapdl.file(rst_file)
+
+
+def test_file_command_remote(mapdl, cube_solve, tmpdir):
+    with pytest.raises(FileNotFoundError):
+        mapdl.file("potato")
+
+    mapdl.post1()
+    # this file already exists remotely
+    mapdl.file("file.rst")
+
+    with pytest.raises(FileNotFoundError):
+        mapdl.file()
+
+    tmpdir = str(tmpdir)
+    mapdl.download("file.rst", tmpdir)
+    local_file = os.path.join(tmpdir, "file.rst")
+    new_local_file = os.path.join(tmpdir, "myrst.rst")
+    os.rename(local_file, new_local_file)
+
+    output = mapdl.file(new_local_file)
+    assert "myrst.rst" in output

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1423,4 +1423,4 @@ def test_file_command_remote(mapdl, cube_solve, tmpdir):
     os.rename(local_file, new_local_file)
 
     output = mapdl.file(new_local_file)
-    assert "myrst.rst" in output
+    assert "DATA FILE CHANGED TO FILE" in output


### PR DESCRIPTION
Resolve #1321 by addressing both the local and edge cases for the MAPDL ``FILE`` command.

### Bonus

Locally (at least on linux) running unit testing leaves behind 100s of processes of MADPL. Turns out that merely using `_kill` doesn't do the trick and you need to kill the MAPDL processes instead. Updated accordingly.