### PR TITLE
Change titles to sentence case

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,45 +33,43 @@ Overview
 --------
 The PyMAPDL project supports Pythonic access to MAPDL to be able to
 communicate with the MAPDL process directly from Python. The latest
-ansys-mapdl-core package enables a more comprehensive interface with
+``ansys-mapdl-core`` package enables a more comprehensive interface with
 MAPDL and supports:
 
-- All the features of the original module (e.g. pythonic commands,
-  interactive sessions).
+- All the features of the original module (for example, Pythonic commands
+  and interactive sessions).
 - Remote connections to MAPDL from anywhere via gRPC.
 - Direct access to MAPDL arrays, meshes, and geometry as Python
   objects.
-- Low level access to the MAPDL solver through APDL math in a scipy
+- Low-level access to the MAPDL solver through APDL math in a SciPy-
   like interface.
 
-Here's a quick demo of PyMAPDL within VSCode:
+Here's a quick demo of PyMAPDL within Visual Studio Code:
 
 .. image:: https://github.com/pyansys/pymapdl/raw/main/doc/landing_page_demo.gif
 
 PyMAPDL works within Jupyter Notebooks, the standard Python console,
 or in batch mode on Windows, Linux, and even Mac OS.
 
-Documentation and Issues
+Documentation and issues
 ------------------------
-See the `Documentation <https://mapdldocs.pyansys.com>`_ page for more
-details, and the `Examples gallery
-<https://mapdldocs.pyansys.com/examples/index.html>`_ for some
-examples.
+For more information, see the `Documentation <https://mapdldocs.pyansys.com>`_ page.
+For some examples, see the `Examples gallery <https://mapdldocs.pyansys.com/examples/index.html>`_.
 
-Please feel free to post issues and other questions at `PyMAPDL Issues
+Feel free to post issues and other questions at `PyMAPDL Issues
 <https://github.com/pyansys/pymapdl/issues>`_.  This is the best place
 to post questions and code.
 
 
 
-Project Transition - Legacy Support
+Project transition - legacy support
 -----------------------------------
 This project was formerly known as ``pyansys``, and we'd like to thank
 all the early adopters, contributors, and users who submitted issues,
 gave feedback, and contributed code through the years.  The
-``pyansys`` project has been taken up Ansys and will be leveraged in
-creating new Pythonic, cross-platform, and multi-language service
-based interfaces for Ansys's products.  Your contributions to
+``pyansys`` project has been taken up at Ansys and is being leveraged in
+creating new Pythonic, cross-platform, and multi-language service-based
+interfaces for Ansys's products.  Your contributions to
 ``pyansys`` has shaped it into a better solution.
 
 The ``pyansys`` project is expanding beyond just MAPDL, and while
@@ -84,7 +82,7 @@ split up into the following projects and modules:
 - `ansys.mapdl.reader <https://github.com/pyansys/pymapdl-reader>`_
 - `ansys.mapdl.corba <https://github.com/pyansys/pymapdl-corba>`_
 
-Please visit the GitHub pages for further details regarding each project.
+For more information on each project, visit their GitHub pages.
 
 
 Installation
@@ -116,7 +114,7 @@ For a local "development" version, install with (requires pip >= 22.0):
    pip install -e .
 
 
-Offline Installation
+Offline installation
 ~~~~~~~~~~~~~~~~~~~~
 If you lack an internet connection on your install machine, the recommended way
 of installing PyMAPDL is downloading the wheelhouse archive from the `Releases
@@ -143,15 +141,15 @@ Consider installing using a `virtual environment
 
 Dependencies
 ------------
-You will need a local licenced copy of Ansys to run MAPDL prior and
+You must have a local licenced copy of Ansys to run MAPDL prior and
 including 2021R1.  If you have the latest version of 2021R1 you do
 not need MAPDL installed locally and can connect to a remote instance.
 
 
-Getting Started
+Getting started
 ---------------
 
-Launch MAPDL Locally
+Launch MAPDL locally
 ~~~~~~~~~~~~~~~~~~~~
 You can launch MAPDL locally directly from Python using ``launch_mapdl``:
 
@@ -165,15 +163,15 @@ launches it as a background process, and immediately connects to it.
 You can then start sending python commands to MAPDL.
 
 
-Launching Manually or Connecting to a Remote Instance
+Launching manually or connecting to a remote instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you wish to connect to a session of MAPDL on a remote computer
+If you want to connect to a session of MAPDL on a remote computer
 (either locally the LAN or through the internet), first ensure you
-have MAPDL started in gRPC server mode.  This example assumes you will
-be launching an instance locally from Windows, but can be easily
+have MAPDL started in gRPC server mode.  This example assumes that you
+are launching an instance locally from Windows, but it can be easily
 adapted to run from Linux, or the LAN provided the necessary ports are
-open.  This example specifies the port with ``-port 50052``, but this
+open. This example specifies the port with ``-port 50052``, but this
 option can be left out if you plan on using the default port 50052.
 
 .. code::
@@ -199,14 +197,14 @@ A successful connection returns:
     ansys.mapdl.core Version: 0.57.0
 
 
-Should you wish to connect to this instance of MAPDL from a remote
+Should you want to connect to this instance of MAPDL from a remote
 computer, you substitute ``ip=`` with the LAN or WAN address of the
 computer you wish to connect to.  Depending on your network settings,
 you may have to open local ports or enable port redirection across the
 WAN.
 
 
-Basic Usage
+Basic usage
 ~~~~~~~~~~~
 You run MAPDL commands via:
 
@@ -236,20 +234,19 @@ properties, or view mesh statistics.  Additionally, there's the
 ``parameters`` property which shows the active MAPDL parameters, and
 you can use to send or receive arrays between MAPDL and Python.
 
-See the full documentation at `PyMAPDL Documentation
-<https://mapdldocs.pyansys.com>`_ for more details.
+For more information, see the full documentation at `PyMAPDL Documentation
+<https://mapdldocs.pyansys.com>`_.
 
 
 Run on Docker
 ~~~~~~~~~~~~~
-Run MAPDL within a container on any OS with ``docker``!
+You can run MAPDL within a container on any OS with ``docker``.
 
-See `MAPDL on Docker README
-<https://github.com/pyansys/pymapdl/blob/master/docker/README.md>`_
-for details regarding using MAPDL within a container.
+For information on using MAPDL within a container, see `MAPDL on Docker README
+<https://github.com/pyansys/pymapdl/blob/master/docker/README.md>`_.
 
 
-Citing this Module
+Citing this module
 -------------------
 If you use ``PyMAPDL`` for research and would like to cite the module
 and source, you can visit `pyansys Zenodo
@@ -270,11 +267,11 @@ correct citation.  For example, the BibTex citation is:
       url          = {https://doi.org/10.5281/zenodo.4009467}
     }
 
-Please visit the link above for the most recent citation as the
-citation here may not be current.
+Because the citation here might not be current, visit the link above to obtain
+the most recent citation.
 
 
-License and Acknowledgments
+License and acknowledgments
 ---------------------------
 ``PyMAPDL`` is licensed under the MIT license.
 
@@ -285,4 +282,4 @@ core behavior or license of the original software.  The use of the
 interactive APDL control of ``PyMAPDL`` requires a legally licensed
 local copy of Ansys.
 
-To get a copy of Ansys, please visit `Ansys <https://www.ansys.com/>`_.
+To get a copy of Ansys, visit `Ansys <https://www.ansys.com/>`_.

--- a/doc/source/getting_started/docker.rst
+++ b/doc/source/getting_started/docker.rst
@@ -1,29 +1,29 @@
 .. _docker:
 
-**************************
-Using MAPDL Through Docker
-**************************
+************************
+Use MAPDL through Docker
+************************
 You can run MAPDL within a container on any OS using `docker` and
 connect to it via PyMAPDL.
 
 There are several situations in which it is advantageous to run MAPDL
-in a containerized environment (e.g. Docker or singularity):
+in a containerized environment (for example, Docker or Singularity):
 
 - Run in a consistent environment regardless of the host OS.
 - Portability and ease of install.
-- Large scale cluster deployment using Kubernetes
+- Large-scale cluster deployment using Kubernetes
 - Genuine application isolation through containerization.
 
 
-Installing the MAPDL Image
---------------------------
-There is a docker image hosted on the `PyMAPDL GitHub
+Install the MAPDL image
+-----------------------
+There is a Docker image hosted on the `PyMAPDL GitHub
 <https://https://github.com/pyansys/pymapdl>`_ repository that you
 can download using your GitHub credentials.
 
-Assuming you have docker installed, you can get started by
-authorizing docker to access this repository using a personal access
-token.  Create a GH personal access token with ``packages read`` permissions
+Assuming that you have docker installed, you can get started by
+authorizing Docker to access this repository using a personal access
+token. Create a GitHub personal access token with ``packages read`` permissions
 according to `Creating a personal access token <https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token>`_
 
 Save that token to a file with:
@@ -33,8 +33,8 @@ Save that token to a file with:
    echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX > GH_TOKEN.txt
 
 
-This lets you send the token to docker without leaving the token value
-in your history.  Next, authorize docker to access this repository
+This lets you send the token to Docker without leaving the token value
+in your history. Next, authorize Docker to access this repository
 with:
 
 .. code::
@@ -44,9 +44,9 @@ with:
 
 
 You can now launch MAPDL directly from docker with a short script or
-directly from the command line.  Since this image contains no license
+directly from the command line. Because this image contains no license
 server, you must enter your license server IP address in the
-``LICENSE_SERVER`` environment variable.  With that, you can launch
+``LICENSE_SERVER`` environment variable. With that, you can launch
 MAPDL with:
 
 .. code::
@@ -59,7 +59,7 @@ MAPDL with:
 
 
 Note that port `50052` (local to the container) is being mapped to
-50052 on the host.  This makes it possible to launch several MAPDL
+50052 on the host. This makes it possible to launch several MAPDL
 instances with different port mappings to allow for multiple instances
 of MAPDL.
 
@@ -76,7 +76,7 @@ Once you've launched MAPDL you should see:
     Server Executable   : MapdlGrpc Server
     Server listening on : 0.0.0.0:50052
 
-Connecting to the MAPDL Container from Python
+Connect to the MAPDL container from Python
 ---------------------------------------------
 
 You can now connect to the instance with:
@@ -103,11 +103,11 @@ Verify your connection with:
     MAPDL Version:       RELEASE  2021 R1           BUILD 21.0
     PyMAPDL Version:     Version: 0.57.0
 
-Additional Considerations
+Additional considerations
 -------------------------
 
-Appending MAPDL Options to the Container
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Append MAPDL options to the container
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the command:
 
@@ -117,9 +117,9 @@ In the command:
     docker run -e ANSYSLMD_LICENSE_FILE=$LICENSE_SERVER -p 50052:50052 $IMAGE -smp
 
 You can provide additional command line parameters to MAPDL by simply
-appending to the docker command.  For example, you can increase the
+appending to the docker command. For example, you can increase the
 number of processors (up to the number available on the host machine)
-with the `-np` switch.  For example:
+with the ```-np``` switch. For example:
 
 .. code::
 
@@ -127,11 +127,11 @@ with the `-np` switch.  For example:
     docker run -e ANSYSLMD_LICENSE_FILE=$LICENSE_SERVER -p 50052:50052 $IMAGE -np 4
 
 For additional command-line arguments, see the Ansys
-documentation at `ANSYS help <https://ansyshelp.ansys.com>`_.  Also,
+documentation at `ANSYS help <https://ansyshelp.ansys.com>`_. Also,
 be sure to have the appropriate license for additional HPC features.
 
-Using ``--restart`` policy with MAPDL products
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``--restart`` policy with MAPDL products
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, MAPDL creates a ``LOCK`` file in the working directory when it starts
 and deletes this file if it exits normally. The file is used to avoid overwriting files
@@ -161,8 +161,8 @@ You can do this in your ``docker run`` command:
       $IMAGE
 
 
-Getting Useful Files After Abnormal Termination
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Get useful files after abnormal termination
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In some cases, the MAPDL container might crash after the MAPDL process experiences an
 abnormal termination. In these cases, you can retrieve log files and output files using 

--- a/doc/source/getting_started/docker.rst
+++ b/doc/source/getting_started/docker.rst
@@ -77,7 +77,7 @@ Once you've launched MAPDL you should see:
     Server listening on : 0.0.0.0:50052
 
 Connect to the MAPDL container from Python
----------------------------------------------
+-------------------------------------------
 
 You can now connect to the instance with:
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -1,17 +1,17 @@
 ===============
-Getting Started
+Getting started
 ===============
-To use PyMAPDL, you need to have a local installation of Ansys.  The
-version of Ansys installed will dictate the interface and features
+To use PyMAPDL, you must have a local installation of Ansys. The
+version of Ansys installed dictates the interface and features
 available to you.
 
-Visit `Ansys <https://www.ansys.com/>`_ for more information on
-getting a licensed copy of Ansys.
+For more information on getting a licensed copy of Ansys, visit
+`Ansys <https://www.ansys.com/>`_ .
 
 You can also try the Student Version of Ansys products in
 `Ansys Student Versions <https://www.ansys.com/academic/students>`_.
-These are versions valid during a year and with limited capabilities 
-regarding number of nodes, elements, etc.
+The Student Verion is valid during a calendar year with limited capabilities,
+such as on the number of nodes and elements.
 
 .. toctree::
    :hidden:
@@ -27,7 +27,7 @@ regarding number of nodes, elements, etc.
 Installation
 ************
 
-Python Module
+Python module
 ~~~~~~~~~~~~~
 The ``ansys.mapdl.core`` package currently supports Python 3.7 through
 Python 3.10 on Windows, Mac OS, and Linux.
@@ -55,12 +55,12 @@ For a local "development" version, install with:
    cd pymapdl
    pip install -e .
 
-This will allow you to install the pymapdl ``ansys-mapdl-core`` module
+This allows you to install the ``ansys-mapdl-core`` module
 and modify it locally and have the changes reflected in your setup
 after restarting the Python kernel.
 
 
-Offline Installation
+Offline installation
 ~~~~~~~~~~~~~~~~~~~~
 If you lack an internet connection on your install machine, the recommended way
 of installing PyMAPDL is downloading the wheelhouse archive from the `Releases
@@ -85,20 +85,20 @@ Consider installing using a `virtual environment
 <https://docs.python.org/3/library/venv.html>`_.
 
 
