### PR TITLE
Prioritize the non-student versions

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,7 @@ ignore:
   - "src/ansys/mapdl/core/jupyter.py"
   - "src/ansys/mapdl/core/mapdl_console.py"
   - "src/ansys/mapdl/core/mapdl_corba.py"
+  - "src/ansys/mapdl/core/launcher.py"
 
 comment:
   layout: "diff"

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -284,139 +284,35 @@ If this command doesn't launch, please pay attention to the command output:
 
 There is a variety of issues that can make ANSYS not launching, including:
 
-- License server setup.
-  Incorrect license server configuration can make ANSYS not able to get a valid license.
-  In those cases, you might see output **similar** to:
-
-  .. code:: pwsh
-
-    (base) PS C:\Users\user\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
-   
-    ANSYS LICENSE MANAGER ERROR:
-
-    Maximum licensed number of demo users already reached.
-
-
-    ANSYS LICENSE MANAGER ERROR:
-
-    Request name mech_2 does not exist in the licensing pool.
-    No such feature exists.
-    Feature:       mech_2
-    License path:  C:\Users\user\AppData\Local\Temp\\cb0400ba-6edb-4bb9-a333-41e7318c007d;
-    FlexNet Licensing error:-5,357
-
-
-- Running behind a VPN.
-  If your device is inside a virtual private network (VPN), ANSYS might have some problems to correctly
-  resolve the IP of the license server. Please do check that the hostname or IP of the license server
-  is correct.
-  In Windows, you can find the license configuration file which points to the license server in:
-
-  .. code:: text
-
-    C:\Program Files\ANSYS Inc\Shared Files\Licensing\ansyslmd.ini
-
-
-- Incorrect environment variables.
-  The license server can be also specified using the environment variable ``ANSYSLMD_LICENSE_FILE``.
-  You can check the value of this environment variable by issuing on Windows:
-
-  .. code:: pwsh
-    
-    $env:ANSYSLMD_LICENSE_FILE
-    1055@1.1.1.1
-
-  And on linux:
-
-  .. code:: bash
-
-    printenv | grep ANSYSLMD_LICENSE_FILE
-
-- Conflicts with Student Version.
-  Although you can install Ansys together with any other Ansys products or versions, on Windows it is **highly**
-  recommended to not install an ANSYS Product Student version together with its non-student version.
-  For example, *Ansys MAPDL 2022R2* and *Ansys MAPDL 2022R2 Student version* installed together might cause
-  some license conflicts due to overwriting of the environment variables.
-  Having different versions, for example *Ansys MAPDL 2021R1* and *Ansys MAPDL 2022R2 Student version* is
-  completely fine.
-
-  If you experience those issues, we recommend you to edit the environment variables ``ANSYSXXX_DIR``, ``AWP_ROOTXXX``,
-  and ``CADOE_LIBDIRXXX`` where ``XXX`` is the MAPDL numeric version (i.e. ``222`` for *Ansys MAPDL 2022R2*)
-  to remove any reference to the student version.
-
-  .. code:: pwsh
-
-    PS echo $env:AWP_ROOT222
-    C:\Program Files\ANSYS Inc\ANSYS Student\v222
-    PS $env:AWP_ROOT222 = "C:\Program Files\ANSYS Inc\v222"  # This will overwrite the env var for the terminal session only.
-    PS [System.Environment]::SetEnvironmentVariable('AWP_ROOT222','C:\Program Files\ANSYS Inc\v222',[System.EnvironmentVariableTarget]::User)  # This will change the env var permanently.
-    PS echo $env:AWP_ROOT222
-    C:\Program Files\ANSYS Inc\v222
-
-    PS echo $env:ANSYS222_DIR
-    C:\Program Files\ANSYS Inc\ANSYS Student\v222\ANSYS
-    PS [System.Environment]::SetEnvironmentVariable('ANSYS222_DIR','C:\Program Files\ANSYS Inc\v222\ANSYS',[System.EnvironmentVariableTarget]::User)
-    PS echo $env:ANSYS222_DIR
-    C:\Program Files\ANSYS Inc\v222\ANSYS
-
-    PS echo $env:CADOE_LIBDIR222
-    C:\Program Files\ANSYS Inc\ANSYS Student\v222\CommonFiles\Language\en-us
-    PS [System.Environment]::SetEnvironmentVariable('CADOE_LIBDIR222','C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us',[System.EnvironmentVariableTarget]::User)
-    PS echo $env:CADOE_LIBDIR222
-    C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us
-
-
-- Missing dependencies.
-  Normally missing dependencies will be shown by Python by raising an error.
-  For example, if the library `Numpy <https://numpy.org/>`_ is missing, Python
-  will show the following error:
-
-  .. code:: python
-
-    from ansys.mapdl.core import launch_mapdl
-    ---------------------------------------------------------------------------
-    ModuleNotFoundError                       Traceback (most recent call last)
-    <ipython-input-1-87b295f34a95> in <module>
-    ----> 1 from ansys.mapdl.core import launch_mapdl
-
-    ~\Others_pymapdls\pymapdl_0\pymapdl\src\ansys\mapdl\core\__init__.py in <module>
-        28 __version__ = importlib_metadata.version(__name__.replace(".", "-"))
-        29
-    ---> 30 from ansys.mapdl.core import examples
-        31 from ansys.mapdl.core._version import SUPPORTED_ANSYS_VERSIONS
-        32 from ansys.mapdl.core.convert import convert_apdl_block, convert_script
-
-    ~\Others_pymapdls\pymapdl_0\pymapdl\src\ansys\mapdl\core\examples\__init__.py in <module>
-        1 from .downloads import *
-        2 from .downloads import _download_rotor_tech_demo_plot
-    ----> 3 from .examples import *
-        4 from .verif_files import vmfiles
-
-    ~\Others_pymapdls\pymapdl_0\pymapdl\src\ansys\mapdl\core\examples\examples.py in <module>
-        2 import os
-        3
-    ----> 4 from matplotlib.colors import ListedColormap
-        5 import numpy as np
-        6
-
-    C:\ProgramData\Miniconda3\envs\pymapdl_0\lib\site-packages\matplotlib\__init__.py in <module>
-        102 import warnings
-        103
-    --> 104 import numpy
-        105 from packaging.version import parse as parse_version
-        106
-
-    ModuleNotFoundError: No module named 'numpy'
-
-  In this cases, the best option is to reinstall the library using:
-
-  .. code:: bash
-
-    python -m pip install ansys-mapdl-core
+- License server setup
+- Running behind a VPN
+- Missing dependencies
+- Conflicts with Student Version
 
 
 Licensing Issues
 ----------------
