### PR TITLE
Set Ansys version and executable from env vars

### DIFF
--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -24,6 +24,7 @@ PyMAPDL, see :ref:`ref_mapdl_commands`.
    helper
    inline
    krylov
+   launcher
    logging
    mapdl
    math

--- a/doc/source/api/launcher.rst
+++ b/doc/source/api/launcher.rst
@@ -1,0 +1,18 @@
+.. _ref_launcher_api:
+
+Launcher
+========
+Various PyMAPDL specific launcher commands.
+
+.. currentmodule:: ansys.mapdl.core
+
+.. autosummary::
+   :toctree: _autosummary
+
+   launcher.change_default_ansys_path
+   launcher.get_available_ansys_installations
+   launcher.save_ansys_path
+   launcher.get_default_ansys
+   launcher.get_default_ansys_version
+   launcher.get_default_ansys_path
+    

--- a/doc/source/api/launcher.rst
+++ b/doc/source/api/launcher.rst
@@ -11,8 +11,8 @@ Various PyMAPDL specific launcher commands.
 
    launcher.change_default_ansys_path
    launcher.get_available_ansys_installations
-   launcher.save_ansys_path
    launcher.get_default_ansys
-   launcher.get_default_ansys_version
    launcher.get_default_ansys_path
+   launcher.get_default_ansys_version
+   launcher.save_ansys_path
     

--- a/doc/source/getting_started/contribution.rst
+++ b/doc/source/getting_started/contribution.rst
@@ -76,6 +76,10 @@ In Linux, use:
 This tells ``ansys.mapdl.core`` to attempt to connect to the existing
 MAPDL service by default when the ``launch_mapdl`` function is used.
 
+Additionally you can use ``PYMAPDL_MAPDL_VERSION`` to specify the MAPDL
+version to launch (it should be installed). 
+This is useful if you have multiple versions of MAPDL.
+
 
 Code style
 ==========

--- a/doc/source/getting_started/contribution.rst
+++ b/doc/source/getting_started/contribution.rst
@@ -76,9 +76,9 @@ In Linux, use:
 This tells ``ansys.mapdl.core`` to attempt to connect to the existing
 MAPDL service by default when the ``launch_mapdl`` function is used.
 
-Additionally you can use ``PYMAPDL_MAPDL_VERSION`` to specify the MAPDL
-version to launch (it should be installed). 
-This is useful if you have multiple versions of MAPDL.
+Additionally you can use the environment variables ``PYMAPDL_MAPDL_EXEC`` 
+and ``PYMAPDL_MAPDL_VERSION`` to specify MAPDL executable path and the
+version to launch (if multiple versions of MAPDL are installed).
 
 
 Code style

--- a/doc/source/getting_started/learning.rst
+++ b/doc/source/getting_started/learning.rst
@@ -5,20 +5,29 @@ Learning PyMAPDL
 ================
 
 Ansys has prepared multiple resources to help you to learn and use PyMAPDL.
+You can access them from the website `Ansys Learning Resources <learning_resources_>`_.
+In this page, you can find a summary of the available resources for MAPDL and PyMAPDL.
 
-Resources
+
+
+
+Downloads
 =========
 
-- You can also try the Student Version of Ansys products in
+- You can try the Student Version of Ansys products in
   `Ansys Student Versions <ansys_student_version_>`_.
   These are versions valid during a year and with limited capabilities 
   regarding number of nodes, elements, etc.
 
-- View and download `PyMAPDL cheatsheet <pymapdl_cheatsheet_>`.
+- View and download `PyMAPDL cheatsheet <pymapdl_cheatsheet_>` to help
+  you to learn PyMAPDL.
+
+- Visit `PyMAPDL examples <ref_examples_>`_ to learn how PyMAPDL can be
+  used to solve different real life problems.
 
 
 Courses
-===============
+=======
 
 Ansys has prepared high quality courses to guide you through the learning process.
 

--- a/doc/source/getting_started/versioning.rst
+++ b/doc/source/getting_started/versioning.rst
@@ -1,3 +1,5 @@
+.. _versions_and_interfaces:
+
 ***********************
 Versions and interfaces
 ***********************

