### PR TITLE
Solving rendering issues for examples documentation 

### DIFF
--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -18,20 +18,23 @@ Here are a series of examples using MAPDL with the ``ansys-mapdl-core`` library.
 
 .. === TECHNOLOGY SHOWCASE EXAMPLES ===
 
+Technology showcase examples
+============================
+
 The PyMAPDL technology showcase examples are more complex test cases than
 the ones presented above. They demonstrate how to use PyMAPDL to effectively
 and accurately solve interdisciplinary problems from a variety of industries
 and engineering fields.
 
 The examples initially come from the `APDL Technology Showcase Manual
-<_tech_demo_intro_>`_ and are modeled with MAPDL files. Some of them have been
+<tech_demo_intro_>`_ and are modeled with MAPDL files. Some of them have been
 reproduced in Python files using PyMAPDL with the ``ansys-mapdl-core``
 library.
 
-The examples are hosted in the  `PyMAPDL Techdemos repository <_tech_demos_repo_>`_.
+The examples are hosted in the  `PyMAPDL Techdemos repository <tech_demos_repo_>`_.
 
 The documentation to the exposed examples can be found in the
-`PyMAPDL Techdemos documentation <_tech_demos_doc_>`_.
+`PyMAPDL Techdemos documentation <tech_demos_doc_>`_.
 
 .. === EXTENDED EXAMPLES ===
 


### PR DESCRIPTION
As title says. After merging #1649 we realized that there were some issues:
- [x] Links not properly rendered
- [x] Missing title

![image](https://user-images.githubusercontent.com/37798125/204511223-133a34d1-7a62-41a8-a5bc-1b0ba84bc02c.png)

This PR will solve those issues