-Ansys Software Requirements
+Ansys software requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-For the latest features, you will need a copy of Ansys 2021R1
-installed locally, but PyMAPDL is compatible with Ansys 17.0 and newer
+For the latest features, you must have a copy of Ansys 2021 R1
+installed locally, but PyMAPDL is compatible with Ansys 17.0 and later
 on Windows and 13.0 on Linux.
 
 .. note::
 
     The latest versions of Ansys provide signifiantly better support
-    and features.  Certain features will not be supported by earlier
-    versions of Ansys (e.g. APDL Math).
+    and features. Certain features are not supported on earlier Ansys versions
+    versions such as APDL Math.
 
 
-Verify Your Installation
+Verify your installation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Check that you can start MAPDL from Python by running:
 
@@ -112,6 +112,6 @@ Check that you can start MAPDL from Python by running:
     MAPDL Version:       RELEASE  2021 R1           BUILD 21.0
     PyMAPDL Version:     Version: 0.58.0
 
-If you see a response from the server, congratulations!  You're ready
-to get started using MAPDL as a service.  For details regarding the
+If you see a response from the server, congratulations. You're ready
+to get started using MAPDL as a service. For information on the
 PyMAPDL interface, see :ref:`ref_mapdl_user_guide`.

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -10,7 +10,7 @@ For more information on getting a licensed copy of Ansys, visit
 
 You can also try the Student Version of Ansys products in
 `Ansys Student Versions <https://www.ansys.com/academic/students>`_.
-The Student Verion is valid during a calendar year with limited capabilities,
+The Student Version is valid during a calendar year with limited capabilities,
 such as on the number of nodes and elements.
 
 .. toctree::

--- a/doc/source/getting_started/running_mapdl.rst
+++ b/doc/source/getting_started/running_mapdl.rst
@@ -1,34 +1,33 @@
 .. _using_standard_install:
 
-***************************************
-Using PyMAPDL from the Standard Install
-***************************************
+******************************************
+Use PyMAPDL from the standard installation
+******************************************
 
-The pyansys ``ansys-mapdl-core`` package requires either a local or
-remote instance of MAPDL to communicate with it.  This section covers
+The PyAnsys ``ansys-mapdl-core`` package requires either a local or
+remote instance of MAPDL to communicate with it. This section covers
 launching and interfacing with MAPDL from a local instance by
 launching it from Python.
 
-Installing MAPDL
-----------------
+Install MAPDL
+-------------
 
-MAPDL is installed by default from the standard installer.  When
-installing ANSYS, verify that the "Mechanical Products" option is
-checked under the "Structural Mechanics" option.  The standard
-installer options may change, but for reference see the following
-figure.
+MAPDL is installed by default from the Ansys standard installer. When
+installing Ansys, verify that the **Mechanical Products** checkbox is
+selected under the **Structural Mechanics** option. While the standard
+installer options can change, see the following figure for reference.
 
 .. figure:: ../images/unified_install_2019R1.jpg
     :width: 400pt
 
 
-Launching MAPDL
----------------
+Launch MAPDL
+------------
 
-Launching MAPDL locally
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Launch MAPDL locally
+~~~~~~~~~~~~~~~~~~~~
 
-You can use the ``launch_mapdl`` function to have Python startup MAPDL and
+You can use the ``launch_mapdl`` method to have Python start MAPDL and
 automatically connect to it:
 
 .. code:: python
@@ -45,16 +44,17 @@ automatically connect to it:
 This is the easiest and fastest way to get PyMAPDL up and running. 
 But you need to have an ANSYS license server installed locally. 
 
-Launching a gRPC MAPDL session
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Launch a gRPC MAPDL session
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can start MAPDL from the command line and then connect to it.
-To launch MAPDL on Windows (assuming a ``C:/Program Files/ANSYS Inc/v211`` installation) use:
+
+To launch MAPDL on Windows (assuming a ``C:/Program Files/ANSYS Inc/v211`` installation), use:
 
 .. code::
 
     C:/Program Files/ANSYS Inc/v211/ansys/bin/winx64/ANSYS211.exe -grpc
 
-Or on Linux (assuming a ``/usr/ansys_inc`` installation):
+To launch MAPDL on Linux (assuming a ``/usr/ansys_inc`` installation), use:
 
 .. code::
 
@@ -73,21 +73,23 @@ This starts up MAPDL in gRPC mode, and MAPDL should output:
      Server Executable   : MapdlGrpc Server
      Server listening on : 0.0.0.0:50052
 
-You can configure the port MAPDL starts on with the ``-port`` argument.  For
-example, you can startup the server to listen for connections at 
+You can configure the port that MAPDL starts on with the ``-port`` argument.
+For example, you can start the server to listen for connections at 
 port 50005 with:
 
 .. code::
 
     /usr/ansys_inc/v211/ansys/bin/ansys211 -port 50005 -grpc
 
-You can also configure the IP. 
-However because of an ANSYS limitation to receive
-strings from command line, the IP needs to be read from an external file 
-called ``mylocal.ip``. This file is read automatically from the directory where 
+You can also configure the IP address. 
+However, because of an Ansys limitation to receive
+strings from a command line, the IP address must be read from an external file 
+named ``mylocal.ip``. This file is read automatically from the directory where 
 MAPDL is running.
 
-You can then setup the IP in Windows (Powershell and CMD) with:
+You can then set up the IP address.
+
+In Windows (Powershell and CMD), use:
 
 .. code::
     
@@ -95,7 +97,7 @@ You can then setup the IP in Windows (Powershell and CMD) with:
     C:/Program Files/ANSYS Inc/v211/ansys/bin/winx64/ANSYS211.exe -grpc
 
 
-or in Linux with:
+In Linux, use:
 
 .. code::
     
@@ -103,11 +105,11 @@ or in Linux with:
     /usr/ansys_inc/v211/ansys/bin/ansys211 -grpc
 
 
-Connecting to a gRPC MAPDL session
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Connect to a gRPC MAPDL session
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A MAPDL gRPC server can be connected to either from the same host, or from an
-external host.  For example, you can connect to a MAPDL service
+A MAPDL gRPC server can be connected to from either the same host or an
+external host. For example, you can connect to a MAPDL service
 running **locally** with:
 
 .. code::
@@ -116,13 +118,13 @@ running **locally** with:
     >>> mapdl = Mapdl()
 
 
-This assumes that your MAPDL service is running locally on the default ip 
-(127.0.0.1) and on the default port (50052).  
+This assumes that your MAPDL service is running locally on the default IP address 
+(127.0.0.1) and on the default port (50052).
 
 If you want to connect to a **remote** instance of MAPDL and you know the IP 
 address of that instance, you can connect to it.
-For example, if on your local network at IP ``192.168.0.1`` there is a
-computer running MAPDL on the port 50052, you can connect to it with
+For example, if on your local network at IP address ``192.168.0.1`` there is a
+computer running MAPDL on the port 50052, you can connect to it with:
 
 .. code::
 
@@ -134,9 +136,9 @@ Alternatively you can use a hostname:
 
     >>> mapdl = Mapdl('myremotemachine', port=50052)
 
-Please note that you must have started MAPDL in gRPC mode in the PC with
-the mentioned IP/hostname for this to work.
+Note that you must have started MAPDL in gRPC mode on the computer with
+the mentioned IP address/hostname for this to work.
 If you have MAPDL installed on your local host, you
-can use ``launch_mapdl`` to both start and connect to MAPDL.
+can use the ``launch_mapdl`` method to both start and connect to MAPDL.
 
-If you find any problem launching PyMAPDL, please check :ref:`debugging_launch_mapdl`
+If you have any problem launching PyMAPDL, see :ref:`debugging_launch_mapdl`

--- a/doc/source/getting_started/using_julia.rst
+++ b/doc/source/getting_started/using_julia.rst
@@ -1,24 +1,24 @@
 .. _using_julia:
 
 
-***********************
-Using PyMAPDL in Julia
-***********************
+********************
+Use PyMAPDL in Julia
+********************
 
 If you like to work with Julia, you can use Python libraries as if they were Julia packages.
 
 
-Installing Julia
-=================
+Install Julia
+=============
 
-To install Julia go to their website `<https://julialang.org/>`_ and follow the instructions given in the *Download* section.
+To install Julia, go to their website `<https://julialang.org/>`_ and follow the instructions given in the **Download** section.
 
 * `Windows <https://julialang.org/downloads/platform/#windows>`_
 * `Linux <https://julialang.org/downloads/platform/#linux_and_freebsd>`_
 * `MacOS <https://julialang.org/downloads/platform/#macos>`_
 
