### PR TITLE
Standardize the ``mapdl.inquire("", "RSTXXX")`` behaviour

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1913,13 +1913,13 @@ class _MapdlCore(Commands):
         try:
             with self.run_as_routine("POST1"):
                 filename = self.inquire("", "RSTFILE")
-        except Exception:
+        except Exception:  # pragma: no cover
             filename = self.jobname
 
         try:
             with self.run_as_routine("POST1"):
                 ext = self.inquire("", "RSTEXT")
-        except Exception:
+        except Exception:  # pragma: no cover
             ext = "rst"
 
         if self._local:  # pragma: no cover

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1911,21 +1911,27 @@ class _MapdlCore(Commands):
     def _result_file(self):
         """Path of the non-distributed result file"""
         try:
-            filename = self.inquire("", "RSTFILE")
-            if not filename:
-                filename = self.jobname
+            with self.run_as_routine("POST1"):
+                filename = self.inquire("", "RSTFILE")
         except Exception:
             filename = self.jobname
 
         try:
-            ext = self.inquire("", "RSTEXT")
-        except Exception:  # check if rth file exists
-            ext = ""
+            with self.run_as_routine("POST1"):
+                ext = self.inquire("", "RSTEXT")
+        except Exception:
+            ext = "rst"
 
         if self._local:  # pragma: no cover
             if ext == "":
+                # Case where there is RST extension because it is thermal for example
+                filename = self.jobname
+
                 rth_file = os.path.join(self.directory, f"{filename}.rth")
                 rst_file = os.path.join(self.directory, f"{filename}.rst")
+
+                if self._prioritize_thermal and os.path.isfile(rth_file):
+                    return rth_file
 
                 if os.path.isfile(rth_file) and os.path.isfile(rst_file):
                     return last_created([rth_file, rst_file])
@@ -1938,7 +1944,7 @@ class _MapdlCore(Commands):
                 if os.path.isfile(filename):
                     return filename
         else:
-            return os.path.join(filename, ext)  # pragma: no cover
+            return f"{filename}.{ext}"
 
     @property
     def _distributed_result_file(self):

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2216,39 +2216,6 @@ class MapdlGrpc(_MapdlCore):
             return rst_file
 
     @property
-    def _result_file(self):
-        """Path of the non-distributed result file"""
-        try:
-            filename = self.inquire("", "RSTFILE")
-            if not filename:
-                filename = self.jobname
-        except:
-            filename = self.jobname
-
-        try:
-            ext = self.inquire("", "RSTEXT")
-        except:  # check if rth file exists
-            ext = ""
-
-        if ext == "":
-            rth_file = os.path.join(self.directory, "%s.%s" % (filename, "rth"))
-            rst_file = os.path.join(self.directory, "%s.%s" % (filename, "rst"))
-
-            if self._prioritize_thermal and os.path.isfile(rth_file):
-                return rth_file
-
-            if os.path.isfile(rth_file) and os.path.isfile(rst_file):
-                return last_created([rth_file, rst_file])
-            elif os.path.isfile(rth_file):
-                return rth_file
-            elif os.path.isfile(rst_file):
-                return rst_file
-        else:
-            filename = os.path.join(self.directory, "%s.%s" % (filename, ext))
-            if os.path.isfile(filename):
-                return filename
-
-    @property
     def thermal_result(self):
         """The thermal result object"""
         self._prioritize_thermal = True

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1385,14 +1385,9 @@ def test_equal_in_comments_and_title(mapdl):
     mapdl.title("This is '=' ")
 
 
-@pytest.mark.xfail
 def test_result_file(mapdl, solved_box):
     assert mapdl.result_file
     assert isinstance(mapdl.result_file, str)
-
-
-def test_empty_result_file(mapdl, cleared):
-    assert mapdl.result_file is None
 
 
 @skip_in_cloud


### PR DESCRIPTION
Close #1451 by running ``mapdl.inquire("", "RSTFILE")`` and ``mapdl.inquire("", "RSTEXT")`` in the ``POST1`` processor.
                