### PR TITLE
Correction of example for parameters extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ venv/
 
 # Pycharm local settings
 .idea/
+/.vs

--- a/doc/source/examples/technology_showcase_examples/techdemo-20/20-example-technology-showcase-dynamic-simulation-PCB.py
+++ b/doc/source/examples/technology_showcase_examples/techdemo-20/20-example-technology-showcase-dynamic-simulation-PCB.py
@@ -305,8 +305,8 @@ mapdl.show("close")
 # store MAPDL results to python variables
 mapdl.dim("frequencies", "array", 4000, 1)
 mapdl.dim("response", "array", 4000, 1)
-mapdl.vget("frequencies(1)", 1)
-mapdl.vget("response(1)", 3)
+mapdl.vget("frequencies", 1)
+mapdl.vget("response", 3)
 frequencies = mapdl.parameters["frequencies"]
 response = mapdl.parameters["response"]
 


### PR DESCRIPTION
Due to recent changes with parameters this example needs to be adjusted for the last section : 
mapdl.vget("frequencies(1)", 1)
mapdl.vget("response(1)", 3)
become:
mapdl.vget("frequencies", 1)
mapdl.vget("response", 3)