-Setting Julia Environment
-==========================
+Set the Julia environment
+=========================
 
 To have access to Python libraries within Julia, you must install the [PyCall](https://github.com/JuliaPy/PyCall.jl) Julia package.
 To install it, run Julia and switch to the package manager by pressing  the``"]"`` key.
@@ -32,27 +32,27 @@ To create a virtual environment, use the ``activate`` command with the name of t
       Activating project at `C:/Users/USER/julia_test`
 
 
-A message should appear, indicating that the new package (``julia_test``) has been activated. This environment name will now precede the command line.
+A message should appear, indicating that the new package (``julia_test``) has been activated. This environment name now precedes the command line.
 
 .. code-block:: julia
 
     (julia_test) pkg>
 
-Next install the *PyCall* package by typing:
+Next install the PyCall package by typing:
 
 .. code-block:: julia
 
     (julia_test) pkg> add PyCall
 
 
-To use *PyCall*, press the backspace key to go to the Julia command line.
-The command line will now be precede by the name ``Julia``. 
+To use PyCall, press the backspace key to go to the Julia command line.
+The command line is then preceded by the name ``Julia``. 
 
 .. code-block:: julia
 
     julia>
 
-Next use the *PyCall* package with:
+Next use the PyCall package with:
 
 .. code-block:: julia
 
@@ -70,10 +70,10 @@ For example:
     math.sin(math.pi/4) # returns ≈ 1/√2 = 0.70710678..
 
 
-Installing PyMAPDL in Julia
-===========================
+Install PyMAPDL in Julia
+========================
 
-*PyCall* includes a lightweight Python environment that uses `Conda <https://conda.io>`_ to manage and access Python packages.
+PyCall includes a lightweight Python environment that uses `Conda <https://conda.io>`_ to manage and access Python packages.
 This environment, currently based on Python 3.9.7, includes the standard basic Python libraries.
 However, because it is a fully working Python environment, you can still use it from outside the Julia command line and install Python packages using ``pip``.
 
@@ -96,8 +96,8 @@ In Linux, the above code prints the following, where ``python3`` is the default 
 
     In Linux, there are no specific installation steps. You only need to add the Julia executable to the path.
     Hence, Julia's Python installation path can differ from user to user.
-    For example, if you uncompress the source files in ``/home/USER/Julia``, Julia's path will be 
-    ``/home/USER/Julia/julia-1.7.2/bin``
+    For example, if you uncompress the source files in ``/home/USER/Julia``, Julia's path is 
+    ``/home/USER/Julia/julia-1.7.2/bin``.
 
 You would use this Python executable to install PyMAPDL:
 
@@ -112,7 +112,7 @@ In Linux:, you would install with:
     python3 -m pip install ansys-mapdl-core
 
 
-Finally, after restarting Julia, you can import PyMAPDL using the same procedure as described above:
+Finally, after restarting Julia, you can import PyMAPDL using the same procedure as described earlier:
 
 .. code-block::
     
@@ -126,15 +126,15 @@ Finally, after restarting Julia, you can import PyMAPDL using the same procedure
     ansys.mapdl Version: 0.60.6
     
 .. note:: 
-    If you experience errors when using *PyCall*, you can try to rebuild the package by pressing ``"]"`` to go to the package manager and typing:
+    If you experience errors when using PyCall, you can try to rebuild the package by pressing ``"]"`` to go to the package manager and typing:
     
     .. code::
         
         pkg> build PyCall
 
 
-Using PyMAPDL in Julia
-======================
+Use PyMAPDL in Julia
+====================
 
 Here is a simple example of using PyMAPDL in Julia:
 
@@ -195,4 +195,4 @@ Here is a simple example of using PyMAPDL in Julia:
     julia> mapdl.eplot()
 
 
-.. note:: Do notice the changes in the strings (only ``""`` strings are allowed) and the loops.
+.. note:: Notice the changes in the strings and the loops. Only ``""`` strings are allowed.

--- a/doc/source/getting_started/versioning.rst
+++ b/doc/source/getting_started/versioning.rst
@@ -1,47 +1,46 @@
-*************************
-Versioning and Interfaces
-*************************
+***********************
+Versions and interfaces
+***********************
 The PyMAPDL project attempts to maintain compatibility with legacy
 versions of MAPDL while allowing for support of faster and better
 interfaces with the latest versions of MAPDL.
 
 
-ANSYS 2021R1 and Newer
-~~~~~~~~~~~~~~~~~~~~~~
-ANSYS v2020R1 and newer support the latest gRPC interface, allowing
+Ansys 2021 R1 and later
+~~~~~~~~~~~~~~~~~~~~~~~
+Ansys 2020 R1 and later support the latest gRPC interface, allowing
 for remote management of MAPDL with rapid streaming of mesh, results,
-and files from the MAPDL service.  Should you have the applicable
-license, you can even install and use MAPDL with docker, enabling you
+and files from the MAPDL service. If you have the applicable
+license, you can install and use MAPDL with Docker, enabling you
 to run and solve even on officially unsupported platforms like Mac
 OS.
 
 
-ANSYS 17.0 to 2020R1 - CORBA
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-ANSYS 17.0 supports the legacy CORBA interface, enabled with the
-``ansys.mapdl.corba`` module.  This interface allows you to send only
+AnsysS 17.0 to 2020 R1 - CORBA
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ansys 17.0 supports the legacy CORBA interface, enabled with the
+``ansys.mapdl.corba`` module. This interface allows you to send only
 text to and from the MAPDL service, relying on file IO for all other
-operations.  While not as performant as gRPC, this interface still
-allows you to control a local instance of MAPDL.  These versions of
-MAPDL support specific versions of Windows and Linux.  See `Ansys Platform Support
-<https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_
-for more details on the supported platforms.
+operations. While not as performant as gRPC, this interface still
+allows you to control a local instance of MAPDL. These versions of
+MAPDL support specific versions of Windows and Linux. For more information
+on the supported platforms, see `Ansys Platform Support
+<https://www.ansys.com/solutions/solutions-by-role/it-professionals/platform-support>`_.
 
 .. Note::
 
-   The CORBA interface will likely be phased out from MAPDL at some
-   point.  The gRPC interface is faster, more stable, and can run in
+   The CORBA interface is likely to be phased out from MAPDL at some
+   point. The gRPC interface is faster, more stable, and can run in
    both local and remote connection configurations.
 
 
-Earlier than ANSYS 17.0
+Earlier than Ansys 17.0
 ~~~~~~~~~~~~~~~~~~~~~~~
-The ``PyMAPDL`` project supports up to ANSYS v13.0 on Linux using a
-console interface.  Like CORBA, it allows for the exchange of text to
-and from the ANSYS instance, but unlike the CORBA
+The ``PyMAPDL`` project supports Ansys versions as early as 13.0 on Linux using a
+console interface. Like CORBA, the console interface allows for the exchange of text to
+and from the Ansys instance.
 
 .. Warning::
 
-   Console specific support will be depreciated at some point and it
-   is recommended to shift to a modern version of Ansys to continue to
-   use PyMAPDL.
+   Because console-specific support is to be depreciated at some point, you should
+   shift to a modern version of Ansys to continue to use PyMAPDL.

--- a/doc/source/getting_started/wsl.rst
+++ b/doc/source/getting_started/wsl.rst
@@ -63,7 +63,7 @@ required libraries:
    sudo yum install openssl openssh-clients mesa-libGL mesa-libGLU motif libgfortran
 
 
-If you are using Ubuntu, follow the instructions in `Running MAPDL: Ubuntu <https://mapdldocs.pyansys.com/getting_started/running_mapdl.html#ubuntu/>`_ .
+If you are using Ubuntu, follow the instructions in `Run MAPDL: Ubuntu <https://mapdldocs.pyansys.com/getting_started/running_mapdl.html#ubuntu/>`_ .
 
 
 Install Ansys products
@@ -133,8 +133,8 @@ open port in Windows 10 Firewall
 This works if you want to run a Docker image using WSL Linux image to host that
 Docker image. The Docker image successfully communicates with the Windows
 License Server using these ports if you use the ``'-p'`` flag when running the
-Docker image and these ports are open.  See `Running MAPDL on a Local Docker
-Image`_.
+Docker image and these ports are open.  See `Run MAPDL on a local Docker
+image`_.
 
 
 If you want to run MAPDL in the CentOS7 image and use the Windows license
@@ -144,7 +144,7 @@ still try to open ports ``1055`` and ``2325`` in the firewall and check if your
 MAPDL installation can communicate with the Windows hosts. If you are having
 problems after setting the firewall rules, you might have to disable the Windows
 firewall for the WSL ethernet virtual interface. This might pose some unknown
-side effects and security risk so use it with caution. See `Disabling Firewall on WSL Ethernet`_.
+side effects and security risk so use it with caution. See `Disable Firewall on WSL Ethernet`_.
 
 
 Set up an environmental variable in WSL that points to Windows host license server
@@ -280,7 +280,7 @@ You can then run the Docker image with:
 Notes
 =====
 
-The specified IP address ``127.0.0.1`` in `Run MAPDL on a Local Docker Image`_ is
+The specified IP address ``127.0.0.1`` in `Run MAPDL on a local Docker image`_ is
 the IP address of WSL CentOS from the WSL perspective, whereas the Windows host IP address is
 normally ``127.0.1.1``. Docker builds the PyMAPDL images using the WSL
 distribution as the base. Hence, PyMAPDL is running on a Linux WSL
@@ -356,8 +356,8 @@ install. To do so, you must provide a full path to the file containing the
 products to install.
 
 
-Regarding IP addresses in WSL and the Windows host
-================================================
+IP addresses in WSL and the Windows host
+========================================
 
 Theory
 ------
@@ -377,7 +377,7 @@ as mentioned earlier, this issue is solved.
 
 
 
-Disabling firewall on WSL ethernet
+Disable firewall on WSL ethernet
 ==================================
 This method shows a notification:
 

--- a/doc/source/getting_started/wsl.rst
+++ b/doc/source/getting_started/wsl.rst
@@ -192,7 +192,7 @@ environment variable with that IP address:
 
 
 Run MAPDL on a local Docker image
-********************************
+*********************************
 
 To run a Docker image, you must follow all steps in `Run PyMAPDL on WSL`_ .
 

--- a/doc/source/getting_started/wsl.rst
+++ b/doc/source/getting_started/wsl.rst
@@ -191,7 +191,7 @@ environment variable with that IP address:
     export ANSYSLMD_LICENSE_FILE=1055@$winhostIP
 
 
-Ru MAPDL on a local Docker image
+Run MAPDL on a local Docker image
 ********************************
 
 To run a Docker image, you must follow all steps in `Run PyMAPDL on WSL`_ .

--- a/doc/source/getting_started/wsl.rst
+++ b/doc/source/getting_started/wsl.rst
@@ -1,16 +1,16 @@
   .. _ref_guide_wsl:
 
 
-PyAnsys Libraries on a Windows Subsystem for Linux and Docker
+PyAnsys libraries on a Windows Subsystem for Linux and Docker
 ##############################################################
 
-This section shows you how to use a PyAnsys library, more specifically PyMAPDL,
-in the Windows Subsystem for Linux (WSL).  WSL is a compatibility layer for
+This page shows you how to use a PyAnsys library, more specifically PyMAPDL,
+in the Windows Subsystem for Linux (WSL). WSL is a compatibility layer for
 running Linux binary executables natively on Windows 10, Windows 11, and
 Windows Server 2019. For more information, see `Wikipedia-WSL`_.
 
-This section walks you through the installation of WSL on Windows and then
-shows how to use it together with MAPDL, PyMAPDL, and Docker.
+Sections on this page walk you through the installation of WSL on Windows and then
+show how to use it together with MAPDL, PyMAPDL, and Docker.
 
 For more information about WSL, see `What is the Windows Subsystem for Linux?`_.
 
@@ -18,45 +18,44 @@ For more information about WSL, see `What is the Windows Subsystem for Linux?`_.
 .. _What is the Windows Subsystem for Linux?: https://docs.microsoft.com/en-us/windows/wsl/about
 
 .. warning::
-   This guide hasn't been fully tested with a VPN connection. If you
-   experience any problems to connect WSL to internet, try to
+   This approach hasn't been fully tested with a VPN connection. If you
+   experience any problems connecting WSL to the internet, try to
    disconnect from the VPN.
 
 
-Running PyMAPDL on WSL 
-***********************
+Run PyMAPDL on WSL 
+******************
 
 Install WSL
-============
+===========
 
 Install WSL by following Microsoft's directions at `Install WSL`_.
 
 .. _Install WSL: https://docs.microsoft.com/en-us/windows/wsl/install/
 
-Currently there are two versions of WSL. The oldest is WSL1, whereas WSL2 is
-the latest and include many improvements over WSL1.  It is highly recommended
-you upgrade and use WSL2 over WSL1.
+Currently there are two versions of WSL: WSL1 abd WSL2. Because WSL2 is
+the latest and includes many improvements over WSL1, using WSL2 is highly recommended.
 
 
-Install CentOS7 WSL Distribution
-=================================
+Install CentOS7 WSL distribution
+================================
 
-We recommend that you use the CentOS7 WSL distribution for working with PyAnsys
+You should use the CentOS7 WSL distribution for working with PyAnsys
 libraries.
 
 You can install it using an unofficial WSL distribution from
 `<https://github.com/wsldl-pg/CentWSL/>`_ or
 `<https://github.com/mishamosher/CentOS-WSL/>`_ .
 
-Optionally, you can also try Ubuntu, but it has not been tested yet in the context of WSL.
+Optionally, you can try Ubuntu, but it has not been tested yet in the context of WSL.
 
 
-Install Ansys Products in WSL CentOS7
+Install Ansys products in WSL CentOS7
 =====================================
 
 Prerequisites
---------------
-If you are using CentOS 7, before installing MAPDL, you need to install some
+-------------
+If you are using CentOS 7, before installing MAPDL, you must install some
 required libraries:
 
 .. code:: bash
@@ -64,20 +63,20 @@ required libraries:
    sudo yum install openssl openssh-clients mesa-libGL mesa-libGLU motif libgfortran
 
 
-If using Ubuntu, follow the instructions in `Running MAPDL: Ubuntu <https://mapdldocs.pyansys.com/getting_started/running_mapdl.html#ubuntu/>`_ .
+If you are using Ubuntu, follow the instructions in `Running MAPDL: Ubuntu <https://mapdldocs.pyansys.com/getting_started/running_mapdl.html#ubuntu/>`_ .
 
 
-Install Ansys Products
------------------------
+Install Ansys products
+----------------------
 
-To install ANSYS products in WSL Linux:
+To install Ansys products in WSL Linux:
 
-1. Download the Ansys Structures image from the customer portal (`Current
+1. Download the **Ansys Structures** image from the customer portal (`Current
    Release <https://download.ansys.com/Current%20Release>`_).  If you are
-   downloading the image on a Windows machine, you can later copy from it to
-   WSL (recommended).
+   downloading the image on a Windows machine, you should later copy it from
+   you downloads folder to  WSL.
 
-2. Decompress the source code file (tar.gz) with:
+2. Decompress the source code file (``tar.gz``) with:
 
    .. code:: bash
    
@@ -92,18 +91,18 @@ To install ANSYS products in WSL Linux:
 
    where: 
 
-   - ``-silent`` : Initiates a silent installation (No GUI).
+   - ``-silent`` : Initiates a silent installation (no GUI).
 
    - ``-install_dir /path/`` : Specifies the directory to which the product or
-     license manager is to be installed.  If you want to install to the default
-     location, you can omit the ``-install_dir`` argument.  The default
-     location is ``/ansys_inc`` if the symbolic link is set. Otherwise, it will
-     default to ``/usr/ansys_inc``.
+     license manager is to be installed. If you want to install to the default
+     location, you can omit the ``-install_dir`` argument. The default
+     location is ``/ansys_inc`` if the symbolic link is set. Otherwise, it
+     defaults to ``/usr/ansys_inc``.
 
    - ``-<product_flag>`` : Specifies one or more specific products to install.
-     If you omit the -product_flag argument, all products will be installed.
-     See the list of valid product_flags in Chapter 6 of the *ANSYS
-     Inc. Installation Guides* PDF.  In this case, only MAPDL (`-mechapdl`) is
+     If you omit this argument, all products are installed.
+     See the list of valid product flags in Chapter 6 of the *ANSYS
+     Inc. Installation Guides* PDF. In this case, only MAPDL (`-mechapdl`) is
      needed.
 
 After installing MAPDL directly in ``/ansys_inc`` or in ``/usr/ansys_inc``,
@@ -114,47 +113,44 @@ create a symbolic link with:
     sudo ln -s /usr/ansys_inc /ansys_inc
 
 By default, PyMAPDL expects the MAPDL executable to be in
-``/usr/ansys_inc``. Whether you install it there or not, we recommend that you
-link that directory, using a symbolic link, to your Ansys installation
-directory (``/*/ansys_inc``).
+``/usr/ansys_inc``. Whether you install it there or not, you should link that directory,
+using a symbolic link, to your Ansys installation directory (``/*/ansys_inc``).
 
 
-Post-installation Setup
+Post-installation setup
 =======================
 
-Opening Ports
--------------
+Open ports
+----------
 
 **Theory:** 
 You should open the ports ``1055`` and ``2325`` for the license server
-communication in *Windows Firewall Advanced*.  You can see the steps in `How to
+communication in **Windows Firewall Advanced**. You can see the steps in `How to
 open port in Windows 10 Firewall
-<https://answers.microsoft.com/en-us/windows/forum/all/how-to-open-port-in-windows-10-firewall/f38f67c8-23e8-459d-9552-c1b94cca579a/>`_
-.
+<https://answers.microsoft.com/en-us/windows/forum/all/how-to-open-port-in-windows-10-firewall/f38f67c8-23e8-459d-9552-c1b94cca579a/>`_.
 
 **Reality:**
 This works if you want to run a Docker image using WSL Linux image to host that
-docker image.  The docker image will successfully communicate with the Windows
+Docker image. The Docker image successfully communicates with the Windows
 License Server using these ports if you use the ``'-p'`` flag when running the
 Docker image and these ports are open.  See `Running MAPDL on a Local Docker
-Image`_ .
+Image`_.
 
 
-If you want to run MAPDL in the CentOS7 image and use the Windows License
-Server, opening the ports might not work properly because the Windows firewall
-seems to block all traffic coming from WSL.  For security purposes, we
-recommend that you still try to open ports ``1055`` and ``2325`` in the
-firewall and check if your MAPDL installation can communicate with the Windows
-Hosts.  If you are having problems after setting the firewall rules, you might
-have to disable Windows Firewall for the WSL ethernet virtual interface.  This
-might pose some unknown side effects and security risk so use it with caution.
-See `Disabling Firewall on WSL Ethernet`_
+If you want to run MAPDL in the CentOS7 image and use the Windows license
+server, opening the ports might not work properly because the Windows firewall
+seems to block all traffic coming from WSL. For security purposes, you should
+still try to open ports ``1055`` and ``2325`` in the firewall and check if your
+MAPDL installation can communicate with the Windows hosts. If you are having
+problems after setting the firewall rules, you might have to disable the Windows
+firewall for the WSL ethernet virtual interface. This might pose some unknown
+side effects and security risk so use it with caution. See `Disabling Firewall on WSL Ethernet`_.
 
 
-Setting Up an Environmental Variable in WSL that Points to Windows Host License Server
----------------------------------------------------------------------------------------
+Set up an environmental variable in WSL that points to Windows host license server
+----------------------------------------------------------------------------------
 
-Windows host IP is given in the WSL file ``/etc/hosts`` before the name
+The Windows host IP address is given in the WSL file ``/etc/hosts`` before the name
 ``host.docker.internal``.
 
 
@@ -187,7 +183,7 @@ Windows host IP is given in the WSL file ``/etc/hosts`` before the name
    ff02::2 ip6-allrouters
 
 You can add the next lines to your WSL ``~/.bashrc`` file to create an
-environment variable with that IP:
+environment variable with that IP address:
 
 .. code:: bash
 
@@ -195,10 +191,10 @@ environment variable with that IP:
     export ANSYSLMD_LICENSE_FILE=1055@$winhostIP
 
 
-Running MAPDL on a Local Docker Image
-*************************************
+Ru MAPDL on a local Docker image
+********************************
 
-To run a Docker image, you must follow all steps in `Running PyMAPDL on WSL`_ .
+To run a Docker image, you must follow all steps in `Run PyMAPDL on WSL`_ .
 
 Additionally, you run a Docker image of PyMAPDL with:
 
@@ -216,19 +212,21 @@ Successive runs should restart the container or just delete it and rerun it usin
     docker run -e ANSYSLMD_LICENSE_FILE=1055@host.docker.internal --restart always --name mapdl -p 50053:50052 ghcr.io/pyansys/pymapdl/mapdl -smp > log.txt
 
 
-This will create a log file (``log.txt``) in your current directory location.
+This creates a log file (``log.txt``) in your current directory location.
 
 
 .. note:: Ensure that your port ``50053`` is open in your firewall.
 
-We recommended that you use a script (batch ``'.bat'`` or powershell ``'.ps'``
+You shodld use a script (batch ``'.bat'`` or powershell ``'.ps'``
 file) to run the above commands all at once.
 
-Notice that we are mapping the WSL internal gRPC port (``50052``) to a
+Notice that the WSL internal gRPC port (``50052``) is being mapped to a
 different Windows host port (``50053``) to avoid ports conflicts.
 
-This image is ready to be connected to from WSL or Windows Host but the port
-and IP should be specified as:
+This image is ready to be connected to from WSL or a Windows host, but the port
+and IP address should be specified. Here are two methods that you can use.
+
+**Method 1**
 
 .. code:: python
 
@@ -236,7 +234,7 @@ and IP should be specified as:
 
     mapdl = launch_mapdl(ip='127.0.0.1', port=50053, start_instance=False) 
 
-Or:
+**Method 2**
 
 .. code:: python 
 
@@ -245,8 +243,8 @@ Or:
     mapdl = Mapdl(ip='127.0.0.1', port=50053)
 
 
-You can also specify them using environment variables that are read when
-launching the MAPDL instance.
+You can also specify the port and IP address using environment variables that are read when
+launching the MAPDL instance:
 
 .. code:: bash
 
@@ -255,11 +253,11 @@ launching the MAPDL instance.
     export PYMAPDL_IP=127.0.0.1
 
 
-Launch Docker with UPF Capabilities
+Launch Docker with UPF capabilities
 ===================================
 
 If you want to specify a custom Python UPF routine, you must have the
-environment variables ``ANS_USER_PATH`` and ``ANS_USE_UPF`` defined.  The
+environment variables ``ANS_USER_PATH`` and ``ANS_USE_UPF`` defined. The
 former should be equal to the path where the UPF routines are located, and the
 latter should be equal to ``TRUE``.
 
@@ -276,36 +274,39 @@ You can then run the Docker image with:
 
     docker run -e ANSYSLMD_LICENSE_FILE=1055@host.docker.internal -e ANS_USER_PATH='/ansys_jobs/upf' -e ANS_USE_UPF='TRUE' --restart always --name mapdl -p 50053:50052 ghcr.io/pyansys/pymapdl/mapdl -smp  1>log.txt
 
-.. warning:: The use of UPFs with Docker images or PyMAPDL is still in the Alpha state.
+.. warning:: The use of UPFs with Docker images or PyMAPDL is still in the alpha state.
 
 
 Notes
 =====
 
-The specified IP ``127.0.0.1`` in `Running MAPDL on a Local Docker Image`_ is
-the IP of WSL CentOS from the WSL perspective, whereas the Windows host IP is
-normally ``127.0.1.1``.  Docker builds the PyMAPDL images using the WSL
-distribution as the base.  Hence, PyMAPDL is running on a Linux WSL
-distribution, which is running on a Windows host.  Because the Docker image
-shares resources with WSL, it also shares the internal IP with the WSL
+The specified IP address ``127.0.0.1`` in `Run MAPDL on a Local Docker Image`_ is
+the IP address of WSL CentOS from the WSL perspective, whereas the Windows host IP address is
+normally ``127.0.1.1``. Docker builds the PyMAPDL images using the WSL
+distribution as the base. Hence, PyMAPDL is running on a Linux WSL
+distribution, which is running on a Windows host. Because the Docker image
+shares resources with WSL, it also shares the internal IP address with the WSL
 distribution.
 
 
-Additional Notes
+Additional notes
 ****************
 
 
-Other Ansys Installation Flags
+Other Ansys installation flags
 ==============================
 
 You can obtain license server information with one of the following, inspecting
-the last lines of the ``INSTALL`` file:
+the last lines of the ``INSTALL`` file, Here are two methods that you can use.
+
+**Method 1**
 
 .. code:: bash
     
     ./INSTALL --help
 
-Or:
+
+**Method 2**
 
 .. code:: bash
 
@@ -351,40 +352,40 @@ Specifies a language to use for the installation of the product.
 ``-productfile``
 ----------------
 You can specify an `options` file that lists the products that you want to
-install.  To do so, you must provide a full path to the file containing the
+install. To do so, you must provide a full path to the file containing the
 products to install.
 
 
-Regarding IPs in WSL and Windows Host
-=====================================
+Regarding IP addresses in WSL and the Windows host
+================================================
 
 Theory
 ------
 
-You should be able to access Windows host using IP specified in ``/etc/hosts``
-which normally is ``127.0.1.1``. This means that the local WSL IP is
+You should be able to access the Windows host using the IP address specified in ``/etc/hosts``,
+which normally is ``127.0.1.1``. This means that the local WSL IP address is
 ``127.0.0.1``.
 
 Reality
 -------
 
 It is almost impossible to use ``127.0.1.1`` for connecting to the Windows
-host. However, it is possible to use ``host.docker.internal`` hostname in the
-same file (``/etc/hosts``).  This is an IP that is randomly allocated, which is
+host. However, it is possible to use the ``host.docker.internal`` hostname in the
+same file (``/etc/hosts``). This is an IP address that is randomly allocated, which is
 an issue when you define the license server. However, if you update ``.bashrc``
-as mentioned before, this issue is solved.
+as mentioned earlier, this issue is solved.
 
 
 
-Disabling Firewall on WSL Ethernet
+Disabling firewall on WSL ethernet
 ==================================
-This method will show a notification:
+This method shows a notification:
 
 .. code:: pwsh
 
     Set-NetFirewallProfile -DisabledInterfaceAliases "vEthernet (WSL)"
 
-This method will not show a notification:
+This method does not show a notification:
 
 .. code:: pwsh
 
@@ -393,11 +394,11 @@ This method will not show a notification:
 
 Link: `<https://github.com/cascadium/wsl-windows-toolbar-launcher#firewall-rules/>`_
 
-Windows 10 Port Forwarding
+Windows 10 port forwarding
 ==========================
 
 
-Link Ports Between WSL and Windows
+Link ports between WSL and Windows
 ----------------------------------
 
 .. code:: pwsh
@@ -405,7 +406,7 @@ Link Ports Between WSL and Windows
     netsh interface portproxy add v4tov4 listenport=1055 listenaddress=0.0.0.0 connectport=1055 connectaddress=XXX.XX.XX.XX
 
 
-PowerShell Command to View all Forwards
+PowerShell command to view all forwards
 ---------------------------------------
 
 .. code:: pwsh
@@ -413,7 +414,7 @@ PowerShell Command to View all Forwards
     netsh interface portproxy show v4tov4
 
 
-Delete Port Forwarding
+Delete port forwarding
 ----------------------
 
 .. code:: pwsh
@@ -421,7 +422,7 @@ Delete Port Forwarding
     netsh interface portproxy delete v4tov4 listenport=1055 listenaddres=0.0.0.0 protocol=tcp
 
 
-Reset Windows Network Adapters
+Reset Windows network adapters
 ==============================
 
 .. code:: pwsh
@@ -439,7 +440,7 @@ Restart WSL service
 
     Get-Service LxssManager | Restart-Service
 
-Kill All Processes with a Given Name
+Kill all processes with a given name
 ====================================
 
 .. code:: pwsh
@@ -447,11 +448,11 @@ Kill All Processes with a Given Name
    Get-Process "ANSYS212" | Stop-Process
 
 
-Install xvfb in CentOS7
-========================
+Install ``xvfb`` in CentOS7
+===========================
 
 If you want to replicate the CI/CD behavior, ``xvfb`` is needed. For more
-information, see ``.ci`` folder.
+information, see the ``.ci`` folder.
 
 .. code:: bash
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-PyMAPDL Documentation |version|
+PyMAPDL documentation |version|
 ===============================
 
 .. toctree::
@@ -15,7 +15,7 @@ PyMAPDL Documentation |version|
 
 
 
-Introduction and Purpose
+Introduction and purpose
 ------------------------
 PyMAPDL is part of the larger `PyAnsys <https://docs.pyansys.com>`_
 effort to facilitate the use of Ansys technologies directly from
@@ -26,12 +26,12 @@ Python. Its primary package, ``ansys-mapdl-core``, provides:
 - Plotting of MAPDL geometry and meshes using `PyVista
   <https://docs.pyvista.org>`_ from within a Python script or an
   interactive `Jupyter notebook <https://jupyter.org/>`_.
-- Access to MAPDL arrays as Python objects (e.g. nodes, elements,
+- Access to MAPDL arrays as Python objects (for example, nodes, elements,
   solution matrices, and results).
 
-With PyMAPDL it is easier than ever to integrate the simulation capabilities 
-of the Ansys MAPDL multi-physics solver directly into novel applications 
-thanks to an API that will look familiar to APDL and Python users alike.
+Thanks to an API that looks familiar to APDL and Python users alike, PyMAPDL
+makes it is easier than ever to integrate the simulation capabilities 
+of the Ansys MAPDL multi-physics solver directly into novel applications.
 The package presents a Python-friendly interface to drive the software
 that manages the submission of low-level APDL commands, while exchanging
 data through high-performance gRPC interfaces.
@@ -39,7 +39,7 @@ data through high-performance gRPC interfaces.
 Accelerate the preparation of your simulations using PyMAPDL. Combine the
 expressiveness of general-purpose Python code to control the flow in your
 input decks with methods that drive the solver. Explore proof of concept 
-studies or capture knowledge using interactive Jupyter notebooks.  Tap
+studies or capture knowledge using interactive Jupyter notebooks. Tap
 the solver as the physics engine in your next Artificial Intelligence
 application. It is now open source: Enjoy it! Contributions are welcome.
 
@@ -61,7 +61,7 @@ commands that can then be transmitted to an MAPDL instance running anywhere,
 while producing network footprints that are compact and efficient.
 
 
-Quick Code
+Quick code
 ----------
 Here's a brief example of how PyMAPDL works:
 
@@ -75,9 +75,9 @@ Here's a brief example of how PyMAPDL works:
     MAPDL Version:       RELEASE  2021 R1           BUILD 21.0
     PyMAPDL Version:     Version: 0.57.0
 
-MAPDL is now active and you can send commands to it as a genuine a
-Python class.  For example, if we wanted to create a surface using
-keypoints we could run:
+MAPDL is now active and you can send commands to it as a genuine
+Python class. For example, if you wanted to create a surface using
+keypoints, you could run:
 
 .. code:: python
 
@@ -92,23 +92,24 @@ keypoints we could run:
     mapdl.run('L, 4, 1')
     mapdl.run('AL, 1, 2, 3, 4')
 
-MAPDL interactively returns the result of each command and it is
-stored to the logging module or can be immediately printed out with
-``print(mapdl.run)``.  Errors are caught immediately and pythonically.
+MAPDL interactively returns the result of each command, which is
+stored to the logging module. The ``print(mapdl.run)`` method can
+also be used to immediately print out the result. Errors are caught
+immediately and Pythonically.
 
 Calling MAPDL Pythonically
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-MAPDL functions can be called directly from an :class:`Mapdl
-<ansys.mapdl.core.mapdl._MapdlCore>` instance in a pythonic manner.  This is to
+MAPDL functions can be called directly from a :class:`Mapdl
+<ansys.mapdl.core.mapdl._MapdlCore>` instance in a Pythonic manner. This is to
 simplify calling MAPDL, especially when inputs are variables within
-Python.  For example, the following two commands are equivalent:
+Python. For example, the following two commands are equivalent:
 
 .. code:: python
 
     mapdl.k(1, 0, 0, 0)
     mapdl.run('K, 1, 0, 0, 0')
 
-This approach takes care of the string formatting for you.  For
+This approach takes care of the string formatting for you. For
 example, inputting points from a numpy array:
 
 .. code:: python
@@ -119,13 +120,13 @@ example, inputting points from a numpy array:
        mapdl.k(i + 1, x, y, z)
 
 
-Advanced Features
+Advanced features
 ~~~~~~~~~~~~~~~~~
 All features available to command line MAPDL can be used within
 PyMAPDL, and there are a variety of new features available through
 gRPC.
 
-For example view the current mesh status with:
+For example, view the current mesh status with:
 
 .. code::
 
@@ -137,7 +138,7 @@ For example view the current mesh status with:
       Number of Node Components:    0
       Number of Element Components: 0
 
-Or save it as vtk with:
+Or save it as a VTK file with:
 
 .. code::
 
@@ -155,13 +156,13 @@ You can even plot directly from the Python environment with:
 .. figure:: ./images/eplot_vtk.png
     :width: 400pt
 
-    Element Plot from MAPDL using ``PyMAPDL`` and ``vtk``
+    Element pot from MAPDL using ``PyMAPDL`` and ``vtk``
 
-For a full listing of the additional PyMAPDL features, please see the
+For a full listing of PyMAPDL features, see the
 :ref:`ref_user_guide`.
 
 
-Project Index
+Project index
 *************
 
 * :ref:`genindex`

--- a/doc/source/learning/index.rst
+++ b/doc/source/learning/index.rst
@@ -23,13 +23,14 @@ Courses
 Ansys has prepared high quality courses which will guide you through your learning process stages:
 
 
-Intro to Python Course
-----------------------
+Intro to Python
+---------------
 
-In `Intro to Python Course <https://courses.ansys.com/index.php/courses/intro-to-python/>`_ you will learn the basis of Python programming language.
+The `Intro to Python <https://courses.ansys.com/index.php/courses/intro-to-python/>`_ course teaches you
+the basis of the Python programming language.
 
 
-Course Content
+Course content
 ~~~~~~~~~~~~~~
 
 * Prerequisites - Installation of Python
@@ -51,10 +52,12 @@ Course Content
 Getting Started with PyMAPDL
 ----------------------------
 
-In this course `Getting Started with PyMAPDL <https://courses.ansys.com/index.php/courses/getting-started-with-pymapdl/>`_, learn about PyMAPDL, the pythonic way to access Ansys MAPDL. 
+The `Getting Started with PyMAPDL <https://courses.ansys.com/index.php/courses/getting-started-with-pymapdl/>`_ course teaches
+you about PyMAPDL, the Pythonic way to access Ansys MAPDL. 
 
-Course Content
+Course content
 ~~~~~~~~~~~~~~
+
 * Overview of PyMAPDL - Lesson 1
 * PyMAPDL Language and Usage - Lesson 2
 * PyMAPDL Categories - Lesson 3
@@ -64,12 +67,13 @@ Course Content
 
 
 
-Intro to Ansys Parametric Design Language Scripting
----------------------------------------------------
+Intro to Ansys Mechanical APDL Scripting
+---------------_------------------------
 
-In `Intro to APDL Scripting <https://courses.ansys.com/index.php/courses/intro-to-ansys-mechanical-apdl-scripting/>`_ you will learn how APDL, the Mechanical solver syntax language, works.
+The `Intro to Ansys Mechanical APDL Scripting <https://courses.ansys.com/index.php/courses/intro-to-ansys-mechanical-apdl-scripting/>`_
+course teaches you how APDL, the Mechanical solver syntax language, works.
 
-Course Content
+Course content
 ~~~~~~~~~~~~~~
 
 * Overview of MAPDL — Lesson 1
@@ -86,7 +90,7 @@ Course Content
 Recommended links
 =================
 
-* `Using Ansys Scripting with pyMAPDL, pyDPF-Post, and More - PART 1: Running and Post-Processing an Ansys Model Outside Ansys - PADT Inc. <https://www.padtinc.com/2022/07/18/ansys-scripting-python-p1-solve-post/>`_.
-* `Ansys Innovation Space - Courses <https://courses.ansys.com/>`_
+* PADT Inc.'s `Using Ansys Scripting with pyMAPDL, pyDPF-Post, and More - PART 1: Running and Post-Processing an Ansys Model Outside <https://www.padtinc.com/2022/07/18/ansys-scripting-python-p1-solve-post/>`_
+* `Ansys Innovation Courses <https://courses.ansys.com/>`_
 
 Feel free to email any educational or learning resources to `PyAnsys Support <pyansys.support@ansys.com>`_.

--- a/doc/source/user_guide/convert.rst
+++ b/doc/source/user_guide/convert.rst
@@ -1,19 +1,19 @@
-Translating Scripts
+Translate scripts
 ===================
 The `ansys-mapdl-core <https://pypi.org/project/ansys-mapdl-core/>`_
 library contains a few basic functions to translate existing MAPDL
-scripts into PyMAPDL scripts.  Ideally, all math and variable setting
-would take place within Python as much as possible as APDL commands
+scripts into PyMAPDL scripts. Ideally, all math and variable setting
+would take place within Python because APDL commands
 are less transparent and more difficult to debug.
 
 Caveats
 ~~~~~~~
 These examples only show an automatic translation of a verification
-file and not optimized code.  Should it be necessary to pull
-parameters or arrays from ansys, use :func:`Mapdl.get_value()
-<ansys.mapdl.core.Mapdl.get_value>`, which is quite similar to the
+file and not optimized code. Should it be necessary to pull
+parameters or arrays from ansys, use the :func:`Mapdl.get_value()
+<ansys.mapdl.core.Mapdl.get_value>` function, which is quite similar to the
 MAPDL :func:`Mapdl.get() <ansys.mapdl.core.Mapdl.get>` 
-command as in:
+command shown here:
 
 .. code:: python
 
@@ -21,7 +21,8 @@ command as in:
    4.532094298033
 
 Alternatively, if a parameter is already defined, you can access it
-using :attr:`Mapdl.parameters <ansys.mapdl.core.Mapdl.parameters>` with:
+using the :attr:`Mapdl.parameters <ansys.mapdl.core.Mapdl.parameters>` attribute
+with:
 
 .. code:: python
 
@@ -37,9 +38,10 @@ using :attr:`Mapdl.parameters <ansys.mapdl.core.Mapdl.parameters>` with:
     4.532094298033
 
 
-Script Translation
+Script translation
 ~~~~~~~~~~~~~~~~~~
-Existing ANSYS scripts can be translated using :func:`convert_script() <ansys.mapdl.core.convert_script>`
+Existing Ansys scripts can be translated using the :func:`convert_script() <ansys.mapdl.core.convert_script>`
+function:
 
 .. code:: python
 
@@ -48,8 +50,8 @@ Existing ANSYS scripts can be translated using :func:`convert_script() <ansys.ma
     pyscript = 'pyscript.py'
     pymapdl.convert_script(inputfile, pyscript)
 
-Or additionally, you can convert code in form of strings for later processing
-using :func:`convert_apdl_block() <ansys.mapdl.core.convert_apdl_block>` :
+Or, you can convert code in form of strings for later processing using the
+:func:`convert_apdl_block() <ansys.mapdl.core.convert_apdl_block>` function:
 
 .. code:: python
 
@@ -63,31 +65,31 @@ using :func:`convert_apdl_block() <ansys.mapdl.core.convert_apdl_block>` :
     pycode = convert_apdl_block(apdl_string) # apdl_string can be also a list of strings.
 
 
-The script conversion functions allows some interesting arguments which can be seen in
+The script conversion functions allow some interesting arguments that can be seen in
 their respective function documentation, :func:`convert_script() <ansys.mapdl.core.convert_script>`
 and :func:`convert_apdl_block() <ansys.mapdl.core.convert_apdl_block>`.
-Especially interesting are they keyword arguments ``add_imports``, ``comment_solve`` or
+Especially interesting are the keyword arguments ``add_imports``, ``comment_solve``, and
 ``print_com``.
 
 Of particular note in the following examples is how most of the
-commands can be called as a method to the ansys object rather than
-sending a string as a command.  Additionally, take note that some
+commands can be called as a method to the Ansys object rather than
+sending a string as a command. Additionally, take note that some
 commands require the :attr:`Mapdl.non_interactive
 <ansys.mapdl.core.Mapdl.non_interactive>` context manager since some
 commands require and may break the server connection for some
-interfaces (e.g. CORBA) or are invalid (as in gRPC).
+interfaces (such as CORBA) or are invalid (as in gRPC).
 
 Also note that APDL macros that use ``*CREATE`` have been replaced
-with python functions.  This will make the code easier to debug
+with Python functions. This makes the code easier to debug
 should it be necessary to insert a ``breakpoint()`` in the script.
 
 
-Example: VM1 - Statically Indeterminate Reaction Force Analysis
+Example: VM1 - statically indeterminate reaction force analysis
 ---------------------------------------------------------------
-Ansys MAPDL contains over 200 verification files used for ANSYS
-validation and demonstration.  These validation files are used here to
+Ansys MAPDL contains over 200 verification files used for Ansys
+validation and demonstration. These validation files are used here to
 demo the use of the PyMAPDL file translator :func:`convert_script()
-<ansys.mapdl.core.convert_script>` and are available in:
+<ansys.mapdl.core.convert_script>` function and are available in:
 
 .. code:: python
 
@@ -96,6 +98,7 @@ demo the use of the PyMAPDL file translator :func:`convert_script()
     '.../ansys/mapdl/core/examples/verif/vm1.dat'
 
 This example translates the verification example ``"vm1.dat"``.
+
 First, the MAPDL code:
 
 .. code::
@@ -152,7 +155,7 @@ First, the MAPDL code:
     FINISH
     *LIST,vm1,vrt
 
-This verification file was translated using:
+Translate the verification file with:
 
 .. code:: python
 
@@ -160,7 +163,7 @@ This verification file was translated using:
     >>> from ansys.mapdl.core import examples
     >>> pymapdl.convert_script(examples.vmfiles['vm1'], 'vm1.py')
 
-Translated code:
+Here is the translated code:
 
 .. code:: python
 
@@ -221,7 +224,7 @@ Translated code:
     mapdl.exit()
 
 
-Results from running the converted file:
+Here are the results from running the converted file:
 
 .. code::
 
@@ -246,13 +249,14 @@ You can verify the reaction forces with:
 
 Note that some of the commands with ``/`` are not directly translated
 to functions and are instead run as "classic" commands like
-``mapdl.run('/COM')``.  Also, please note that the ``*VWRITE`` command
-requires a command immediately following it.  This normally locks the
+``mapdl.run('/COM')``. Also, note that the ``*VWRITE`` command
+requires a command immediately following it. This normally locks the
 interface, so it's implemented in the background as an input file
-using :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`.
+using the :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`
+attribute.
 
 
-VM7 - Plastic Compression of a Pipe Assembly
+VM7 - plastic compression of a pipe assembly
 --------------------------------------------
 Here is the input file from VM7:
 

--- a/doc/source/user_guide/database.rst
+++ b/doc/source/user_guide/database.rst
@@ -1,16 +1,16 @@
-Accessing MAPDL Database
-========================
+Access MAPDL database
+=====================
 
-.. warning:: This feature is still in beta. Please report any errors or suggestions to pyansys.support@ansys.com.
+.. warning:: This feature is still in beta. Report any errors or suggestions to pyansys.support@ansys.com.
 
 
-From PyMAPDL v0.61.2, you can access elements and nodes data from the MAPDL database using the DB module.
+In PyMAPDL v0.61.2 and later, you can access elements and nodes data from the MAPDL database using the DB module.
 
 
 Usage
 ~~~~~
 
-Getting the elems and nodes objects:
+Get the ``elems`` and ``nodes`` objects.
 
 .. code:: py
 
@@ -33,7 +33,7 @@ Getting the elems and nodes objects:
         Number of selected nodes: 3652
         Maximum node number:      3652
 
-To obtain the first element:
+Obtain the first element.
 
 .. code:: py
     
@@ -42,7 +42,7 @@ To obtain the first element:
     1
 
 
-Check if the element is selected or not:
+Check if the element is selected.
 
 .. code:: py
 
@@ -94,18 +94,18 @@ Return the selection status and the coordinates of node 22.
     >>> coord
     (-0.0014423144202849985, 0.010955465718673852, 0.0, 0.0, 0.0, 0.0)
 
-.. note:: The coordenates returned by the method ``coord`` contains the following: X, Y, Z, THXY, THYZ, and THZX.
+.. note:: The coordinates returned by the ``coord`` method contain the following: X, Y, Z, THXY, THYZ, and THZX.
 
 
 Requirements
 ~~~~~~~~~~~~
 
-To use ``DB`` feature, you need to meet the following requirements:
+To use the ``DB`` feature, you must meet these requirements:
 
-* ``ansys.api.mapdl`` package version should be 0.5.1 or higher.
-* ANSYS MAPDL version should be 2021R1 or newer.
+* ``ansys.api.mapdl`` package version should be 0.5.1 or later.
+* Ansys MAPDL version should be 2021 R1 or later.
 
-.. warning:: This feature does not work in the latest Ansys 2023R1.
+.. warning:: This feature does not work in the Ansys 2023 R1.
 
 
 

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -1,10 +1,9 @@
 .. _ref_user_guide:
 
 ==========
-User Guide
+User guide
 ==========
-This guide provides a general overview of the basics and usage of the
-PyMAPDL library.
+This section provides a general overview of PyMAPDL and how you use it.
 
 
 ..
@@ -30,19 +29,19 @@ PyMAPDL library.
    upf
 
 
-PyMAPDL Basic Overview
-======================
+PyMAPDL overview
+================
 The :func:`launch_mapdl() <ansys.mapdl.core.launch_mapdl>` function
-within the ``ansys-mapdl-core`` library creates an instance of of
-:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` in the background and sends
-commands to that service.  Errors and warnings are processed
-Pythonically letting the user develop a script real-time without
-worrying about if it will function correctly when deployed in batch
+within the ``ansys-mapdl-core`` library creates an instance of the
+:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class in the background and sends
+commands to that service. Errors and warnings are processed
+Pythonically, letting you develop a script in real time, without
+worrying about it functioning correctly when deployed in batch
 mode.
 
-MAPDL can be started from python in gRPC mode using
-:func:`launch_mapdl() <ansys.mapdl.core.launch_mapdl>`.  This starts
-MAPDL in a temporary directory by default.  You can change this to
+MAPDL can be started from Python in gRPC mode using the
+:func:`launch_mapdl() <ansys.mapdl.core.launch_mapdl>` method. This starts
+MAPDL in a temporary directory by default. You can change this to
 your current directory with:
 
 .. code:: python
@@ -53,9 +52,9 @@ your current directory with:
     path = os.getcwd()
     mapdl = launch_mapdl(run_location=path)
 
-MAPDL is now active and you can send commands to it as a genuine a
-Python class.  For example, if we wanted to create a surface using
-keypoints we could run:
+MAPDL is now active, and you can send commands to it as a genuine a
+Python class.  For example, if you wanted to create a surface using
+keypoints, you could run:
 
 .. code:: python
 
@@ -70,8 +69,8 @@ keypoints we could run:
     mapdl.run('L, 4, 1')
     mapdl.run('AL, 1, 2, 3, 4')
 
-MAPDL interactively returns the result of each command and it is
-stored to the logging module.  Errors are caught immediately.  For
+MAPDL interactively returns the result of each command, which is
+stored to the logging module. Errors are caught immediately. For
 example, if you input an invalid command:
 
 .. code:: python
@@ -89,37 +88,37 @@ example, if you input an invalid command:
    Keypoint 1 is referenced by only one line.  Improperly connected line   
    set for AL command.                                                     
 
-This ``MapdlRuntimeError`` was caught immediately, and this means that
-you can write your MAPDL scripts in python, run them interactively and
-then as a batch without worrying if the script will run correctly if
+This ``MapdlRuntimeError`` was caught immediately. This means that
+you can write your MAPDL scripts in Python, run them interactively, and
+then run them as a batch without worrying if the script would run correctly if
 you had instead outputted it to a script file.
 
 The :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class supports much more
-than just sending text to MAPDL and includes higher level wrapping
-allowing for better scripting and interaction with MAPDL.  See the
-:ref:`ref_examples` for an overview of the various advanced
-methods to visualize, script, and interact with MAPDL.
+than just sending text to MAPDL. It includes higher-level wrapping,
+allowing for better scripting and interaction with MAPDL. For an overview of the
+various advanced methods to visualize, script, and interact with MAPDL, see
+:ref:`ref_examples`.
 
 
 Calling MAPDL Pythonically
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 MAPDL functions can be called directly from an instance of
-:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` in a pythonic manner.  This is
-to simplify calling ANSYS, especially when inputs are variables within
-Python.  For example, the following two commands are equivalent:
+:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` in a Pythonic manner. This is
+to simplify calling Anys, especially when inputs are variables within
+Python. For example, the following two commands are equivalent:
 
 .. code:: python
 
     mapdl.k(1, 0, 0, 0)
     mapdl.run('K, 1, 0, 0, 0')
 
-This approach has some obvious advantages, chiefly that it's a easier
-to script as ``ansys-mapdl-core`` takes care of the string formatting for you.
-For example, inputting points from a numpy array:
+This approach has some obvious advantages. Chiefly, it's easier
+to script because ``ansys-mapdl-core`` takes care of the string formatting for you.
+For example, you can input points from a numpy array with:
 
 .. code:: python
 
-   # make 10 random keypoints in ANSYS
+   # make 10 random keypoints in Ansys
    points = np.random.random((10, 3))
    for i, (x, y, z) in enumerate(points):
        mapdl.k(i + 1, x, y, z)
@@ -143,7 +142,7 @@ Additionally, exceptions are caught and handled within Python.
 
 
 For longer scripts, instead of sending commands to MAPDL as in the
-area creation example, we can instead run:
+area creation example, you can instead run:
 
 .. code:: python
 
@@ -165,7 +164,7 @@ area creation example, we can instead run:
 
 This approach has some obvious advantages, chiefly that it's a bit
 easier to script as :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>`
-takes care of the string formatting for you.  For example, inputting
+takes care of the string formatting for you. For example, inputting
 points from a numpy array:
 
 .. code:: python
@@ -178,7 +177,7 @@ points from a numpy array:
        mapdl.k(i + 1, x, y, z)
 
 Additionally, each function with the MAPDL class has help associated
-within it.  For example:
+with it. For example:
 
 .. code:: python
 
@@ -196,12 +195,12 @@ within it.  For example:
         Parameters
         ----------
         npt
-            Reference number for keypoint.  If zero, the lowest
+            Reference number for keypoint. If zero, the lowest
             available number is assigned [NUMSTR].
 
         x, y, z
             Keypoint location in the active coordinate system (may be
-            R, θ, Z or R, θ, Φ).  If X = P, graphical picking is
+            R, θ, Z or R, θ, Φ). If X = P, graphical picking is
             enabled and all other fields (including NPT) are ignored
             (valid only in the GUI).
 
@@ -214,11 +213,11 @@ within it.  For example:
         Notes
         -----
         Defines a keypoint in the active coordinate system [CSYS] for
-        line, area, and volume descriptions.  A previously defined
-        keypoint of the same number will be redefined.  Keypoints may
+        line, area, and volume descriptions. A previously defined
+        keypoint of the same number is then redefined. A keypoint may
         be redefined only if it is not yet attached to a line or is
-        not yet meshed.  Solid modeling in a toroidal system is not
+        not yet meshed. Solid modeling in a toroidal system is not
         recommended.
 
 
-Visit :ref:`ref_pymapdl_stability` for stability considerations.
+For stability considerations, see :ref:`ref_pymapdl_stability`.

--- a/doc/source/user_guide/launcher.rst
+++ b/doc/source/user_guide/launcher.rst
@@ -1,47 +1,49 @@
-Initial Setup and Launching MAPDL Locally
+Initial setup and launch of MAPDL locally
 -----------------------------------------
-To run, ``ansys.mapdl.core`` needs to know the location of the MAPDL
-binary.  Most of the time this can be automatically determined, but
-non-standard installs will need to provide the location of MAPDL.
-When running for the first time, ``ansys-mapdl-core`` will request the
+To run, ``ansys.mapdl.core`` must know the location of the MAPDL
+binary. Most of the time this can be automatically determined, but
+the location of MAPDL must be provided for non-standard installations.
+When running for the first time, ``ansys-mapdl-core`` requests the
 location of the MAPDL executable if it cannot automatically find it.
 You can test your installation of PyMAPDL and set it up by running
-the :func:`launch_mapdl() <ansys.mapdl.core.launch_mapdl>`:
+the :func:`launch_mapdl() <ansys.mapdl.core.launch_mapdl>` function:
 
 .. code:: python
 
     from ansys.mapdl.core import launch_mapdl
     mapdl = launch_mapdl()
 
-Python will automatically attempt to detect your MAPDL binary based on
-environmental variables.  If it is unable to find a copy of MAPDL, you
-will be prompted for the location of the MAPDL executable.  Here is a
-sample input for Linux:
+Python automatically attempts to detect your MAPDL binary based on
+environmental variables. If it is unable to find a copy of MAPDL, you
+are prompted for the location of the MAPDL executable.
+
+Here is a sample input for Linux:
 
 .. code::
 
-    Enter location of MAPDL executable: /usr/ansys_inc/v212/ansys/bin/ansys212
+    Enter location of MAPDL executable: /usr/ansys_inc/v222/ansys/bin/ansys222
 
-and for Windows:
+Here is a sample input for Windows:
 
 .. code::
 
-    Enter location of MAPDL executable: C:\Program Files\ANSYS Inc\v212\ANSYS\bin\winx64\ansys212.exe
+    Enter location of MAPDL executable: C:\Program Files\ANSYS Inc\v222\ANSYS\bin\winx64\ansys222.exe
 
-The settings file is stored locally and you will not not need to enter
-the path again.  If you need to change the default ansys path
-(i.e. changing the default version of MAPDL), run the following:
+The settings file is stored locally, which means that you are not prompted
+to enter the path again. If you must change the default Ansys path
+(meaning change the default version of MAPDL), run the following:
 
 .. code:: python
 
     from ansys.mapdl import core as pymapdl
-    new_path = 'C:\\Program Files\\ANSYS Inc\\v212\\ANSYS\\bin\\winx64\\ansys212.exe'
+    new_path = 'C:\\Program Files\\ANSYS Inc\\v212\\ANSYS\\bin\\winx64\\ansys222.exe'
     pymapdl.change_default_ansys_path(new_path)
 
-Also see :func:`change_default_ansys_path() <ansys.mapdl.core.change_default_ansys_path>` and
-:func:`find_ansys() <ansys.mapdl.core.find_ansys>`.
+Also see the :func:`change_default_ansys_path() <ansys.mapdl.core.change_default_ansys_path>` method and
+the :func:`find_ansys() <ansys.mapdl.core.find_ansys>` method.
 
 Additionally, it is possible to specify the executable using the keyword argument ``exec_file``. 
+
 In Linux:
 
 .. code:: python
@@ -51,7 +53,7 @@ In Linux:
     mapdl = launch_mapdl(exec_file='/usr/ansys_inc/v212/ansys/bin/ansys212')
 
 
-And in Windows:
+In Windows:
 
 .. code:: python
 
@@ -59,7 +61,8 @@ And in Windows:
 
     mapdl = launch_mapdl(exec_file='C://Program Files//ANSYS Inc//v212//ANSYS//bin//winx64//ansys212.exe')
 
-You could also specify a custom executable by adding the correspondent flag (``-custom``) to the additional switches keyword argument.
+You could also specify a custom executable by adding the correspondent flag (``-custom``) to the ``additional_switches``
+keyword argument:
 
 .. code:: python
 
@@ -71,7 +74,7 @@ You could also specify a custom executable by adding the correspondent flag (``-
 
 
 
-API Reference
+API reference
 ~~~~~~~~~~~~~
-For more details for controlling how MAPDL launches locally, see the
-function description of :func:`launch_mapdl() <ansys.mapdl.core.launch_mapdl>`.
+For more information on controlling how MAPDL launches locally, see the
+description of the :func:`launch_mapdl() <ansys.mapdl.core.launch_mapdl>` function.

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -277,7 +277,7 @@ using the :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`
 attribute or implemented Pythonically.
 
 
-Warnings and erors
+Warnings and errors
 ~~~~~~~~~~~~~~~~~~~
 Errors are handled Pythonically. For example:
 
@@ -855,7 +855,7 @@ Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 There are several PyMAPDL-specific environment variables that can be
 used to control the behavior or launching of PyMAPDL and MAPDL, including those
-described in the follwoing table.
+described in the following table.
 
 +---------------------------------+-------------------------------------------------+
 | ``ANSYSLMD_LICENSE_FILE``       | License file or IP address (192.168.0.16).      |

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -199,8 +199,8 @@ This is useful when using PyMAPDL with older MAPDL scripts. For example:
 
 Alternatively, you can simply write the commands to a file and then
 run the file using the :func:`Mapdl.input() <ansys.mapdl.core.Mapdl.input>`
-method. For example, if you have a ``"ds.dat"``file generated from Ansys Mechanical,
-you can run that with:
+method. For example, if you have a ``"ds.dat"`` file generated from Ansys
+Mechanical, you can run that with:
 
 .. code:: python
 
@@ -615,7 +615,7 @@ MAPDL through Python with the :func:`Mapdl.run()
     mapdl.parameters['MYARR'] = arr
 
 Verify that the data has been properly loaded to MAPDL by indexing the
-:attr:`Mapdl.Parameters <ansys.mapdl.core.Mapdl.parameters>`attribute as if it
+:attr:`Mapdl.Parameters <ansys.mapdl.core.Mapdl.parameters>` attribute as if it
 was a Python dictionary:
 
 .. code:: python

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -1,43 +1,43 @@
 .. _ref_mapdl_user_guide:
 
 **************************
-PyMAPDL Language and Usage
+PyMAPDL language and usage
 **************************
-This section gives you an overview of the PyMAPDL API for the
-:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class.  
-For additional reference, see :ref:`ref_mapdl_api`.
+This page gives you an overview of the PyMAPDL API for the
+:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class.
+For more information, see :ref:`ref_mapdl_api`.
 
 Overview
 --------
 When calling MAPDL commands as functions, each command has been
 translated from its original MAPDL all CAPS format to a PEP8
-compatible format.  For example, ``ESEL`` is now 
-:func:`Mapdl.esel() <ansys.mapdl.core.Mapdl.esel>`.  
+compatible format. For example, ``ESEL`` is now the
+:func:`Mapdl.esel() <ansys.mapdl.core.Mapdl.esel>` function.
 Additionally, MAPDL commands
 containing a ``/`` or ``*`` have had those characters removed, unless
-this causes a conflict with an existing name.  Most notable is
-``/SOLU`` which would conflict with ``SOLU``.  Therefore, the
-``/SOLU`` has been renamed to :func:`Mapdl.slashsolu()
-<ansys.mapdl.core.Mapdl.slashsolu>` to differentiate it from ``solu``.
+this causes a conflict with an existing name. Most notable is
+``/SOLU``, which would conflict with ``SOLU``. Therefore,
+``/SOLU`` is renamed to the :func:`Mapdl.slashsolu()
+<ansys.mapdl.core.Mapdl.slashsolu>` function to differentiate it from ``solu``.
 Out of the 1500 MAPDL commands, about 15 start with ``slash (/)`` and 8
-with ``star (*)``.
+start with ``star (*)``.
 
 MAPDL commands that normally have an empty space, such as 
-``ESEL,S,TYPE,,1`` should include an empty string when called by Python:
+``ESEL,S,TYPE,,1``, should include an empty string when called by Python:
 
 .. code:: python
 
     mapdl.esel('s', 'type', '', 1)
 
-or these commands can be called using keyword arguments:
+Or, these commands can be called using keyword arguments:
 
 .. code:: python
 
     mapdl.esel('s', 'type', vmin=1)
 
 None of these restrictions apply to commands run with :func:`Mapdl.run()
-<ansys.mapdl.core.Mapdl.run>`, and it may be easier to run some of
-these commands (e.g. ``"/SOLU"``):
+<ansys.mapdl.core.Mapdl.run>`. It might be easier to run some of
+these commands, such as ``"/SOLU"``:
 
 .. code:: python
 
@@ -50,14 +50,14 @@ You can use the alternative:
 
     mapdl.slashsolu()
 
-Some commands can only be run non-interactively from within in a
-script.  PyMAPDL gets around this restriction by writing the commands
-to a temporary input file and then reading the input file.  To run a
+Some commands can only be run non-interactively from within a
+script. PyMAPDL gets around this restriction by writing the commands
+to a temporary input file and then reading the input file. To run a
 group of commands that must be run non-interactively, set the
-:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` to run a series
-of commands as an input file by using
+:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class to run a series
+of commands as an input file by using the
 :func:`Mapdl.non_interactive() <ansys.mapdl.core.Mapdl.non_interactive>`
-as in this example:
+function. Here is an example:
 
 .. code:: python
 
@@ -65,8 +65,8 @@ as in this example:
         mapdl.run("*VWRITE,LABEL(1),VALUE(1,1),VALUE(1,2),VALUE(1,3)")
         mapdl.run("(1X,A8,'   ',F10.1,'  ',F10.1,'   ',1F5.3)")
 
-Also note that macros created within PyMAPDL (rather than loaded from
-a file) do not appear to run correctly.  For example, the macro
+Note that macros created within PyMAPDL (rather than loaded from
+a file) do not appear to run correctly. For example, here is the macro
 ``DISP`` created using the ``*CREATE`` command within APDL:
 
 .. code::
@@ -85,7 +85,7 @@ a file) do not appear to run correctly.  For example, the macro
     *USE,DISP,-.05
     *USE,DISP,-.1
 
-Should be written as:
+It should be written as:
 
 .. code:: python
 
@@ -103,9 +103,9 @@ Should be written as:
     DISP(-.05)
     DISP(-.1)
 
-If you have an existing input file with a macro, it can be converted
-using :func:`convert_script() <ansys.mapdl.core.convert_script>`
-setting ``macros_as_functions=True``:
+If you have an existing input file with a macro, you can convert it
+using the :func:`convert_script() <ansys.mapdl.core.convert_script>`
+function with the setting ``macros_as_functions=True``:
 
 .. code:: python
 
@@ -114,13 +114,13 @@ setting ``macros_as_functions=True``:
 
 
 
-Additional Options When Running Commands
+Additional options when running commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Commands can be run in ``mute`` or ``verbose`` mode, which allows you
-to suppress or print the output in as it is being run for any MAPDL
-command.  This can be especially helpful for long-running commands
-like ``SOLVE``.  This works for the pythonic wrapping of all commands
-and when using :func:`Mapdl.run() <ansys.mapdl.core.Mapdl.run>`.
+to suppress or print the output as it is being run for any MAPDL
+command. This can be especially helpful for long-running commands
+like ``SOLVE``. This works for the Pythonic wrapping of all commands
+and when using the :func:`Mapdl.run() <ansys.mapdl.core.Mapdl.run>` method.
 
 Run a command and suppress its output:
 
@@ -129,7 +129,7 @@ Run a command and suppress its output:
     >>> mapdl.run('/PREP7', mute=True)
     >>> mapdl.prep7(mute=True)
 
-Run a command and stream its output while it is being run.
+Run a command and stream its output while it is being run:
 
 .. code:: python
 
@@ -141,12 +141,11 @@ Run a command and stream its output while it is being run.
     running MAPDL in gRPC mode.
 
 
-Running Several Commands or an Input File
+Running several commands or an input file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You can run several MAPDL commands as a unified block using
-:func:`Mapdl.input_strings() <ansys.mapdl.core.Mapdl.input_strings>`.
-This is useful when using PyMAPDL with older MAPDL scripts.  For
-example:
+You can run several MAPDL commands as a unified block using the
+:func:`Mapdl.input_strings() <ansys.mapdl.core.Mapdl.input_strings>` method.
+This is useful when using PyMAPDL with older MAPDL scripts. For example:
 
 .. code:: python
 
@@ -199,8 +198,8 @@ example:
     MAXIMUM ELEMENT NUMBER     =      8000
 
 Alternatively, you can simply write the commands to a file and then
-run it using :func:`Mapdl.input() <ansys.mapdl.core.Mapdl.input>`.  For
-example, if you have a ``"ds.dat"`` generated from Ansys Mechanical,
+run the file using the :func:`Mapdl.input() <ansys.mapdl.core.Mapdl.input>`
+method. For example, if you have a ``"ds.dat"``file generated from Ansys Mechanical,
 you can run that with:
 
 .. code:: python
@@ -208,11 +207,11 @@ you can run that with:
     >>> resp = mapdl.input("ds.dat")
 
 
-Conditional Statements and Loops
+Conditional statements and loops
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 APDL conditional statements such as ``*IF`` must be either implemented
-pythonically or using :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`.
-For example:
+Pythonically or by using the :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`
+attribute. For example:
 
 .. code::
 
@@ -232,7 +231,7 @@ For example:
       *GET,ARG9,KZ,ARG3
     *ENDIF
 
-Should be implemented as:
+This should be implemented as:
 
 .. code:: python
 
@@ -253,7 +252,7 @@ Should be implemented as:
         mapdl.run("*GET,ARG9,KZ,ARG3")
         mapdl.run("*ENDIF")
 
-Or pythonically as:
+Or, implemented Ppythonically as:
 
 .. code:: python
 
@@ -274,13 +273,13 @@ Or pythonically as:
         mapdl.run("*GET,ARG9,KZ,ARG3")
 
 APDL loops using ``*DO`` or ``*DOWHILE`` should also be implemented
-using :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`
-or pythonically.
+using the :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`
+attribute or implemented Pythonically.
 
 
-Warnings and Errors
+Warnings and erors
 ~~~~~~~~~~~~~~~~~~~
-Errors are handled pythonically.  For example:
+Errors are handled Pythonically. For example:
 
 .. code:: python
 
@@ -289,9 +288,9 @@ Errors are handled pythonically.  For example:
     except:
         # do something else with MAPDL
 
-Commands that are ignored within MAPDL are flagged as errors.  This is
+Commands that are ignored within MAPDL are flagged as errors. This is
 different than MAPDL's default behavior where commands that are
-ignored are treated as warnings.  For example, in ``ansys-mapdl-core``
+ignored are treated as warnings. For example, in ``ansys-mapdl-core``
 running a command in the wrong session raises an error:
 
 .. code:: python
@@ -307,8 +306,8 @@ running a command in the wrong session raises an error:
      command will be ignored.
 
 You can change this behavior so ignored commands can be logged as
-warnings not raised as an exception by setting
-:func:`Mapdl.allow_ignore() <ansys.mapdl.core.Mapdl.allow_ignore>`.  For
+warnings and not raised as exceptions by using the
+:func:`Mapdl.allow_ignore() <ansys.mapdl.core.Mapdl.allow_ignore>` function. For
 example:
 
 .. code:: python
@@ -320,19 +319,19 @@ example:
 Prompts
 ~~~~~~~
 Prompts from MAPDL automatically continued as if MAPDL is in batch
-mode.  Commands requiring user input, such as :func:`Mapdl.vwrite()
-<ansys.mapdl.core.Mapdl.vwrite>` will fail and must be entered in
+mode. Commands requiring user input, such as the :func:`Mapdl.vwrite()
+<ansys.mapdl.core.Mapdl.vwrite>` method fail and must be entered in
 non-interactively.
 
 
-APDL Command Logging
+APDL command logging
 --------------------
 While ``ansys-mapdl-core`` is designed to make it easier to control an
-APDL session by calling it using Python, it may be necessary to call
-MAPDL again using an input file generated from a PyMAPDL script.  This
+APDL session by calling it using Python, it might be necessary to call
+MAPDL again using an input file generated from a PyMAPDL script. This
 is automatically enabled with the ``log_apdl='apdl.log'`` parameter.
-Enabling this parameter will cause
-:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` to write each
+Enabling this parameter causes the
+:class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class to write each
 command run into a log file named ``"apdl.log"`` in the active
 :attr:`Mapdl.directory <ansys.mapdl.core.Mapdl.directory>`. 
 For example:
@@ -348,7 +347,7 @@ For example:
     ansys.k(3, 1, 1, 0)
     ansys.k(4, 0, 1, 0)    
 
-Will write the following to ``"apdl.log"``
+This code writes the following to the ``"apdl.log"`` file:
 
 .. code::
 
@@ -361,21 +360,20 @@ Will write the following to ``"apdl.log"``
 This allows for the translation of a Python script to an APDL script
 except for conditional statements, loops, or functions.
 
-Using ``lgwrite``
-~~~~~~~~~~~~~~~~~
-Alternatively, if you just want the database command output, you can use
-:func:`Mapdl.lgwrite <Mapdl.ansys.mapdl.core.Mapdl.lgwrite>` to write all the
-database command log to a file.
+Use ``lgwrite``
+~~~~~~~~~~~~~~~
+Alternatively, if you just want the database command output, you can use the
+:func:`Mapdl.lgwrite <Mapdl.ansys.mapdl.core.Mapdl.lgwrite>` method to write the
+entire database command log to a file.
 
 
-Interactive Breakpoint
+Interactive breakpoint
 ----------------------
 In most circumstances it is necessary or preferable to open up the
-MAPDL GUI.  The :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` module
-has :func:`Mapdl.open_gui() <ansys.mapdl.core.Mapdl.open_gui>` that
+MAPDL GUI. The :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class
+has the :func:`Mapdl.open_gui() <ansys.mapdl.core.Mapdl.open_gui>` method, which
 allows you to seamlessly open up the GUI without losing work or
-having to restart your session. 
-For example:
+having to restart your session. For example:
 
 .. code:: python
 
@@ -406,17 +404,17 @@ For example:
     >>> mapdl.eplot()    
 
 This approach avoids the hassle of having to switch back and forth
-between an interactive session and a scripting session.  Instead, you
+between an interactive session and a scripting session. Instead, you
 can have one scripting session and open up a GUI from the scripting
-session without losing work or progress.  Additionally, none of the
-changes made in the GUI will affect the script.  You can experiment in
-the GUI and the script will be left unaffected.
+session without losing work or progress. Additionally, none of the
+changes made in the GUI affect the script. You can experiment in
+the GUI, and the script is left unaffected.
 
 
-Running a Batch
----------------
-Instead of running an MAPDL batch by calling MAPDL with an input file,
-you can instead define a function that runs MAPDL.  This example runs
+Run a batch
+------------
+Instead of running a MAPDL batch by calling MAPDL with an input file,
+you can instead define a function that runs MAPDL. This example runs
 a mesh convergence study based on the maximum stress of a cylinder
 with torsional loading.
 
@@ -556,15 +554,15 @@ This is the result from the script:
     Element size 0.150000: 412324 nodes and maximum vom Mises stress 144.275406
 
 
-Chaining Commands in MAPDL
---------------------------
+Chain commands in MAPDL
+-----------------------
 MAPDL permits several commands on one line by using the separation
-character ``"$"``.  This can be utilized within ``ansys-mapdl-core``
-to effectively chain several commands together rather and send them to
-MAPDL for execution rather than executing them individually.  This can
-be helpful when you need to execute thousands of commands in a python
-loop and don't need the individual results for each command.  For
-example, if you wish to create a 1000 keypoints along the X axis you
+character ``"$"``. This can be utilized within ``ansys-mapdl-core``
+to effectively chain several commands together and send them to
+MAPDL for execution rather than executing them individually. Chaining
+commands can be helpful when you need to execute thousands of commands in a Python
+loop and don't need the individual results for each command. For
+example, if you want to create 1000 keypoints along the X axis, you
 would run:
 
 .. code:: python
@@ -574,12 +572,11 @@ would run:
         mapdl.k(x=x)
 
 
-However, since each command executes individually and returns a
+However, because each command executes individually and returns a
 response, it is much faster to send the commands to be executed by
-MAPDL in groups and have :class:`Mapdl
-<ansys.mapdl.core.mapdl._MapdlCore>` handle grouping the commands by
-using :attr:`Mapdl.chain_commands
-<ansys.mapdl.core.Mapdl.chain_commands>`.
+MAPDL in groups and have the :class:`Mapdl
+<ansys.mapdl.core.mapdl._MapdlCore>` class handle grouping the commands by
+using the :attr:`Mapdl.chain_commands <ansys.mapdl.core.Mapdl.chain_commands>` attribute.
 
 .. code:: python
 
@@ -588,26 +585,26 @@ using :attr:`Mapdl.chain_commands
         for x in xloc:
             mapdl.k(x=x)
 
-The execution time on this generally 4 to 10 times faster than running
-each command individually.  You can then view the final response of
-the chained commands with :attr:`Mapdl.last_response
-<ansys.mapdl.core.Mapdl.last_response>`.
+The execution time using this approach is generally 4 to 10 times faster than running
+each command individually. You can then view the final response of
+the chained commands with the :attr:`Mapdl.last_response
+<ansys.mapdl.core.Mapdl.last_response>` attribute.
 
 .. note::
    Command chaining is not supported in distributed MAPDL.  To improve
-   performances, use ``mute=True`` or 
-   :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`.
+   performances, use the ``mute=True`` or 
+   :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>`
+   attribute.
 
 
-Sending Arrays to MAPDL
+Sending arrays to MAPDL
 -----------------------
 You can send ``numpy`` arrays or Python lists directly to MAPDL using
-:attr:`Mapdl.Parameters <ansys.mapdl.core.Mapdl.parameters>`.
+the :attr:`Mapdl.Parameters <ansys.mapdl.core.Mapdl.parameters>` attribute.
 This is far more efficient than individually sending parameters to
-MAPDL through Python with :func:`Mapdl.run()
-<ansys.mapdl.core.Mapdl.run>`.  It uses :func:`Mapdl.vread()
-<ansys.mapdl.core._commands.ParameterDefinition>` behind the scenes
-and will be replaced with a faster interface in the future.
+MAPDL through Python with the :func:`Mapdl.run()
+<ansys.mapdl.core.Mapdl.run>` method.  It uses the :func:`Mapdl.vread()
+<ansys.mapdl.core._commands.ParameterDefinition>` method behind the scenes.
 
 .. code:: python
 
@@ -617,8 +614,9 @@ and will be replaced with a faster interface in the future.
     arr = np.random.random((5, 3))
     mapdl.parameters['MYARR'] = arr
 
-Verify the data has been properly loaded to MAPDL by indexing
-:attr:`Mapdl.Parameters <ansys.mapdl.core.Mapdl.parameters>` as if it was a Python dictionary:
+Verify that the data has been properly loaded to MAPDL by indexing the
+:attr:`Mapdl.Parameters <ansys.mapdl.core.Mapdl.parameters>`attribute as if it
+was a Python dictionary:
 
 .. code:: python
 
@@ -631,12 +629,12 @@ Verify the data has been properly loaded to MAPDL by indexing
           [0.33189362, 0.9681039 , 0.47525875]])
 
 
-Downloading a Remote MAPDL File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When running MAPDL in gRPC mode, remote files can be listed and
-downloaded using :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>`
-with :func:`Mapdl.download() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download>` For
-example, to list the remote files and download one of them:
+Download a remote MAPDL file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When running MAPDL in gRPC mode, remote MAPDL files can be listed and
+downloaded using the :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>`
+class with the :func:`Mapdl.download() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download>`
+function. For example, to list the remote files and download one of them:
 
 .. code:: python
 
@@ -650,11 +648,11 @@ example, to list the remote files and download one of them:
 
 .. note::
 
-   This feature is only available for MAPDL 2021R1 or newer.
+   This feature is only available in MAPDL 2021 R1 and later.
 
 Alternatively, you can download several files at once using the glob pattern 
-or list of file names in :func:`Mapdl.download() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download>`.
-For example:
+or a list of file names in the :func:`Mapdl.download() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.download>`
+method. For example:
 
 .. code:: python
 
@@ -664,24 +662,24 @@ For example:
     # Using glob pattern to match the list_files
     mapdl.download('file*')
 
-You can also download all the files in the MAPDL working directory
-(:func:`Mapdl.directory <ansys.mapdl.core.Mapdl.directory>`), using:
+You can also download all files in the MAPDL working directory
+(:func:`Mapdl.directory <ansys.mapdl.core.Mapdl.directory>`) using:
 
 .. code:: python
 
     mapdl.download_project()
 
-Or filter by extensions, for example:
+Or, filter by extensions. For example:
 
 .. code:: python
 
     mapdl.download_project(['log', 'out'], target_dir='myfiles')  # Download the files to 'myfiles' directory
 
 
-Uploading a Local MAPDL File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You can upload a local file a the remote mapdl instance with
-:func:`Mapdl.upload() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.upload>`.
+Upload a local MAPDL file
+~~~~~~~~~~~~~~~~~~~~~~~~~
+You can upload a local MAPDL file as the remote MAPDL instance with the
+:func:`Mapdl.upload() <ansys.mapdl.core.mapdl_grpc.MapdlGrpc.upload>` function.
 For example:
 
 .. code:: python
@@ -695,36 +693,37 @@ For example:
 
 .. note::
 
-   This feature is only available for MAPDL 2021R1 or newer.
+   This feature is only available in MAPDL 2021 R1 and later.
 
 
-Unsupported MAPDL Commands and Other Considerations
+Unsupported MAPDL commands and other considerations
 ---------------------------------------------------
-Most MAPDl commands have been mapped pythonically into their
-equivalent methods.  Some commands, however, are not supported either
-because they are not applicable to an interactive session, or require
+Most MAPDl commands have been mapped Pythonically into their
+equivalent methods. Some commands, however, are not supported, either
+because they are not applicable to an interactive session or require
 additional commands that are incompatible with the way inputs are
-handled in the MAPDL server.
+handled on the MAPDL server.
 
 
 .. _ref_unsupported_commands:
 
-Non-available Commands
+Non-available commands
 ~~~~~~~~~~~~~~~~~~~~~~~
-Some commands are not available in PyMAPDL because of different reasons.
+Some commands are not available in PyMAPDL for a variety of reasons.
 
-Some these commands do not make sense in a Python context.
-For example the ``*ASK`` can be replaced with a Python ``input``,
-``*IF`` with a Python ``if`` statement, and instead of ``*CREATE`` and
-``*USE`` can simply call another Python function or module.
+Some of these commands do not make sense in a Python context.
+Some examples follow.
 
-Others do not make sense in a non-GUI session. For example ``/ERASE``
-and ``ERASE`` which clear the graphics screen.
+- The ``*ASK`` command can be replaced with a Python ``input``.
+- The ``*IF`` command can be replaced with a Python ``if`` statement.
+- The ``*CREATE`` and ``*USE`` commands can be replaced with calls to another Python function or module.
 
-Others simply are not available or not supported for different reasons. 
-Some are quietly ignored by MAPDL but you are still free to
-use them.  For example ``/BATCH``, can be run as 
-:func:`mapdl.run("/BATCH") <ansys.mapdl.core.Mapdl.run>`
+Other commands do not make sense in a non-GUI session. For example, the ``/ERASE``
+and ``ERASE`` commands that clear the graphics screen are not needed in a non-GUI session.
+
+Other commands are quietly ignored by MAPDL, but you are still free to
+use them. For example, the ``/BATCH`` command can be run as the
+:func:`mapdl.run("/BATCH") <ansys.mapdl.core.Mapdl.run>` function,
 which returns:
 
 .. code::
@@ -735,7 +734,7 @@ which returns:
 
 
 
-These commands are detailed in Table-1_.
+Table-1_ provides comprehensive information on the commands that are non-available.
 
 .. _Table-1:
 
@@ -792,12 +791,12 @@ These commands are detailed in Table-1_.
 
 
 .. note::
-    * **Interactive** means there is a method in the mapdl such as 
+    * **Interactive** means there is a method in the MAPDL such as 
       :func:`Mapdl.prep7() <ansys.mapdl.core.Mapdl.prep7>`.
     * **Non-interactive** means it is run inside a 
       :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>` context block,
-      :func:`Mapdl.input() <ansys.mapdl.core.Mapdl.input>` or
-      :func:`Mapdl.input_strings() <ansys.mapdl.core.Mapdl.input_strings>`.
+      :func:`Mapdl.input() <ansys.mapdl.core.Mapdl.input>` method, or
+      :func:`Mapdl.input_strings() <ansys.mapdl.core.Mapdl.input_strings>` method.
       For example:
 
       .. code:: python
@@ -810,24 +809,25 @@ These commands are detailed in Table-1_.
       For example, :func:`mapdl.run("/PREP7") <ansys.mapdl.core.Mapdl.run>`.
 
 
-Note, that running these commands with
-:func:`mapdl.run() <ansys.mapdl.core.Mapdl.run>` will
-not cause MAPDL to exit, however it might raise runtime exceptions.
+Note that running these commands with the
+:func:`mapdl.run() <ansys.mapdl.core.Mapdl.run>` function does
+not cause MAPDL to exit. However, it might raise runtime exceptions.
 
-These MAPDL commands can be executed also using 
-:func:`mapdl.input() <ansys.mapdl.core.Mapdl.input>`
+These MAPDL commands can also be executed using the
+:func:`mapdl.input() <ansys.mapdl.core.Mapdl.input>` method
 or
 :func:`mapdl.input_strings() <ansys.mapdl.core.Mapdl.input_strings>`
-and the results should be same as running them in a normal batch MAPDL session.
+method. The results should be same as running them in a normal batch MAPDL session.
 
 
-Unsupported "Interactive" Commands
+Unsupported "interactive" commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following commands can be only run in non-interactive mode (inside
+The following commands can be only run in non-interactive mode (inside a
 :attr:`Mapdl.non_interactive <ansys.mapdl.core.Mapdl.non_interactive>` block or
-using :func:`mapdl.input() <ansys.mapdl.core.Mapdl.input>`).
-These commands are detailed in Table-2_.
+using the :func:`mapdl.input() <ansys.mapdl.core.Mapdl.input>` method).
+Table-2_ provides comprehensive information on the "interactive" commands that
+are unsupported.
 
 
 .. _Table-2:
@@ -851,28 +851,28 @@ These commands are detailed in Table-2_.
 
 
 
-Environment Variables
+Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
-There are several PyMAPDL specific environment variables that can be
-used to control the behavior or launching of PyMAPDL and MAPDL.  These
-include:
+There are several PyMAPDL-specific environment variables that can be
+used to control the behavior or launching of PyMAPDL and MAPDL, including those
+described in the follwoing table.
 
 +---------------------------------+-------------------------------------------------+
-| ``ANSYSLMD_LICENSE_FILE``       | License file or IP address (e.g. 192.168.0.16). |
-|                                 | This is helpful for supplying licencing for     |
-|                                 | docker.                                         |
+| ``ANSYSLMD_LICENSE_FILE``       | License file or IP address (192.168.0.16).      |
+|                                 | This is helpful for supplying licensing for     |
+|                                 | Docker.                                         |
 +---------------------------------+-------------------------------------------------+
-| ``PYMAPDL_MAX_MESSAGE_LENGTH``  | Maximum gRPC message length.  If your           |
+| ``PYMAPDL_MAX_MESSAGE_LENGTH``  | Maximum gRPC message length. If your            |
 |                                 | connection terminates when running              |
-|                                 | PRNSOL or NLIST, raise this.  In bytes,         |
-|                                 | defaults to 256 MB                              |
+|                                 | PRNSOL or NLIST, raise this. In bytes,          |
+|                                 | defaults to 256 MB.                             |
 +---------------------------------+-------------------------------------------------+
 | ``PYMAPDL_PORT``                | Default port to look for when connecting        |
-|                                 | PyMAPDL.  Normally used for unit testing.       |
+|                                 | PyMAPDL. Normally used for unit testing.        |
 +---------------------------------+-------------------------------------------------+
-| ``PYMAPDL_START_INSTANCE``      | Override the behavior of                        |
-|                                 | :func:`ansys.mapdl.core.launch_mapdl` to only   |
-|                                 | attempt to connect to existing                  |
-|                                 | instances of PyMAPDL.  Generally used           |
-|                                 | in combination with ``PYMAPDL_PORT``            |
+| ``PYMAPDL_START_INSTANCE``      | Override the behavior of the                    |
+|                                 | :func:`ansys.mapdl.core.launch_mapdl` function  |
+|                                 | to only attempt to connect to existing          |
+|                                 | instances of PyMAPDL. Generally used            |
+|                                 | in combination with ``PYMAPDL_PORT``.           |
 +---------------------------------+-------------------------------------------------+

--- a/doc/source/user_guide/mapdl_examples.rst
+++ b/doc/source/user_guide/mapdl_examples.rst
@@ -1,11 +1,11 @@
-ANSYS APDL Interactive Control Examples
+ANSYS APDL interactive control examples
 =======================================
-These examples are used to demonstrate how to convert an existing
-ANSYS APDL script to a python PyMAPDL script.  You could also simply
+These examples demonstrate how to convert an existing
+ANSYS APDL script to a Python PyMAPDL script. You could also simply
 use the built-in :func:`convert_script()
-<ansys.mapdl.core.convert_script>` within `ansys-mapdl-core
+<ansys.mapdl.core.convert_script>` function within `ansys-mapdl-core
 <https://pypi.org/project/ansys-mapdl-core/>`_ to convert an existing
-input file:
+input file.
 
 .. code:: python
 
@@ -15,15 +15,15 @@ input file:
     >>> pymapdl.convert_script(inputfile, pyscript)
 
 
-Torsional Load on a Bar using SURF154 Elements
+Torsional load on a bar using SURF154 elements
 ----------------------------------------------
-This ANSYS APDL script builds a bar and applies torque to it using
-SURF154 elements.  This is a static analysis example.
+This Ansys APDL script builds a bar and applies torque to it using
+SURF154 elements. This is a static analysis example.
 
 
-Script Initialization
+Script initialization
 ~~~~~~~~~~~~~~~~~~~~~
-Beginning of MAPDL script:
+Here is the beginning of the MAPDL script:
 
 .. code::
 
@@ -40,8 +40,8 @@ Beginning of MAPDL script:
     FORCE = 100/RADIUS
     PRESSURE = FORCE/(H_TIP*2*PI*RADIUS)
 
-Corresponding PyMAPDL script including the initialization of an
-instance of :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>`:
+Here is the corresponding PyMAPDL script, including the initialization of an
+instance of the :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>` class:
 
 .. code:: python
 
@@ -49,7 +49,7 @@ instance of :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>`:
     import numpy as np
     from ansys.mapdl.core import launch_mapdl
     
-    # start ANSYS in the current working directory with default jobname "file"
+    # start Ansys in the current working directory with default jobname "file"
     mapdl = launch_mapdl(run_location=os.getcwd())
         
     # define cylinder and mesh parameters
@@ -63,9 +63,9 @@ instance of :class:`Mapdl <ansys.mapdl.core.mapdl._MapdlCore>`:
     pressure = force/(h_tip*2*np.pi*radius)
 
 
-Model Creation
+Model creation
 ~~~~~~~~~~~~~~    
-APDL Script:
+Here is an APDL script for creating the model:
 
 .. code::
 
@@ -116,7 +116,7 @@ APDL Script:
     amesh,all
     finish
 
-Corresponding PyMAPDL script:
+Here is the corresponding PyMAPDL script:
 
 .. code:: python
 
@@ -169,7 +169,7 @@ Corresponding PyMAPDL script:
 
 Solution
 ~~~~~~~~
-APDL script:
+Here is the APDL script for the solution:
 
 .. code::
 
@@ -202,7 +202,7 @@ APDL script:
     SAVE
 
 
-Corresponding PyMAPDL script:
+Here is the corresponding PyMAPDL script:
 
 .. code:: python
 
@@ -226,7 +226,7 @@ Corresponding PyMAPDL script:
     mapdl.pbc('u', 1)
     mapdl.solve()
 
-Access and plot the results within python using PyMAPDL:
+Access and plot the results within Python using PyMAPDL:
 
 .. code:: python
 
@@ -280,11 +280,12 @@ Access and plot the results within python using PyMAPDL:
 .. figure:: ../images/cylinder_vonmises.png
     :width: 300pt
 
-    Non-interactive Screenshot of von Mises Stress from PyMAPDL
+    Non-interactive screenshot of von Mises stress from PyMAPDL
 
 
 Alternatively, you can access the same results directly from MAPDL
-using the :attr:`Mapdl.post_processing <ansys.mapdl.core.Mapdl.post_processing>`:
+using the :attr:`Mapdl.post_processing <ansys.mapdl.core.Mapdl.post_processing>`
+attribute:
 
 .. code:: python
 
@@ -294,10 +295,10 @@ using the :attr:`Mapdl.post_processing <ansys.mapdl.core.Mapdl.post_processing>`
     result.plot_nodal_eqv_stress()
 
 
-Running an Input File - Spotweld SHELL181 Example
+Running an input file - spotweld SHELL181 example
 -------------------------------------------------
 This MAPDL example demonstrates how to model spot welding on three
-thin sheets of metal.  Here, we simply run the full input file using
+thin sheets of metal. Here, the full input file is simply run using
 the PyMAPDL interface.
 
 .. code::
@@ -444,7 +445,7 @@ the PyMAPDL interface.
 
 
 Here is the Python script using `ansys-mapdl-reader
-<https://pypi.org/project/ansys-mapdl-reader/>`_ to access the results
+<https://pypi.org/project/ansys-mapdl-reader/>`_ package to access the results
 after running the MAPDL analysis.
 
 .. code:: python
@@ -462,7 +463,7 @@ after running the MAPDL analysis.
 
     Spot Weld: Displacement
 
-Get the nodal and element component stress at time step 0.  Plot the
+Get the nodal and element component stress at time step 0. Plot the
 stress in the Z direction.
 
 .. code:: python
@@ -478,11 +479,11 @@ stress in the Z direction.
 .. figure:: ../images/spot_sz.png
     :width: 300pt
 
-    Spot Weld: Z Stress
+    Spot weld: Z stress
 
 .. code:: python
 
-    Get the principal nodal stress and plot the von Mises Stress
+    Get the principal nodal stress and plot the von Mises stress
 
     >>> nnum, pstress = result.principal_nodal_stress(0)
     >>> result.plot_principal_nodal_stress(0, 'SEQV')
@@ -490,4 +491,4 @@ stress in the Z direction.
 .. figure:: ../images/spot_seqv.png
     :width: 300pt
 
-    Spot Weld: von Mises Stress
+    Spot weld: von Mises stress


### PR DESCRIPTION
I also fixed other Google style guide violations that I saw while skimming the file content. Most of these changes were removing future tense and double spaces between sentences. Content reviewed so far includes that in the Getting Started section and half of the User Guide section.