+
+Incorrect license server configuration can make ANSYS not being able to get a valid license.
+In those cases, you might see output **similar** to:
+
+.. code:: pwsh
+
+   (base) PS C:\Users\user\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
+
+   ANSYS LICENSE MANAGER ERROR:
+
+   Maximum licensed number of demo users already reached.
+
+
+   ANSYS LICENSE MANAGER ERROR:
+
+   Request name mech_2 does not exist in the licensing pool.
+   No such feature exists.
+   Feature:          mech_2
+   License path:  C:\Users\user\AppData\Local\Temp\\cb0400ba-6edb-4bb9-a333-41e7318c007d;
+   FlexNet Licensing error:-5,357
+
 
 PADT generally has a great blog regarding ANSYS issues, and licensing is always a common issue 
 (for example `Changes to Licensing at ANSYS 2020R1 <https://www.padtinc.com/blog/15271-2/>`_).  
@@ -440,6 +336,34 @@ Parallel", rather than the default "Distributed Memory Parallel" mode.
     >>> mapdl = launch_mapdl(additional_switches='-smp')
 
 While this approach has the disadvantage of using the potentially slower shared memory parallel mode, you'll at least be able to run MAPDL.  For more details on shared vs distributed memory, see `High-Performance Computing for Mechanical Simulations using ANSYS <https://www.ansys.com/-/media/Ansys/corporate/resourcelibrary/presentation/hpc-for-mechanical-ansys.pdf>`_.
+
+
+In addition, if your device is inside a virtual private network (VPN), ANSYS might have some problems to correctly
+resolve the IP of the license server. Please do check that the hostname or IP of the license server
+is correct.
+In Windows, you can find the license configuration file which points to the license server in:
+
+.. code:: text
+
+    C:\Program Files\ANSYS Inc\Shared Files\Licensing\ansyslmd.ini
+
+
+Incorrect environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The license server can be also specified using the environment variable ``ANSYSLMD_LICENSE_FILE``.
+You can check the value of this environment variable by issuing on Windows:
+
+  .. code:: pwsh
+    
+    $env:ANSYSLMD_LICENSE_FILE
+    1055@1.1.1.1
+
+  And on linux:
+
+  .. code:: bash
+
+    printenv | grep ANSYSLMD_LICENSE_FILE
 
 
 Missing Dependencies on Linux
@@ -489,3 +413,40 @@ then installs it via ``dpkg``.
     sudo bash -c "tar c postinst postrm md5sums control | gzip -c > control.tar.gz"
     sudo ar rcs libxp6_1.0.2-2_amd64_mod.deb debian-binary control.tar.gz data.tar.xz
     sudo dpkg -i ./libxp6_1.0.2-2_amd64_mod.deb
+
+
+
+Conflicts with Student Version
+------------------------------
+
+Although you can install Ansys together with any other Ansys products or versions, on Windows it is **highly**
+recommended to not install an ANSYS Product Student version together with its non-student version.
+For example, *Ansys MAPDL 2022R2* and *Ansys MAPDL 2022R2 Student version* installed together might cause
+some license conflicts due to overwriting of the environment variables.
+Having different versions, for example *Ansys MAPDL 2021R1* and *Ansys MAPDL 2022R2 Student version* is
+completely fine.
+
+If you experience those issues, we recommend you to edit the environment variables ``ANSYSXXX_DIR``, ``AWP_ROOTXXX``,
+and ``CADOE_LIBDIRXXX`` where ``XXX`` is the MAPDL numeric version (i.e. ``222`` for *Ansys MAPDL 2022R2*)
+to remove any reference to the student version.
+
+.. code:: pwsh
+
+    PS echo $env:AWP_ROOT222
+    C:\Program Files\ANSYS Inc\ANSYS Student\v222
+    PS $env:AWP_ROOT222 = "C:\Program Files\ANSYS Inc\v222"  # This will overwrite the env var for the terminal session only.
+    PS [System.Environment]::SetEnvironmentVariable('AWP_ROOT222','C:\Program Files\ANSYS Inc\v222',[System.EnvironmentVariableTarget]::User)  # This will change the env var permanently.
+    PS echo $env:AWP_ROOT222
+    C:\Program Files\ANSYS Inc\v222
+
+    PS echo $env:ANSYS222_DIR
+    C:\Program Files\ANSYS Inc\ANSYS Student\v222\ANSYS
+    PS [System.Environment]::SetEnvironmentVariable('ANSYS222_DIR','C:\Program Files\ANSYS Inc\v222\ANSYS',[System.EnvironmentVariableTarget]::User)
+    PS echo $env:ANSYS222_DIR
+    C:\Program Files\ANSYS Inc\v222\ANSYS
+
+    PS echo $env:CADOE_LIBDIR222
+    C:\Program Files\ANSYS Inc\ANSYS Student\v222\CommonFiles\Language\en-us
+    PS [System.Environment]::SetEnvironmentVariable('CADOE_LIBDIR222','C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us',[System.EnvironmentVariableTarget]::User)
+    PS echo $env:CADOE_LIBDIR222
+    C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -227,6 +227,10 @@ does not accept two equal keys.
 The result of ``_get_available_base_ansys()`` is in order, higher version first and student versions
 at last.
 
