### PR TITLE
Fixing licensing in docker building cicd

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ HAS_GRPC = int(rver) >= 211 or ON_CI
 
 # determine if we can launch an instance of MAPDL locally
 # start with ``False`` and always assume the remote case
-local = [False]
+LOCAL = [False]
 
 # check if the user wants to permit pytest to start MAPDL
 START_INSTANCE = get_start_instance()
@@ -250,7 +250,7 @@ def mapdl_corba(request):
         mapdl.prep7()
 
 
-@pytest.fixture(scope="session", params=local)
+@pytest.fixture(scope="session", params=LOCAL)
 def mapdl(request, tmpdir_factory):
     # don't use the default run location as tests run multiple unit testings
     run_path = str(tmpdir_factory.mktemp("ansys"))

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -276,10 +276,9 @@ def test_stop_license_checker():
     license_checker = licensing.LicenseChecker()
 
     license_checker.start()
-    time.sleep(1)
+    license_checker.wait()
 
     license_checker.stop = True
-    time.sleep(1)  # giving some time to reach end of the file.
     assert not license_checker._lic_file_thread.is_alive()
 
 
@@ -287,10 +286,9 @@ def test_is_connected_license_checker():
     license_checker = licensing.LicenseChecker()
 
     license_checker.start()
-    time.sleep(1)
+    license_checker.wait()
 
     license_checker.is_connected = True
-    time.sleep(1)  # giving some time to reach end of the file.
     assert not license_checker._lic_file_thread.is_alive()
 
 

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -17,7 +17,8 @@ except:
     LIC_INSTALLED = None
 
 skip_no_lic_bin = pytest.mark.skipif(
-    not (LIC_INSTALLED and IS_LOCAL), reason="Requires local license utilities binaries"
+    not (LIC_INSTALLED and IS_LOCAL),
+    reason="Requires being in 'local' mode and have license utilities binaries.",
 )
 
 skip_launch_mapdl = pytest.mark.skipif(

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -167,7 +167,7 @@ def test_license_checker(tmpdir, license_checker):
 @skip_no_lic_bin
 def test_check_license_file(tmpdir):
     timeout = 15
-    checker = licensing.LicenseChecker(verbose=True, timeout=timeout)
+    checker = licensing.LicenseChecker(timeout=timeout)
     # start the license check in the background
     checker.start(checkout_license=False)
 


### PR DESCRIPTION
The docker image builiding was failing because of two things:

* Unsufficient time given to some license check threads
* The tests that requires license binaries were being executed although the testing was made in remote way.

I have added the `local` requirement to the license binaries tests, and also increased the waiting time before checking threads health.

Pinging @dts12263 for visibility