### PR TITLE
Adding root to docker run

### DIFF
--- a/.ci/start_mapdl_ubuntu.sh
+++ b/.ci/start_mapdl_ubuntu.sh
@@ -13,6 +13,8 @@ docker run \
     -e ANSYS_LOCK="OFF" \
     -p $PYMAPDL_PORT:50052 \
     -p $PYMAPDL_DB_PORT:50055 \
+    -w /jobs \
+    -u=0:0 \
     $MAPDL_IMAGE /ansys_inc/v222/ansys/bin/mapdl -grpc -dir /jobs -smp -np 2 > log.txt &
 grep -q 'Server listening on' <(timeout 60 tail -f log.txt)
 # python -c "from ansys.mapdl.core import launch_mapdl; print(launch_mapdl())"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
           if compgen -G './logs-build-docs/*.out' > /dev/null ;then for f in ./logs-build-docs/*.out; do echo "::group:: Output file $f" && cat $f && echo "::endgroup::" ; done; fi
 
   build_test:
-    name: "Build and unit testing"
+    name: "Remote: Build and unit testing"
     runs-on: ubuntu-latest
     needs: [smoke-tests]
     strategy:
@@ -399,13 +399,13 @@ jobs:
           if compgen -G './logs-${{ matrix.mapdl-version }}/*.out' > /dev/null ;then for f in ./logs-${{ matrix.mapdl-version }}/*.out; do echo "::group:: Output file $f" && cat $f && echo "::endgroup::" ; done; fi
 
   build_test_ubuntu:
-    name: "Local unit testing on ubuntu"
+    name: "Local: Build and unit testing on Ubuntu"
     runs-on: ubuntu-latest
     needs: [smoke-tests]
     timeout-minutes: 35
     container:
       image: ghcr.io/pyansys/mapdl:v22.2-ubuntu
-      options: "--entrypoint /bin/bash"
+      options: "-u=0:0 --entrypoint /bin/bash"
       credentials:
         username: ${{ secrets.GH_USERNAME }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -466,7 +466,7 @@ jobs:
           root_dir: ${{ github.workspace }}
 
   test_windows:
-    name: "Unit testing on windows"
+    name: "Local: Build and unit testing on Windows"
     runs-on: [self-hosted, Windows, pymapdl]
     timeout-minutes: 30
 


### PR DESCRIPTION
Because in https://github.com/pyansys/mapdl-docker-image-builder/pull/30 the root stopped to be the default user.

We need the root to operate at `/jobs`. Otherwise the CICD shows:
```text
Digest: sha256:3082a8d05bc4c0cd0e4a7e978be14c86f7cafd381ff0b556d097285a5db147a0
Status: Downloaded newer image for ghcr.io/pyansys/mapdl:v22.2-ubuntu
ghcr.io/pyansys/mapdl:v22.2-ubuntu
mkdir: cannot create directory '/jobs': Permission denied
Error: Process completed with exit code 1.
```

Also when using the docker image as a container for running the test locally we see the following error in the checkout action:
```text
Run actions/checkout@v3
/usr/bin/docker exec  76ecd63f3a8f7a867b0adef45933ee0e317478b8c8b47cf18b0a8dcbec98db83 sh -c "cat /etc/*release | grep ^ID"
##[debug]ID=ubuntu
##[debug]ID_LIKE=debian
##[debug]Running JavaScript Action with default external tool: node16
node:internal/fs/utils:344
    throw err;
    ^

Error: EACCES: permission denied, open '/__w/_temp/_runner_file_commands/save_state_07907405-b62e-4cec-86f4-a6f9bb258ed2'
    at Object.openSync (node:fs:585:3)
    at Object.writeFileSync (node:fs:21[53](https://github.com/pyansys/pymapdl/actions/runs/3694418976/jobs/6255654262#step:3:54):35)
    at Object.appendFileSync (node:fs:2215:6)
    at Object.issueFileCommand (/__w/_actions/actions/checkout/v3/dist/index.js:2344:8)
    at Object.saveState (/__w/_actions/actions/checkout/v3/dist/index.js:11928:31)
    at Object.153 (/__w/_actions/actions/checkout/v3/dist/index.js:4095:10)
    at __webpack_require__ (/__w/_actions/actions/checkout/v3/dist/index.js:22:30)
    at Object.287 (/__w/_actions/actions/checkout/v3/dist/index.js:7064:34)
    at __webpack_require__ (/__w/_actions/actions/checkout/v3/dist/index.js:22:30)
    at Object.853 (/__w/_actions/actions/checkout/v3/dist/index.js:31838:36) {
  errno: -13,
  syscall: 'open',
  code: 'EACCES',
  path: '/__w/_temp/_runner_file_commands/save_state_07907405-b62e-4cec-86f4-a6f9bb2[58](https://github.com/pyansys/pymapdl/actions/runs/3694418976/jobs/6255654262#step:3:59)ed2'
}
##[debug]Node Action run completed with exit code 1
##[debug]Finishing: Install Git and checkout project
```