### PR TITLE
Upload a coverage report at every unit test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,6 @@ jobs:
           xvfb-run pytest -v --durations=10 --maxfail=10  --reruns 7 --reruns-delay 3 --only-rerun MapdlExitedError  --cov=ansys.mapdl.core --cov-report=xml --cov-report=html
 
       - uses: codecov/codecov-action@v3
-        if: matrix.mapdl-version == 'v21.2.1'
         name: 'Upload coverage to Codecov'
 
       - name: Check package


### PR DESCRIPTION
As the title.

This is because some modules (future `Krylov` module #1490 ) only runs on specific (last) MAPDL versions. Since I don't want coverage complains, I'm pushing this.
