### PR TITLE
Fixing order import

### DIFF
--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -37,6 +37,13 @@ from ansys.mapdl.core.launcher import (
     get_ansys_path,
     save_ansys_path,
 )
+
+# override default launcher when on pyansys.com
+if "ANSJUPHUB_VER" in os.environ:
+    from ansys.mapdl.core.jupyter import launch_mapdl_on_cluster as launch_mapdl
+else:
+    from ansys.mapdl.core.launcher import launch_mapdl
+
 from ansys.mapdl.core.mapdl_grpc import MapdlGrpc as Mapdl
 from ansys.mapdl.core.misc import Information, Report, _check_has_ansys
 from ansys.mapdl.core.pool import LocalMapdlPool
@@ -56,12 +63,5 @@ try:
 
 except:  # pragma: no cover
     pass
-
-
-# override default launcher when on pyansys.com
-if "ANSJUPHUB_VER" in os.environ:
-    from ansys.mapdl.core.jupyter import launch_mapdl_on_cluster as launch_mapdl
-else:
-    from ansys.mapdl.core.launcher import launch_mapdl
 
 BUILDING_GALLERY = False

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -35,7 +35,6 @@ from ansys.mapdl.core.launcher import (
     close_all_local_instances,
     find_ansys,
     get_ansys_path,
-    launch_mapdl,
     save_ansys_path,
 )
 from ansys.mapdl.core.mapdl_grpc import MapdlGrpc as Mapdl
@@ -62,6 +61,7 @@ except:  # pragma: no cover
 # override default launcher when on pyansys.com
 if "ANSJUPHUB_VER" in os.environ:
     from ansys.mapdl.core.jupyter import launch_mapdl_on_cluster as launch_mapdl
-
+else:
+    from ansys.mapdl.core.launcher import launch_mapdl
 
 BUILDING_GALLERY = False

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -39,7 +39,7 @@ from ansys.mapdl.core.launcher import (
 )
 
 # override default launcher when on pyansys.com
-if "ANSJUPHUB_VER" in os.environ:
+if "ANSJUPHUB_VER" in os.environ:  # pragma: no cover
     from ansys.mapdl.core.jupyter import launch_mapdl_on_cluster as launch_mapdl
 else:
     from ansys.mapdl.core.launcher import launch_mapdl

--- a/src/ansys/mapdl/core/jupyter.py
+++ b/src/ansys/mapdl/core/jupyter.py
@@ -49,7 +49,7 @@ def launch_mapdl_on_cluster(
         may segfault.
     loglevel : str, optional
         Sets which messages are printed to the console.  Default
-        ``'INFO'`` logs out all MAPDL messages, ``'WARNING``` prints only
+        ``'INFO'`` logs out all MAPDL messages, ``'WARNING'`` prints only
         messages containing MAPDL warnings, and ``'ERROR'`` prints only
         error messages.
     additional_switches : str, optional


### PR DESCRIPTION


So I did realize that VSCode was showing the wrong docstring info for ``launch_mapdl``, and it seems it is because of the import order.

### Before:
![image](https://user-images.githubusercontent.com/28149841/185989380-8c2584cd-79c2-4ff0-b019-7e6a87503999.png)


### After:
![image](https://user-images.githubusercontent.com/28149841/185989112-48f4927f-4a02-4630-8963-1c6fb7285bb7.png)
