### PR TITLE
Improving error  message in ``mapdl.get_value``

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1577,11 +1577,13 @@ class MapdlGrpc(_MapdlCore):
             self._get_lock = False
 
         if getresponse.type == 0:
-            self._log.debug("The 'grpc' get method seems to have failed. Trying old implementation for more verbose output.")
+            self._log.debug(
+                "The 'grpc' get method seems to have failed. Trying old implementation for more verbose output."
+            )
             try:
                 out = self.run("*GET,__temp__," + cmd)
             except MapdlRuntimeError:
-                # Get can thrown some errors, in that case, they are catched in the default run method.
+                # Get can thrown some errors, in that case, they are caught in the default run method.
                 raise
             else:
                 # Here we catch the rest of the errors and warnings

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1579,7 +1579,7 @@ class MapdlGrpc(_MapdlCore):
         if getresponse.type == 0:
             # Fall back to run to get most verbose output.
             out = self.run("*GET,__temp__," + cmd)
-            self.run("__temp__=") # deleting parameter
+            self.run("__temp__=", mute=False)  # deleting parameter
             raise ValueError(out)
 
         if getresponse.type == 1:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1577,10 +1577,18 @@ class MapdlGrpc(_MapdlCore):
             self._get_lock = False
 
         if getresponse.type == 0:
-            # Fall back to run to get most verbose output.
-            out = self.run("*GET,__temp__," + cmd)
-            self.run("__temp__=", mute=False)  # deleting parameter
-            raise ValueError(out)
+            self._log.debug("The 'grpc' get method seems to have failed. Trying old implementation for more verbose output.")
+            try:
+                out = self.run("*GET,__temp__," + cmd)
+            except MapdlRuntimeError:
+                # Get can thrown some errors, in that case, they are catched in the default run method.
+                raise
+            else:
+                # Here we catch the rest of the errors and warnings
+                raise ValueError(out)
+            finally:
+                # deleting parameter
+                self.run("__temp__=", mute=False)
 
         if getresponse.type == 1:
             return getresponse.dval

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1577,11 +1577,11 @@ class MapdlGrpc(_MapdlCore):
             self._get_lock = False
 
         if getresponse.type == 0:
-            raise ValueError(
-                "This is either an invalid get request, or MAPDL is set"
-                " to the wrong processor (e.g. on BEGIN LEVEL vs."
-                " POST26)"
-            )
+            # Fall back to run to get most verbose output.
+            out = self.run("*GET,__temp__," + cmd)
+            self.run("__temp__=") # deleting parameter
+            raise ValueError(out)
+
         if getresponse.type == 1:
             return getresponse.dval
         elif getresponse.type == 2:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1588,9 +1588,6 @@ class MapdlGrpc(_MapdlCore):
             else:
                 # Here we catch the rest of the errors and warnings
                 raise ValueError(out)
-            finally:
-                # deleting parameter
-                self.run("__temp__=", mute=False)
 
         if getresponse.type == 1:
             return getresponse.dval

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -6,6 +6,7 @@ import pytest
 
 from ansys.mapdl.core import examples, launch_mapdl
 from ansys.mapdl.core.common_grpc import DEFAULT_CHUNKSIZE
+from ansys.mapdl.core.errors import MapdlRuntimeError
 from ansys.mapdl.core.launcher import check_valid_ansys, get_start_instance
 
 PATH = os.path.dirname(os.path.abspath(__file__))
@@ -122,7 +123,7 @@ def test_clear_multiple(mapdl):
 
 
 def test_invalid_get(mapdl):
-    with pytest.raises(ValueError):
+    with pytest.raises(MapdlRuntimeError):
         mapdl.get_value("ACTIVE", item1="SET", it1num="invalid")
 
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1520,3 +1520,11 @@ def test_lsread(mapdl, cleared):
     assert "No nodal" in mapdl.flist()
     mapdl.lsread(mute=True)
     assert "No nodal" not in mapdl.flist()
+
+
+def test_get_fallback(mapdl,cleared):
+    with pytest.raises(ValueError, match="There are no NODES defined"):
+        mapdl.get_value("node",0,"num","maxd")
+
+    with pytest.raises(ValueError, match="There are no ELEMENTS defined"):
+        mapdl.get_value("elem", 0, "num", "maxd")

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1522,9 +1522,9 @@ def test_lsread(mapdl, cleared):
     assert "No nodal" not in mapdl.flist()
 
 
-def test_get_fallback(mapdl,cleared):
+def test_get_fallback(mapdl, cleared):
     with pytest.raises(ValueError, match="There are no NODES defined"):
-        mapdl.get_value("node",0,"num","maxd")
+        mapdl.get_value("node", 0, "num", "maxd")
 
     with pytest.raises(ValueError, match="There are no ELEMENTS defined"):
         mapdl.get_value("elem", 0, "num", "maxd")


### PR DESCRIPTION
Improving command error message by falling back to ``mapdl.run("*get, ...")`` in ``mapdl._get`` (grpc version of ``get``)

Close #1406 