--- a/src/ansys/mapdl/core/_version.py
+++ b/src/ansys/mapdl/core/_version.py
@@ -18,17 +18,17 @@ except ModuleNotFoundError:  # pragma: no cover
 __version__ = importlib_metadata.version("ansys-mapdl-core")
 
 # In descending order
-SUPPORTED_ANSYS_VERSIONS = [
-    231,
-    222,
-    221,
-    212,
-    211,
-    202,
-    201,
-    195,
-    194,
-    193,
-    192,
-    191,
-]
+SUPPORTED_ANSYS_VERSIONS = {
+    231: "2023R1",
+    222: "2022R2",
+    221: "2022R1",
+    212: "2021R2",
+    211: "2021R1",
+    202: "2020R2",
+    201: "2020R1",
+    195: "19.5",
+    194: "19.4",
+    193: "19.3",
+    192: "19.2",
+    191: "19.1",
+}

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -635,16 +635,16 @@ def get_start_instance(start_instance_default=True):
 def _get_available_base_ansys():
     """Return a dictionary of available Ansys versions with their base paths.
 
+    Returns
+    -------
+    Return all installed Ansys paths in Windows.
+
     Notes
     -----
 
     On Windows, It uses the environment variable ``AWP_ROOTXXX``.
 
     The student versions are returned at the end of the dict and with negative value for the version.
-
-    Returns
-    -------
-    Return all installed Ansys paths in Windows.
 
     Examples
     --------
@@ -733,16 +733,17 @@ def _get_available_base_ansys():
 def get_available_ansys_installations():
     """Return a dictionary of available Ansys versions with their base paths.
 
+    Returns
+    -------
+    dict[int: str]
+        Return all installed Ansys paths in Windows.
+
     Notes
     -----
 
     On Windows, It uses the environment variable ``AWP_ROOTXXX``.
 
     The student versions are returned at the end of the dict and with negative value for the version.
-
-    Returns
-    -------
-    Return all installed Ansys paths in Windows.
 
     Examples
     --------
@@ -851,7 +852,7 @@ def get_default_ansys_path():
 
     Returns
     -------
-    ansys_path : str
+    str
         Full path to ANSYS executable.
 
     Examples
@@ -876,7 +877,7 @@ def get_default_ansys_version():
 
     Returns
     -------
-    version : float
+    float
         Version float.  For example, 21.1 corresponds to 2021R1.
 
     Examples

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -646,6 +646,10 @@ def _get_available_base_ansys():
     -------
     Return all installed Ansys paths in Windows.
 