+.. warning::
+    It is not recommended to have installed Ansys product and Ansys student products with the same version.
+    See `Debug Launch Issues`_
+
 Debug Launch Issues
 ~~~~~~~~~~~~~~~~~~~
 In some cases, it may be necessary to debug why MAPDL isn't launching
@@ -328,8 +332,85 @@ There is a variety of issues that can make ANSYS not launching, including:
 
     printenv | grep ANSYSLMD_LICENSE_FILE
 
+- Conflicts with Student Version.
+  Although you can install Ansys together with any other Ansys products or versions, on Windows it is **highly**
+  recommended you do not install the Student version together with its non-student version.
+  For example, *Ansys MAPDL 2022R2* and *Ansys MAPDL 2022R2 Student version* installed together might cause
+  some license conflicts due to overwriting of the environment variables.
+  Having different versions, for example *Ansys MAPDL 2021R1* and *Ansys MAPDL 2022R2 Student version* is
+  completely fine.
+
+  If you experience those issues, we recommend you to edit the environment variables ``ANSYSXXX_DIR``, ``AWP_ROOTXXX``,
+  and ``CADOE_LIBDIRXXX`` where ``XXX`` is the MAPDL numeric version (i.e. ``222`` for *Ansys MAPDL 2022R2*)  to remove any reference to the student version.
+
+  .. code:: pwsh
+
+    PS echo $env:AWP_ROOT222
+    C:\Program Files\ANSYS Inc\ANSYS Student\v222
+    PS $env:AWP_ROOT222 = "C:\Program Files\ANSYS Inc\v222"
+    PS echo $env:AWP_ROOT222
+    C:\Program Files\ANSYS Inc\v222
+
+    PS echo $env:ANSYS222_DIR
+    C:\Program Files\ANSYS Inc\ANSYS Student\v222\ANSYS
+    PS $env:ANSYS222_DIR = "C:\Program Files\ANSYS Inc\v222\ANSYS"
+    PS echo $env:ANSYS222_DIR
+    C:\Program Files\ANSYS Inc\v222\ANSYS
+
+    PS echo $env:CADOE_LIBDIR222
+    C:\Program Files\ANSYS Inc\ANSYS Student\v222\CommonFiles\Language\en-us
+    PS $env:CADOE_LIBDIR222 = "C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us"
+    PS echo $env:CADOE_LIBDIR222
+    C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us
+
+
 - Missing dependencies.
-  
+  Normally missing dependencies will be shown by Python by raising an error.
+  For example, if the library `Numpy <https://numpy.org/>`_ is missing, Python
+  will show the following error:
+
+  .. code:: python
+
+    from ansys.mapdl.core import launch_mapdl
+    ---------------------------------------------------------------------------
+    ModuleNotFoundError                       Traceback (most recent call last)
+    <ipython-input-1-87b295f34a95> in <module>
+    ----> 1 from ansys.mapdl.core import launch_mapdl
+
+    ~\Others_pymapdls\pymapdl_0\pymapdl\src\ansys\mapdl\core\__init__.py in <module>
+        28 __version__ = importlib_metadata.version(__name__.replace(".", "-"))
+        29
+    ---> 30 from ansys.mapdl.core import examples
+        31 from ansys.mapdl.core._version import SUPPORTED_ANSYS_VERSIONS
+        32 from ansys.mapdl.core.convert import convert_apdl_block, convert_script
+
+    ~\Others_pymapdls\pymapdl_0\pymapdl\src\ansys\mapdl\core\examples\__init__.py in <module>
+        1 from .downloads import *
+        2 from .downloads import _download_rotor_tech_demo_plot
+    ----> 3 from .examples import *
+        4 from .verif_files import vmfiles
+
+    ~\Others_pymapdls\pymapdl_0\pymapdl\src\ansys\mapdl\core\examples\examples.py in <module>
+        2 import os
+        3
+    ----> 4 from matplotlib.colors import ListedColormap
+        5 import numpy as np
+        6
+
+    C:\ProgramData\Miniconda3\envs\pymapdl_0\lib\site-packages\matplotlib\__init__.py in <module>
+        102 import warnings
+        103
+    --> 104 import numpy
+        105 from packaging.version import parse as parse_version
+        106
+
+    ModuleNotFoundError: No module named 'numpy'
+
+  In this cases, the best option is to reinstall the library using:
+
+  .. code:: bash
+
+    python -m pip install ansys-mapdl-core
 
 
 Licensing Issues

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -334,7 +334,7 @@ There is a variety of issues that can make ANSYS not launching, including:
 
 - Conflicts with Student Version.
   Although you can install Ansys together with any other Ansys products or versions, on Windows it is **highly**
