### PR TITLE
Update materials.py 

### DIFF
--- a/src/ansys/mapdl/core/_commands/preproc/materials.py
+++ b/src/ansys/mapdl/core/_commands/preproc/materials.py
@@ -341,7 +341,7 @@ class Materials:
 
         This command is also valid in SOLUTION.
         """
-        command = "MPCOPY,%s,%s" % (str(matf), str(matt))
+        command = "MPCOPY,,%s,%s" % (str(matf), str(matt))
         return self.run(command, **kwargs)
 
     def mpdata(


### PR DESCRIPTION
The command for MPCOPY does not work, because there is an unused field in the definition, which is not icluded in the code:
need of an extra ","

see doc of the command:
https://www.mm.bme.hu/~gyebro/files/ans_help_v182/ans_cmd/Hlp_C_MPCOPY.html #