+    Examples
+    --------
+
+    >>> from ansys.mapdl.core import _get_available_base_ansys
     >>> _get_available_base_ansys()
     {222: 'C:\\Program Files\\ANSYS Inc\\v222',
      212: 'C:\\Program Files\\ANSYS Inc\\v212',

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -203,14 +203,6 @@ def port_in_use(port, host=LOCALHOST):
             return True
 
 
-def create_ip_file(ip, path):
-    """Create 'mylocal.ip' file required for ansys to change the IP of the gRPC server."""
-
-    file_name = os.path.join(path, "mylocal.ip")
-    with open(file_name, "w") as f:
-        f.write(ip)
-
-
 def launch_grpc(
     exec_file="",
     jobname="file",
@@ -438,11 +430,6 @@ def launch_grpc(
         port += 1
         LOG.debug(f"Port in use.  Incrementing port number. port={port}")
     pymapdl._LOCAL_PORTS.append(port)
-
-    # setting ip for the grpc server
-    if ip != LOCALHOST:  # Default local ip is 127.0.0.1
-        create_ip_file(ip, run_location)
-        LOG.debug(f"Writing ip ({ip}) in 'mylocal.ip' file.")
 
     cpu_sw = "-np %d" % nproc
 
@@ -1142,7 +1129,7 @@ def launch_mapdl(
 
     run_location : str, optional
         MAPDL working directory.  Defaults to a temporary working
-        directory.  If directory doesn't exist, will create one.
+        directory.  If directory doesn't exist, one is created.
 
     jobname : str, optional
         MAPDL jobname.  Defaults to ``'file'``.
@@ -1168,15 +1155,16 @@ def launch_mapdl(
         ``ansys_corba`` module.  Finally, the ``'console'`` mode
         is for legacy use only Linux only prior to v17.0.  This console
         mode is pending depreciation.
+        Visit :ref:`versions_and_interfaces` for more information.
 
     override : bool, optional
-        Attempts to delete the lock file at the run_location.
+        Attempts to delete the lock file at the ``run_location``.
         Useful when a prior MAPDL session has exited prematurely and
         the lock file has not been deleted.
 
     loglevel : str, optional
         Sets which messages are printed to the console.  ``'INFO'``
-        prints out all ANSYS messages, ``'WARNING``` prints only
+        prints out all ANSYS messages, ``'WARNING'`` prints only
         messages containing ANSYS warnings, and ``'ERROR'`` logs only
         error messages.
 
@@ -1186,7 +1174,7 @@ def launch_mapdl(
 
         - ``additional_switches="-aa_r"``
 
-        Avoid adding switches like -i -o or -b as these are already
+        Avoid adding switches like ``-i``, ``-o`` or ``-b`` as these are already
         included to start up the MAPDL server.  See the notes
         section for additional details.
 
@@ -1211,7 +1199,7 @@ def launch_mapdl(
 
     start_instance : bool, optional
         When False, connect to an existing MAPDL instance at ``ip``
-        and ``port``, which default to ``'127.0.0.1'`` at 50052.
+        and ``port``, which default to ip ``'127.0.0.1'`` at port 50052.
         Otherwise, launch a local instance of MAPDL.  You can also
         override the default behavior of this keyword argument with
         the environment variable ``PYMAPDL_START_INSTANCE=FALSE``.
@@ -1219,10 +1207,11 @@ def launch_mapdl(
     ip : bool, optional
         Used only when ``start_instance`` is ``False``. If provided,
         it will force ``start_instance`` to be ``False``.
+        Specify the IP address of the MAPDL instance to connect to.
         You can also provide a hostname as an alternative to an IP address.
         Defaults to ``'127.0.0.1'``. You can also override the
         default behavior of this keyword argument with the
-        environment variable "PYMAPDL_IP=FALSE".
+        environment variable ``PYMAPDL_IP=FALSE``.
 
     clear_on_connect : bool, optional
         Defaults to ``True``, giving you a fresh environment when
@@ -1233,11 +1222,12 @@ def launch_mapdl(
         Enables logging every APDL command to the local disk.  This
         can be used to "record" all the commands that are sent to
         MAPDL via PyMAPDL so a script can be run within MAPDL without
-        PyMAPDL. This string is the path of the output file (e.g.
+        PyMAPDL. This argument is the path of the output file (e.g.
         ``log_apdl='pymapdl_log.txt'``). By default this is disabled.
 
     remove_temp_files : bool, optional
-        Deprecated option, please use ``remove_temp_dir_on_exit``.
+        .. deprecated:: 0.64.0
+           Use argument ``remove_temp_dir_on_exit`` instead.
 
         When ``run_location`` is ``None``, this launcher creates a new MAPDL
         working directory within the user temporary directory, obtainable with

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1663,6 +1663,9 @@ def launch_mapdl(
         return mapdl
 
     # verify version
+    if exec_file and version:
+        raise ValueError("Cannot specify both ``exec_file`` and ``version``.")
+
     if version is None:
         version = os.getenv("PYMAPDL_MAPDL_VERSION", None)
 

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1234,7 +1234,17 @@ def launch_mapdl(
     ----------
     exec_file : str, optional
         The location of the MAPDL executable.  Will use the cached
-        location when left at the default ``None``.
+        location when left at the default ``None`` and no environment
+        variable is set.
+
+        .. note::
+
+           The executable path can be also set through the environment variable
+           ``PYMAPDL_MAPDL_EXEC``. For example:
+
+           .. code:: bash
+
+              export PYMAPDL_MAPDL_EXEC=/ansys_inc/v211/ansys/bin/mapdl
 
     run_location : str, optional
         MAPDL working directory.  Defaults to a temporary working
@@ -1659,6 +1669,9 @@ def launch_mapdl(
     version = _verify_version(version)  # return a int version or none
 
     # verify executable
+    if exec_file is None:
+        exec_file = os.getenv("PYMAPDL_MAPDL_EXEC", None)
+
     if exec_file is None:
         LOG.debug("Using default executable.")
         # Load cached path

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -637,7 +637,8 @@ def _get_available_base_ansys():
 
     Returns
     -------
-    Return all installed Ansys paths in Windows.
+    dict[int: str]
+        Return all installed Ansys paths in Windows.
 
     Notes
     -----

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -493,3 +493,8 @@ def test_get_ansys():
 def test_version(mapdl):
     version = int(10 * mapdl.version)
     mapdl_ = launch_mapdl(version=version)
+
+
+def test_raise_exec_path_and_version_launcher():
+    with pytest.raises(ValueError):
+        launch_mapdl(exec_file="asdf", version="asdf")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -474,6 +474,10 @@ def test__verify_version_pass():
         assert min(versions.keys()) <= ver <= max(versions.keys())
 
 
+@pytest.mark.skipif(
+    get_start_instance() is False,
+    reason="Skip when start instance is disabled",
+)
 def test_find_ansys(mapdl):
     version = int(mapdl.version * 10)
     assert find_ansys() is not None
@@ -483,6 +487,10 @@ def test_find_ansys(mapdl):
         assert find_ansys(version="11")
 
 
+@pytest.mark.skipif(
+    get_start_instance() is False,
+    reason="Skip when start instance is disabled",
+)
 def test_get_ansys():
     assert get_default_ansys is not None
     assert get_default_ansys_path is not None
@@ -490,11 +498,19 @@ def test_get_ansys():
     assert get_ansys_path is not None
 
 
+@pytest.mark.skipif(
+    get_start_instance() is False,
+    reason="Skip when start instance is disabled",
+)
 def test_version(mapdl):
     version = int(10 * mapdl.version)
     mapdl_ = launch_mapdl(version=version)
 
 
+@pytest.mark.skipif(
+    get_start_instance() is False,
+    reason="Skip when start instance is disabled",
+)
 def test_raise_exec_path_and_version_launcher():
     with pytest.raises(ValueError):
         launch_mapdl(exec_file="asdf", version="asdf")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -12,7 +12,13 @@ from ansys.mapdl.core.launcher import (
     _check_license_argument,
     _force_smp_student_version,
     _validate_MPI,
+    _verify_version,
     _version_from_path,
+    find_ansys,
+    get_ansys_path,
+    get_default_ansys,
+    get_default_ansys_path,
+    get_default_ansys_version,
     get_start_instance,
     is_common_executable_path,
     is_valid_executable_path,
@@ -452,3 +458,38 @@ def test_license_product_argument_p_arg(license_short, license_name):
 def test_license_product_argument_p_arg_warning():
     with pytest.warns(UserWarning):
         assert "qwer -p asdf" in _check_license_argument(None, "qwer -p asdf")
+
+
+def test__verify_version_pass():
+    valid_versions = []
+    valid_versions.extend(list(versions.keys()))
+    valid_versions.extend([each / 10 for each in versions.keys()])
+    valid_versions.extend([str(each) for each in list(versions.keys())])
+    valid_versions.extend([str(each / 10) for each in versions.keys()])
+    valid_versions.extend(list(versions.values()))
+
+    for version in valid_versions:
+        ver = _verify_version(version)
+        assert isinstance(ver, int)
+        assert min(versions.keys()) <= ver <= max(versions.keys())
+
+
+def test_find_ansys(mapdl):
+    version = int(mapdl.version * 10)
+    assert find_ansys() is not None
+    assert find_ansys(version=version) is not None
+
+    with pytest.raises(ValueError):
+        assert find_ansys(version="11")
+
+
+def test_get_ansys():
+    assert get_default_ansys is not None
+    assert get_default_ansys_path is not None
+    assert get_default_ansys_version is not None
+    assert get_ansys_path is not None
+
+
+def test_version(mapdl):
+    version = int(10 * mapdl.version)
+    mapdl_ = launch_mapdl(version=version)


### PR DESCRIPTION
Now you can use env vars to specify:
* Ansys executable path using ``PYMAPDL_MAPDL_EXEC``
* Ansys version using ``PYMAPDL_MAPDL_VERSION``

Additionally you can specify ansys version (if multiple are available) in ``launcher_mapdl(version=22.2)``.

Close #1566 