### PR TITLE
Removing needs from unit tests in CICD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,6 @@ jobs:
 
   build_test:
     name: Build and Unit Testing
-    needs: testimport
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Most of the times the smoke tests do not fail. So delaying unit test by 3-4 minutes until the smoke tests are done seems to me a waste of time.