### PR TITLE
Fix multidependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    insecure-external-code-execution: allow
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Maintenance"
-      - "Dependencies"
-    ignore:
-      - dependency-name: "vtk"
-      - dependency-name: "grpcio"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: marcoroth/dependabot-bump-together-action@v0.3.1
         with:
-          dependencies: ansys-api-mapdl, ansys-corba, ansys-dpf-core, ansys-mapdl-reader, ansys-platform-instancemanagement, ansys-sphinx-theme, pyansys-tools-report, appdirs, autopep8, click, grpcio, imageio-ffmpeg, imageio, importlib-metadata, jupyter_sphinx, jupyterlab, matplotlib, numpy, numpydoc, pandas, pexpect, plotly, protobuf, pyiges, pypandoc, pytest-cov, pytest-rerunfailures, pytest-sphinx, pytest, pythreejs, pyvista, scipy, setuptools, sphinx-autobuild, sphinx-autodoc-typehints, sphinx-copybutton, sphinx-gallery, sphinx-notfound-page, Sphinx, sphinxcontrib-websupport, sphinxemoji, tqdm, vtk, wheel
+          dependencies: ansys-api-mapdl, ansys-corba, ansys-dpf-core, ansys-mapdl-reader, ansys-platform-instancemanagement, ansys-sphinx-theme, pyansys-tools-report, appdirs, autopep8, click, imageio-ffmpeg, imageio, importlib-metadata, jupyter_sphinx, jupyterlab, matplotlib, numpy, numpydoc, pandas, pexpect, plotly, protobuf, pyiges, pypandoc, pytest-cov, pytest-rerunfailures, pytest-sphinx, pytest, pythreejs, pyvista, scipy, setuptools, sphinx-autobuild, sphinx-autodoc-typehints, sphinx-copybutton, sphinx-gallery, sphinx-notfound-page, Sphinx, sphinxcontrib-websupport, sphinxemoji, tqdm, wheel
           package_managers: pip
           directory: /
           branch: main


### PR DESCRIPTION
Removing libraries, we want to keep fixed.

To keep consistency with previous dependabot settings.

Eventually we should check if we can upgrade any of them.