### PR TITLE
Fixing doc build nightly.

### DIFF
--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -100,7 +100,6 @@ jobs:
       - name: Tar logs
         if: always()
         run: |
-          cp -f doc/build/latex/*.log ./logs-nightly-docs/
           cp log.txt ./logs-nightly-docs/
           tar cvzf ./logs-nightly-docs.tgz ./logs-nightly-docs
 


### PR DESCRIPTION
As the title.

Current implementation was attempting to include the latex log file in the artifact, but the PDF is not built in the nightly.