-  recommended you do not install the Student version together with its non-student version.
+  recommended to not install an ANSYS Product Student version together with its non-student version.
   For example, *Ansys MAPDL 2022R2* and *Ansys MAPDL 2022R2 Student version* installed together might cause
   some license conflicts due to overwriting of the environment variables.
   Having different versions, for example *Ansys MAPDL 2021R1* and *Ansys MAPDL 2022R2 Student version* is
@@ -348,19 +348,20 @@ There is a variety of issues that can make ANSYS not launching, including:
 
     PS echo $env:AWP_ROOT222
     C:\Program Files\ANSYS Inc\ANSYS Student\v222
-    PS $env:AWP_ROOT222 = "C:\Program Files\ANSYS Inc\v222"
+    PS $env:AWP_ROOT222 = "C:\Program Files\ANSYS Inc\v222"  # This will overwrite the env var for the terminal session only.
+    PS [System.Environment]::SetEnvironmentVariable('AWP_ROOT222','C:\Program Files\ANSYS Inc\v222',[System.EnvironmentVariableTarget]::User)  # This will change the env var permanently.
     PS echo $env:AWP_ROOT222
     C:\Program Files\ANSYS Inc\v222
 
     PS echo $env:ANSYS222_DIR
     C:\Program Files\ANSYS Inc\ANSYS Student\v222\ANSYS
-    PS $env:ANSYS222_DIR = "C:\Program Files\ANSYS Inc\v222\ANSYS"
+    PS [System.Environment]::SetEnvironmentVariable('ANSYS222_DIR','C:\Program Files\ANSYS Inc\v222\ANSYS',[System.EnvironmentVariableTarget]::User)
     PS echo $env:ANSYS222_DIR
     C:\Program Files\ANSYS Inc\v222\ANSYS
 
     PS echo $env:CADOE_LIBDIR222
     C:\Program Files\ANSYS Inc\ANSYS Student\v222\CommonFiles\Language\en-us
-    PS $env:CADOE_LIBDIR222 = "C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us"
+    PS [System.Environment]::SetEnvironmentVariable('CADOE_LIBDIR222','C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us',[System.EnvironmentVariableTarget]::User)
     PS echo $env:CADOE_LIBDIR222
     C:\Program Files\ANSYS Inc\v222\CommonFiles\Language\en-us
 

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -341,7 +341,8 @@ There is a variety of issues that can make ANSYS not launching, including:
   completely fine.
 
   If you experience those issues, we recommend you to edit the environment variables ``ANSYSXXX_DIR``, ``AWP_ROOTXXX``,
-  and ``CADOE_LIBDIRXXX`` where ``XXX`` is the MAPDL numeric version (i.e. ``222`` for *Ansys MAPDL 2022R2*)  to remove any reference to the student version.
+  and ``CADOE_LIBDIRXXX`` where ``XXX`` is the MAPDL numeric version (i.e. ``222`` for *Ansys MAPDL 2022R2*)
+  to remove any reference to the student version.
 
   .. code:: pwsh
 

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -173,6 +173,59 @@ the output of MAPDL within Python and can be used to debug why MAPDL
 isn't launching.  Output will be limited on Windows due to the way
 MAPDL launches on Windows.
 
