### PR TITLE
Fix dependabot permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,9 @@ on:
     # Every Sunday at 1PM UTC (9AM EST)
     - cron: "0 0 * * 0"
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   check-dependencies:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,5 +20,5 @@ jobs:
           directory: /
           branch: main
           username: ${{ secrets.GH_USERNAME }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEPENDABOT_PAT }}
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,6 +5,8 @@ on:
     # Every Sunday at 1PM UTC (9AM EST)
     - cron: "0 0 * * 0"
 
+permissions: write-all
+
 jobs:
   check-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: marcoroth/dependabot-bump-together-action@v0.3.1
         with:
-          dependencies: ansys-api-mapdl, ansys-corba, ansys-dpf-core, ansys-mapdl-reader, ansys-platform-instancemanagement, ansys-sphinx-theme, pyansys-tools-report, appdirs, autopep8, click, imageio-ffmpeg, imageio, importlib-metadata, jupyter_sphinx, jupyterlab, matplotlib, numpy, numpydoc, pandas, pexpect, plotly, protobuf, pyiges, pypandoc, pytest-cov, pytest-rerunfailures, pytest-sphinx, pytest, pythreejs, pyvista, scipy, setuptools, sphinx-autobuild, sphinx-autodoc-typehints, sphinx-copybutton, sphinx-gallery, sphinx-notfound-page, Sphinx, sphinxcontrib-websupport, sphinxemoji, tqdm, wheel
+          dependencies: ansys-api-mapdl,vtk, ansys-corba, ansys-dpf-core, ansys-mapdl-reader, ansys-platform-instancemanagement, ansys-sphinx-theme, pyansys-tools-report, appdirs, autopep8, click, imageio-ffmpeg, imageio, importlib-metadata, jupyter_sphinx, jupyterlab, matplotlib, numpy, numpydoc, pandas, pexpect, plotly, protobuf, pyiges, pypandoc, pytest-cov, pytest-rerunfailures, pytest-sphinx, pytest, pythreejs, pyvista, scipy, setuptools, sphinx-autobuild, sphinx-autodoc-typehints, sphinx-copybutton, sphinx-gallery, sphinx-notfound-page, Sphinx, sphinxcontrib-websupport, sphinxemoji, tqdm, wheel
           package_managers: pip
           directory: /
           branch: main

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,5 +20,5 @@ jobs:
           directory: /
           branch: main
           username: ${{ secrets.GH_USERNAME }}
-          token: ${{ secrets.DEPENDABOT_PAT }}
+          token: ${{ secrets.MULTIPR_DEPENDABOT }}
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,8 +5,6 @@ on:
     # Every Sunday at 1PM UTC (9AM EST)
     - cron: "0 0 * * 0"
 
-permissions: write-all
-
 jobs:
   check-dependencies:
     runs-on: ubuntu-latest
@@ -17,6 +15,6 @@ jobs:
           package_managers: pip
           directory: /
           branch: main
-          username: x-access-token
+          username: ${{ secrets.GH_USERNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The multiPR dependabot mood doesn't seem to have permissions to run workflows.