### PR TITLE
Adding ``write_to_log`` option to ``mapdl.input`` (grpc method)

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1388,7 +1388,7 @@ class MapdlGrpc(_MapdlCore):
         ]
 
         # since we can't directly run /INPUT, we have to write a
-        # temporary input file that tells mainan to read the input
+        # temporary input file that tells MAPDL to read the input
         # file.
         id_ = random_string()
         tmp_name = f"_input_tmp_{id_}_.inp"

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1302,6 +1302,7 @@ class MapdlGrpc(_MapdlCore):
         time_step_stream=None,
         chunk_size=512,
         orig_cmd="/INP",
+        write_to_log=True,
         **kwargs,
     ):
         """Stream a local input file to a remote mapdl instance.
@@ -1400,6 +1401,10 @@ class MapdlGrpc(_MapdlCore):
         else:
             # Using default INPUT
             tmp_dat = f"/OUT,{tmp_out}\n{orig_cmd},'{filename}'\n"
+
+        if write_to_log and self._apdl_log is not None:
+            if not self._apdl_log.closed:
+                self._apdl_log.write(tmp_dat)
 
         if self._local:
             local_path = self.directory

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -526,6 +526,11 @@ def test_apdl_logging(mapdl, tmpdir):
         mapdl.slashsolu()
         mapdl.prep7()
 
+    file_input = str(tmp_dir.join("input.inp"))
+    str_not_in_apdl_logger = "/com, this input should not appear"
+    with open(file_input, "w") as fid:
+        fid.write(str_not_in_apdl_logger)
+
     mapdl._apdl_log.flush()
     with open(file_path, "r") as fid:
         log = fid.read()
@@ -537,6 +542,24 @@ def test_apdl_logging(mapdl, tmpdir):
     assert "This is a comment" in log
     assert "This is a non-interactive command" in log
     assert "/SOLU" in log
+
+    # The input of the ``non_interactive`` should not write to the apdl_logger.
+    assert "/INP," not in log
+    assert "'input.inp'" not in log
+    assert "/OUT,_input_tmp_" not in log
+    assert str_not_in_apdl_logger not in log
+
+    # Testing /input, i
+    mapdl.input(file_input)
+    mapdl._apdl_log.flush()
+    with open(file_path, "r") as fid:
+        log = fid.read()
+
+    # Testing /input #
+    assert "/INP," in log
+    assert "'input.inp'" in log
+    assert "/OUT,_input_tmp_" in log
+    assert str_not_in_apdl_logger not in log
 
     # Closing
     mapdl._close_apdl_log()

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -555,7 +555,7 @@ def test_apdl_logging(mapdl, tmpdir):
     with open(file_path, "r") as fid:
         log = fid.read()
 
-    # Testing /input #
+    # Testing /input PR #1455
     assert "/INP," in log
     assert "'input.inp'" in log
     assert "/OUT,_input_tmp_" in log


### PR DESCRIPTION
As the title. Updated unit tests.


Close #1424