+Default executable Location
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The first time you run PyMAPDL it will detect the
+available ANSYS installations, normally under:
+
+.. code:: text
+
+    C:/Program Files/ANSYS Inc/vXXX
+
+in windows, and:
+
+.. code:: text
+
+    /usr/ansys_inc/vXXX
+
+on Linux.
+
+If PyMAPDL successfully find a valid ANSYS installation, it will cache its
+path in the configuration file ``config.txt`` which can be found by following
+the next code:
+
+.. code:: python
+
+    >>> from ansys.mapdl.core.launcher import CONFIG_FILE
+    >>> print(CONFIG_FILE)
+    'C:\\Users\\user\\AppData\\Local\\ansys_mapdl_core\\ansys_mapdl_core\\config.txt'
+
+
+In certain cases, this configuration might become obsolete. For example, when a new
+ANSYS version is installed, and the old one is removed.
+To update this configuration file with the latest path you can the following:
+
+.. code:: python
+
+    >>> from ansys.mapdl.core import save_ansys_path
+    >>> save_ansys_path(r"C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ansys222.exe")
+    'C:\\Program Files\\ANSYS Inc\\v222\\ansys\\bin\\winx64\\ansys222.exe'
+
+If you want to check which ANSYS installations is PyMAPDL detecting you can issue:
+
+.. code:: python
+
+    >>> from ansys.mapdl.core.launcher import _get_available_base_ansys
+    >>> _get_available_base_ansys()
+    {222: 'C:\\Program Files\\ANSYS Inc\\v222',
+    212: 'C:\\Program Files\\ANSYS Inc\\v212',
+    -222: 'C:\\Program Files\\ANSYS Inc\\ANSYS Student\\v222'}
+
+It should be noticed that the student versions are provided as negative version (Python ``dict``
+does not accept two equal keys.
+The result of ``_get_available_base_ansys()`` is in order, higher version first and student versions
+at last.
 
 Debug Launch Issues
 ~~~~~~~~~~~~~~~~~~~
@@ -197,18 +250,101 @@ For Linux:
 
 Note that you should probably startup MAPDL in a temporary working
 directory as MAPDL creates a several temporary files.
+You can specify a directory by either launching MAPDL from the temporary directory:
 
-If this command doesn't launch, you could have a variety of issues, including:
+.. code:: pwsh
 
-- License server setup
-- Running behind a VPN
-- Missing dependencies
+    mkdir temporary_directory
+    cd temporary_directory
+     & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
+
+Or specifying the ``-dir`` flag:
+
+.. code:: pwsh
+
+    mkdir temporary_directory
+    & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe' -dir "C:\ansys_job\mytest1"
+
+
+If this command doesn't launch, please pay attention to the command output:
+
+.. code:: pwsh
+
+    (base) PS C:\Users\gayuso\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
+    *** ERROR ***
+    Another ANSYS job with the same job name (file) is already running in this
+    directory or the file.lock file has not been deleted from an abnormally
+    terminated ANSYS run.  To disable this check, set the ANSYS_LOCK environment
+    variable to OFF.
+
+
+There is a variety of issues that can make ANSYS not launching, including:
+
+- License server setup.
+  Incorrect license server configuration can make ANSYS not able to get a valid license.
+  In those cases, you might see output **similar** to:
+
+  .. code:: pwsh
+
+    (base) PS C:\Users\gayuso\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
+   
+    ANSYS LICENSE MANAGER ERROR:
+
+    Maximum licensed number of demo users already reached.
+
+
+    ANSYS LICENSE MANAGER ERROR:
+
+    Request name mech_2 does not exist in the licensing pool.
+    No such feature exists.
+    Feature:       mech_2
+    License path:  C:\Users\gayuso\AppData\Local\Temp\\cb0400ba-6edb-4bb9-a333-41e7318c007d;
+    FlexNet Licensing error:-5,357
+
+
+- Running behind a VPN.
+  If your device is inside a virtual private network (VPN), ANSYS might have some problems to correctly
+  resolve the IP of the license server. Please do check that the hostname or IP of the license server
+  is correct.
+  In Windows, you can find the license configuration file which points to the license server in:
+
+  .. code:: text
+
+    C:\Program Files\ANSYS Inc\Shared Files\Licensing\ansyslmd.ini
+
+  On linux:
+
+  .. code:: text
+    
+    /usr/
+
+- Incorrect environment variables.
+  The license server can be also specified using the environment variable ``ANSYSLMD_LICENSE_FILE``.
+  You can check the value of this environment variable by issuing on Windows:
+
+  .. code:: pwsh
+    
+    $env:ANSYSLMD_LICENSE_FILE
+    1055@1.1.1.1
+
+  And on linux:
+
+  .. code:: bash
+
+    printenv | grep ANSYSLMD_LICENSE_FILE
+
+- Missing dependencies.
+  
 
 
 Licensing Issues
 ----------------
 
-PADT generally has a great blog regarding ANSYS issues, and licensing is always a common issue (for example `Changes to Licensing at ANSYS 2020R1 <https://www.padtinc.com/blog/15271-2/>`_).  Should you be responsible for maintaining Ansys licensing or have a personal install of Ansys, please check the online Ansys licensing documentation at `Installation and Licensing <https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/prod_page.html?pn=Installation%20and%20Licensing&pid=InstallationAndLicensing&lang=en>`_.
+PADT generally has a great blog regarding ANSYS issues, and licensing is always a common issue 
+(for example `Changes to Licensing at ANSYS 2020R1 <https://www.padtinc.com/blog/15271-2/>`_).  
+Should you be responsible for maintaining Ansys licensing or have a personal install of Ansys,
+please check the online Ansys licensing documentation at 
+`Installation and Licensing <https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/prod_page.html?pn=Installation%20and%20Licensing&pid=InstallationAndLicensing&lang=en>`_.
 
 For an in-depth explanation, please see the :download:`ANSYS Licensing Guide <ANSYS_Inc._Licensing_Guide.pdf>`.
 

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -270,7 +270,7 @@ If this command doesn't launch, please pay attention to the command output:
 
 .. code:: pwsh
 
-    (base) PS C:\Users\gayuso\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
+    (base) PS C:\Users\user\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
     *** ERROR ***
     Another ANSYS job with the same job name (file) is already running in this
     directory or the file.lock file has not been deleted from an abnormally
@@ -286,7 +286,7 @@ There is a variety of issues that can make ANSYS not launching, including:
 
   .. code:: pwsh
 
-    (base) PS C:\Users\gayuso\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
+    (base) PS C:\Users\user\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
    
     ANSYS LICENSE MANAGER ERROR:
 
@@ -298,7 +298,7 @@ There is a variety of issues that can make ANSYS not launching, including:
     Request name mech_2 does not exist in the licensing pool.
     No such feature exists.
     Feature:       mech_2
-    License path:  C:\Users\gayuso\AppData\Local\Temp\\cb0400ba-6edb-4bb9-a333-41e7318c007d;
+    License path:  C:\Users\user\AppData\Local\Temp\\cb0400ba-6edb-4bb9-a333-41e7318c007d;
     FlexNet Licensing error:-5,357
 
 
@@ -312,11 +312,6 @@ There is a variety of issues that can make ANSYS not launching, including:
 
     C:\Program Files\ANSYS Inc\Shared Files\Licensing\ansyslmd.ini
 
-  On linux:
-
-  .. code:: text
-    
-    /usr/
 
 - Incorrect environment variables.
   The license server can be also specified using the environment variable ``ANSYSLMD_LICENSE_FILE``.

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -170,28 +170,28 @@ For Linux:
 Should this fail to launch or hang while launching, pass
 ``verbose_mapdl=True`` when using ``launch_mapdl``.  This will print
 the output of MAPDL within Python and can be used to debug why MAPDL
-isn't launching.  Output is limited on Windows due to the way
-MAPDL launches on Windows.
+isn't launching. On Windows, output is limited due to the way
+MAPDL launches.
 
-Default executable Location
+Default Executable Location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The first time that you run PyMAPDL, it detects the
-available ANSYS installations, normally under:
+available ANSYS installations.
+
+On Windows, Ansys installations are normally under:
 
 .. code:: text
 
     C:/Program Files/ANSYS Inc/vXXX
 
-on Windows, and:
+On Linux, Ansys installations are normally under:
 
 .. code:: text
 
     /usr/ansys_inc/vXXX
 
-on Linux.
-
-If PyMAPDL successfully finds a valid ANSYS installation, it caches its
+If PyMAPDL finds a valid ANSYS installation, it caches its
 path in the configuration file, ``config.txt``, whose path is shown in the
 following code:
 
@@ -203,8 +203,8 @@ following code:
 
 
 In certain cases, this configuration might become obsolete. For example, when a new
-Ansys version is installed, and the old one is removed.
-To update this configuration file with the latest path, do the following:
+Ansys version is installed and an earlier installation is removed.
+To update this configuration file with the latest path, use:
 
 .. code:: python
 
@@ -212,7 +212,7 @@ To update this configuration file with the latest path, do the following:
     >>> save_ansys_path(r"C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ansys222.exe")
     'C:\\Program Files\\ANSYS Inc\\v222\\ansys\\bin\\winx64\\ansys222.exe'
 
-If you want to check which Ansys installations PyMAPDL has detected, run:
+If you want to check which Ansys installations PyMAPDL has detected, use:
 
 .. code:: python
 
@@ -224,10 +224,11 @@ If you want to check which Ansys installations PyMAPDL has detected, run:
 
 Student versions are provided as negative versions because the Python dictionary
 does not accept two equal keys. The result of the ``_get_available_base_ansys()`` method
-listing higher versions first and student versions last.
+lists higher versions first and student versions last.
 
 .. warning::
-    You should not have the same Ansys product version and student version. For more information, see `Debug Launch Issues`_.
+    You should not have the same Ansys product version and student version installed. For more
+    information, see `Debug Launch Issues`_.
 
 Debug Launch Issues
 ~~~~~~~~~~~~~~~~~~~
@@ -252,6 +253,7 @@ For Linux:
 
 You should start MAPDL in a temporary working directory because MAPDL creates
 several temporary files.
+
 You can specify a directory by launching MAPDL from the temporary directory:
 
 .. code:: pwsh
@@ -268,7 +270,7 @@ Or, you can specify the directory using the ``-dir`` flag:
     & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe' -dir "C:\ansys_job\mytest1"
 
 
-If this command doesn't launch, look at the command output:
+If this command doesn't launch MAPDL, look at the command output:
 
 .. code:: pwsh
 
@@ -276,7 +278,7 @@ If this command doesn't launch, look at the command output:
     *** ERROR ***
     Another Ansys job with the same job name (file) is already running in this
     directory or the file.lock file has not been deleted from an abnormally
-    terminated Ansys run.  To disable this check, set the ANSYS_LOCK environment
+    terminated Ansys run. To disable this check, set the ANSYS_LOCK environment
     variable to OFF.
 
 
@@ -285,13 +287,13 @@ There are many issues that can cause Ansys not to launch, including:
 - License server setup
 - Running behind a VPN
 - Missing dependencies
-- Conflicts with Student Version
+- Conflicts with a student version
 
 
 Licensing Issues
 ----------------
 
-Incorrect license server configuration can make ANSYS not being able to get a valid license.
+Incorrect license server configuration can prevent Ansys from being able to get a valid license.
 In those cases, you might see output **similar** to:
 
 .. code:: pwsh
@@ -318,7 +320,7 @@ Should you be responsible for maintaining Ansys licensing or have a personal ins
 please check the online Ansys licensing documentation at 
 `Installation and Licensing <https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/prod_page.html?pn=Installation%20and%20Licensing&pid=InstallationAndLicensing&lang=en>`_.
 
-For an in-depth explanation, please see the :download:`ANSYS Licensing Guide <ANSYS_Inc._Licensing_Guide.pdf>`.
+For more comprehensive information, download the :download:`ANSYS Licensing Guide <ANSYS_Inc._Licensing_Guide.pdf>`.
 
 
 VPN Issues
@@ -339,7 +341,7 @@ While this approach has the disadvantage of using the potentially slower shared 
 In addition, if your device is inside a virtual private network (VPN), ANSYS might have some problems to correctly
 resolve the IP of the license server. Please do check that the hostname or IP of the license server
 is correct.
-In Windows, you can find the license configuration file which points to the license server in:
+In Windows, you can find the license configuration file that points to the license server in:
 
 .. code:: text
 
@@ -417,16 +419,17 @@ then installs it via ``dpkg``.
 Conflicts with Student Version
 ------------------------------
 
-Although you can install Ansys together with any other Ansys products or versions, on Windows it is **highly**
-recommended to not install an ANSYS Product Student version together with its non-student version.
-For example, *Ansys MAPDL 2022R2* and *Ansys MAPDL 2022R2 Student version* installed together might cause
-some license conflicts due to overwriting of the environment variables.
-Having different versions, for example *Ansys MAPDL 2021R1* and *Ansys MAPDL 2022R2 Student version* is
-completely fine.
+Although you can install Ansys together with other Ansys products or versions, on Windows, you
+should not install a student version of an Ansys product together with its non-student version.
+For example, installing both the Ansys MAPDL 202 2R2 Student Version and Ansys MAPDL 2022
+R2 might cause license conflicts due to overwriting of environment variables. Having different
+versions, for example the Ansys MAPDL 2022 R2 Student Version and Ansys MAPDL 2021 R1,
+is fine.
 
-If you experience those issues, we recommend you to edit the environment variables ``ANSYSXXX_DIR``, ``AWP_ROOTXXX``,
-and ``CADOE_LIBDIRXXX`` where ``XXX`` is the MAPDL numeric version (i.e. ``222`` for *Ansys MAPDL 2022R2*)
-to remove any reference to the student version.
+If you experience issues, you should edit these environment variables to remove any
+reference to the student version: ``ANSYSXXX_DIR``, ``AWP_ROOTXXX``, and
+``CADOE_LIBDIRXXX``. The three-digit MAPDL version appears where ``XXX`` is
+shown. For Ansys MAPDL 2022 R2, ``222`` appears where ``XXX`` is shown.
 
 .. code:: pwsh
 

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -170,20 +170,20 @@ For Linux:
 Should this fail to launch or hang while launching, pass
 ``verbose_mapdl=True`` when using ``launch_mapdl``.  This will print
 the output of MAPDL within Python and can be used to debug why MAPDL
-isn't launching.  Output will be limited on Windows due to the way
+isn't launching.  Output is limited on Windows due to the way
 MAPDL launches on Windows.
 
 Default executable Location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The first time you run PyMAPDL it will detect the
+The first time that you run PyMAPDL, it detects the
 available ANSYS installations, normally under:
 
 .. code:: text
 
     C:/Program Files/ANSYS Inc/vXXX
 
-in windows, and:
+on Windows, and:
 
 .. code:: text
 
@@ -191,9 +191,9 @@ in windows, and:
 
 on Linux.
 
-If PyMAPDL successfully find a valid ANSYS installation, it will cache its
-path in the configuration file ``config.txt`` which can be found by following
-the next code:
+If PyMAPDL successfully finds a valid ANSYS installation, it caches its
+path in the configuration file, ``config.txt``, whose path is shown in the
+following code:
 
 .. code:: python
 
@@ -203,8 +203,8 @@ the next code:
 
 
 In certain cases, this configuration might become obsolete. For example, when a new
-ANSYS version is installed, and the old one is removed.
-To update this configuration file with the latest path you can the following:
+Ansys version is installed, and the old one is removed.
+To update this configuration file with the latest path, do the following:
 
 .. code:: python
 
@@ -212,7 +212,7 @@ To update this configuration file with the latest path you can the following:
     >>> save_ansys_path(r"C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ansys222.exe")
     'C:\\Program Files\\ANSYS Inc\\v222\\ansys\\bin\\winx64\\ansys222.exe'
 
-If you want to check which ANSYS installations is PyMAPDL detecting you can issue:
+If you want to check which Ansys installations PyMAPDL has detected, run:
 
 .. code:: python
 
@@ -222,14 +222,12 @@ If you want to check which ANSYS installations is PyMAPDL detecting you can issu
     212: 'C:\\Program Files\\ANSYS Inc\\v212',
     -222: 'C:\\Program Files\\ANSYS Inc\\ANSYS Student\\v222'}
 
