### PR TITLE
Fix/aplot index error

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1568,8 +1568,12 @@ class _MapdlCore(Commands):
             # color individual areas
             if color_areas:
                 anum = surf["entity_num"]
-                rand = np.random.random(anum[-1] + 1)
-                area_color = rand[anum]
+                size_ = anum[-1] + 1
+                rand = np.random.random(size_)
+                if size_ == 1:
+                    area_color = rand[0]
+                else:
+                    area_color = rand[anum]
                 meshes.append({"mesh": surf, "scalars": area_color})
             else:
                 meshes.append({"mesh": surf, "color": kwargs.get("color", "white")})

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1566,7 +1566,7 @@ class _MapdlCore(Commands):
 
             # individual surface isolation is quite slow, so just
             # color individual areas
-            if color_areas:
+            if color_areas:  # pragma: no cover
                 anum = surf["entity_num"]
                 size_ = max(anum) + 1
                 rand = np.random.random(size_)

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1568,12 +1568,9 @@ class _MapdlCore(Commands):
             # color individual areas
             if color_areas:
                 anum = surf["entity_num"]
-                size_ = anum[-1] + 1
+                size_ = max(anum) + 1
                 rand = np.random.random(size_)
-                if size_ == 1:
-                    area_color = rand[0]
-                else:
-                    area_color = rand[anum]
+                area_color = rand[anum]
                 meshes.append({"mesh": surf, "scalars": area_color})
             else:
                 meshes.append({"mesh": surf, "color": kwargs.get("color", "white")})


### PR DESCRIPTION
I have seen this error randomly in few places in the CICD:

```bash
WARNING: /home/runner/work/pymapdl/pymapdl/examples/00-mapdl-examples/lathe_cutter.py failed to execute correctly: Traceback (most recent call last):
  File "/home/runner/work/pymapdl/pymapdl/examples/00-mapdl-examples/lathe_cutter.py", line 164, in <module>
    mapdl.vplot(
  File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/ansys/mapdl/core/mapdl.py", line 1433, in vplot
    out = self.aplot(
  File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/ansys/mapdl/core/mapdl.py", line 15[72](https://github.com/pyansys/pymapdl/actions/runs/3689261536/jobs/6245029261#step:16:73), in aplot
    area_color = rand[anum]
IndexError: index 1 is out of bounds for axis 0 with size 1
```

Link: https://github.com/pyansys/pymapdl/actions/runs/3689261536/jobs/6245029261#step:16:77


This comes from:
```py
  if color_areas:
      anum = surf["entity_num"]
      rand = np.random.random(anum[-1]+1)
      area_color = rand[anum]
      meshes.append({"mesh": surf, "scalars": area_color})
```
The only reason for ``rand[anum]`` to show an index error is because the ``anum[-1]+1`` is 1, meaning that in ``anum``, the last element is zero. Because ``anum`` comes from ``surf["entity_num"]`` there should not be zero (one index based).

Several approaches here to increase robustness:
* Fix ``anum[-1]`` to be at least 1. I.e. ``np.random.random(max([anum[-1]+1,1]))``.
* Use ``max`` on anum, assuming that only the last element is zero. This might help us to "define" a bit more this random error. So I'm going for this.
