### PR TITLE
Fix checking against existing MATH parameters

### DIFF
--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -205,7 +205,7 @@ class MapdlMath:
         if not name:
             name = id_generator()
 
-        if name not in self._parm:
+        if name.upper() not in self._parm:
             self._mapdl.run(f"*VEC,{name},{MYCTYPE[dtype]},ALLOC,{size}", mute=True)
 
         ans_vec = AnsVec(name, self._mapdl, dtype, init)


### PR DESCRIPTION
The parameter check should be done on the capital version of the parameter name:

```py
        if name.upper() not in self._parm:
            self._mapdl.run(f"*VEC,{name},{MYCTYPE[dtype]},ALLOC,{size}", mute=True)
```