-It should be noticed that the student versions are provided as negative version (Python ``dict``
-does not accept two equal keys.
-The result of ``_get_available_base_ansys()`` is in order, higher version first and student versions
-at last.
+Student versions are provided as negative versions because the Python dictionary
+does not accept two equal keys. The result of the ``_get_available_base_ansys()`` method
+listing higher versions first and student versions last.
 
 .. warning::
-    It is not recommended to have installed Ansys product and Ansys student products with the same version.
-    See `Debug Launch Issues`_
+    You should not have the same Ansys product version and student version. For more information, see `Debug Launch Issues`_.
 
 Debug Launch Issues
 ~~~~~~~~~~~~~~~~~~~
@@ -252,9 +250,9 @@ For Linux:
 
     /usr/ansys_inc/v211/ansys/bin/ansys211
 
-Note that you should probably startup MAPDL in a temporary working
-directory as MAPDL creates a several temporary files.
-You can specify a directory by either launching MAPDL from the temporary directory:
+You should start MAPDL in a temporary working directory because MAPDL creates
+several temporary files.
+You can specify a directory by launching MAPDL from the temporary directory:
 
 .. code:: pwsh
 
@@ -262,7 +260,7 @@ You can specify a directory by either launching MAPDL from the temporary directo
     cd temporary_directory
      & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
 
-Or specifying the ``-dir`` flag:
+Or, you can specify the directory using the ``-dir`` flag:
 
 .. code:: pwsh
 
@@ -270,19 +268,19 @@ Or specifying the ``-dir`` flag:
     & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe' -dir "C:\ansys_job\mytest1"
 
 
-If this command doesn't launch, please pay attention to the command output:
+If this command doesn't launch, look at the command output:
 
 .. code:: pwsh
 
     (base) PS C:\Users\user\temp> & 'C:\Program Files\ANSYS Inc\v222\ansys\bin\winx64\ANSYS222.exe'
     *** ERROR ***
-    Another ANSYS job with the same job name (file) is already running in this
+    Another Ansys job with the same job name (file) is already running in this
     directory or the file.lock file has not been deleted from an abnormally
-    terminated ANSYS run.  To disable this check, set the ANSYS_LOCK environment
+    terminated Ansys run.  To disable this check, set the ANSYS_LOCK environment
     variable to OFF.
 
 
-There is a variety of issues that can make ANSYS not launching, including:
+There are many issues that can cause Ansys not to launch, including:
 
 - License server setup
 - Running behind a VPN

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -642,24 +642,24 @@ def _get_available_base_ansys():
         supported_versions = SUPPORTED_ANSYS_VERSIONS
         # The student version overwrites the AWP_ROOT env var (if it is installed later)
         # However the priority should be given to the non-student version.
-        awp_roots = {}
+        awp_roots = []
+        awp_roots_student = []
+
         for ver in supported_versions:
             path_ = os.environ.get(f"AWP_ROOT{ver}", "")
             path_non_student = path_.replace("\\ANSYS Student", "")
 
             if "student" in path_.lower() and os.path.exists(path_non_student):
                 # Check if also exist a non-student version
-                awp_roots[ver] = path_non_student
-                awp_roots[-1 * ver] = path_
+                awp_roots.append([ver, path_non_student])
+                awp_roots_student.insert(0, [-1 * ver, path_])
 
             else:
-                awp_roots[ver] = path_
+                awp_roots.append([ver, path_])
 
-        # sorting
+        awp_roots.extend(awp_roots_student)
         installed_versions = {
-            each_key: awp_roots[each_key]
-            for each_key in sorted(awp_roots.keys(), reverse=True)
-            if awp_roots[each_key] and os.path.isdir(awp_roots[each_key])
+            ver: path for ver, path in awp_roots if path and os.path.isdir(path)
         }
 
         if installed_versions:

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -640,12 +640,28 @@ def _get_available_base_ansys():
     base_path = None
     if os.name == "nt":  # pragma: no cover
         supported_versions = SUPPORTED_ANSYS_VERSIONS
-        awp_roots = {
-            ver: os.environ.get(f"AWP_ROOT{ver}", "") for ver in supported_versions
-        }
+        # The student version overwrites the AWP_ROOT env var (if it is installed later)
+        # However the priority should be given to the non-student version.
+        awp_roots = {}
+        for ver in supported_versions:
+            path_ = os.environ.get(f"AWP_ROOT{ver}", "")
+            path_non_student = path_.replace("\\ANSYS Student", "")
+
+            if "student" in path_.lower() and os.path.exists(path_non_student):
+                # Check if also exist a non-student version
+                awp_roots[ver] = path_non_student
+                awp_roots[-1 * ver] = path_
+
+            else:
+                awp_roots[ver] = path_
+
+        # sorting
         installed_versions = {
-            ver: path for ver, path in awp_roots.items() if path and os.path.isdir(path)
+            each_key: awp_roots[each_key]
+            for each_key in sorted(awp_roots.keys(), reverse=True)
+            if awp_roots[each_key] and os.path.isdir(awp_roots[each_key])
         }
+
         if installed_versions:
             return installed_versions
         else:  # pragma: no cover
@@ -716,6 +732,7 @@ def find_ansys():
         return "", ""
     version = max(versions.keys())
     ans_path = versions[version]
+    version = abs(version)
     if os.name == "nt":
         ansys_bin = os.path.join(
             ans_path, "ansys", "bin", "winx64", f"ansys{version}.exe"

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -210,7 +210,7 @@ class Plain_Report:
         mapdl_install = _get_available_base_ansys()
         if not mapdl_install:
             lines.append("Unable to locate any Ansys installations")
-        else:
+        else:  # pragma: no cover
             lines.append("Version   Location")
             lines.append("------------------")
             for key in sorted(mapdl_install.keys()):

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -214,7 +214,7 @@ class Plain_Report:
             lines.append("Version   Location")
             lines.append("------------------")
             for key in sorted(mapdl_install.keys()):
-                lines.append(f"{key}       {mapdl_install[key]}")
+                lines.append(f"{abs(key)}       {mapdl_install[key]}")
         install_info = "\n".join(lines)
 
         env_info_lines = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,6 +184,7 @@ def mapdl_console(request):
     # find a valid version of corba
     console_path = None
     for version in ansys_base_paths:
+        version = abs(version)
         if version < 211:
             console_path = get_ansys_bin(str(version))
 
@@ -218,6 +219,7 @@ def mapdl_corba(request):
     # find a valid version of corba
     corba_path = None
     for version in ansys_base_paths:
+        version = abs(version)
         if version >= 170 and version < 202:
             corba_path = get_ansys_bin(str(version))
 


### PR DESCRIPTION
Currently, the Ansys Student installation overwrites the ``AWP_ROOT`` env var, hence it is chosen over a non-student version.

To simplify things and avoid the users to manually change the env var, I am forcing PyMAPDL to use (if available) non-student versions, even if they are an order version.

## Notes
There is some nuances with this.
* Since the data is given in a dict, and dicts cannot have two equal keys, I'm using negative version for the student versions.
* I have also extended/updated the docs.

