### PR TITLE
Fixing dependabot and commeter

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -82,6 +82,7 @@ jobs:
       # if: toJSON(github.event.pull_request.labels.*.name) == '[]'
       if: github.event.pull_request.labels[0] == null # Empty labels
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           Please add one of the following labels to add this contribution to the Release Notes :point_down:


### PR DESCRIPTION
It seems that dependabot has not enough permissions to run the commenter.

I'm going to try this... Wish me luck.

