### PR TITLE
FIX: gh_token scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ concurrency:
 
 permissions:
   packages: read
+  pages: write
 
 defaults:
   run:


### PR DESCRIPTION
As soon as you declare the `permissions` section, everything goes to null:

> If you specify the access for any of these scopes, all of those that are not specified are set to none.

We need write scope for the GH_TOKEN to write to the gh-pages branch.