### PR TITLE
Deprecating ``allow_ignore`` in favor of ``ignore_errors``

### DIFF
--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -14,7 +14,6 @@
    :toctree: _autosummary
 
    Mapdl.add_file_handler
-   Mapdl.allow_ignore
    Mapdl.chain_commands
    Mapdl.directory
    Mapdl.get

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -307,12 +307,12 @@ running a command in the wrong session raises an error:
 
 You can change this behavior so ignored commands can be logged as
 warnings and not raised as exceptions by using the
-:func:`Mapdl.allow_ignore() <ansys.mapdl.core.Mapdl.allow_ignore>` function. For
+:func:`Mapdl.ignore_errors() <ansys.mapdl.core.Mapdl.ignore_errors>` function. For
 example:
 
 .. code:: python
 
-   >>> mapdl.allow_ignore = True
+   >>> mapdl.ignore_errors = True
    >>> mapdl.k()  # warning silently ignored
 
 

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -922,7 +922,7 @@ class _MapdlCore(Commands):
         This command will be ignored.
 
         """
-        warn.warn(
+        warn(
             "'allow_ignore' is being deprecated and will be removed in a future release. "
             "Use ``mapdl.ignore_errors`` instead.",
             DeprecationWarning,
@@ -932,7 +932,7 @@ class _MapdlCore(Commands):
     @allow_ignore.setter
     def allow_ignore(self, value):
         """Set allow ignore"""
-        warn.warn(
+        warn(
             "'allow_ignore' is being deprecated and will be removed in a future release. "
             "Use ``mapdl.ignore_errors`` instead.",
             DeprecationWarning,

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -163,7 +163,7 @@ class _MapdlCore(Commands):
         self._show_matplotlib_figures = True  # for testing
         self._query = None
         self._exited = False
-        self._allow_ignore = False
+        self._ignore_errors = False
         self._apdl_log = None
         self._store_commands = False
         self._stored_commands = []
@@ -191,7 +191,6 @@ class _MapdlCore(Commands):
         self._vget_arr_counter = 0
         self._start_parm = start_parm
         self._path = start_parm.get("run_location", None)
-        self._ignore_errors = False
         self._print_com = print_com  # print the command /COM input.
         self._cached_routine = None
         self._geometry = None

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -922,12 +922,22 @@ class _MapdlCore(Commands):
         This command will be ignored.
 
         """
-        return self._allow_ignore
+        warn.warn(
+            "'allow_ignore' is being deprecated and will be removed in a future release. "
+            "Use ``mapdl.ignore_errors`` instead.",
+            DeprecationWarning,
+        )
+        return self._ignore_errors
 
     @allow_ignore.setter
     def allow_ignore(self, value):
         """Set allow ignore"""
-        self._allow_ignore = bool(value)
+        warn.warn(
+            "'allow_ignore' is being deprecated and will be removed in a future release. "
+            "Use ``mapdl.ignore_errors`` instead.",
+            DeprecationWarning,
+        )
+        self._ignore_errors = bool(value)
 
     def open_apdl_log(self, filename, mode="w"):
         """Start writing all APDL commands to an MAPDL input file.
@@ -2837,20 +2847,19 @@ class _MapdlCore(Commands):
             self._response = None
             return self._response
 
-        if "is not a recognized" in text:
-            if not self.allow_ignore:
+        if not self.ignore_errors:
+            if "is not a recognized" in text:
                 text = text.replace("This command will be ignored.", "")
-                text += "\n\nIgnore these messages by setting allow_ignore=True"
+                text += "\n\nIgnore these messages by setting 'ignore_errors'=True"
                 raise MapdlInvalidRoutineError(text)
 
-        if "command is ignored" in text:
-            if not self.allow_ignore:
-                text += "\n\nIgnore these messages by setting allow_ignore=True"
+            if "command is ignored" in text:
+                text += "\n\nIgnore these messages by setting 'ignore_errors'=True"
                 raise MapdlCommandIgnoredError(text)
 
-        # flag errors
-        if "*** ERROR ***" in self._response and not self._ignore_errors:
-            self._raise_output_errors(self._response)
+            # flag errors
+            if "*** ERROR ***" in self._response:
+                self._raise_output_errors(self._response)
 
         # special returns for certain geometry commands
         short_cmd = parse_to_short_cmd(command)
@@ -2862,12 +2871,33 @@ class _MapdlCore(Commands):
 
     @property
     def ignore_errors(self) -> bool:
-        """
-        Flag to ignore MAPDL errors.
+        """Invalid commands will be ignored rather than exceptions
 
         Normally, any string containing "*** ERROR ***" from MAPDL
         will trigger a ``MapdlRuntimeError``.  Set this to ``True`` to
         ignore these errors.
+
+        For example, a command executed in the wrong processor will
+        raise an exception when ``ignore_errors=False``.
+        This is the default behavior.
+
+        Examples
+        --------
+        >>> mapdl.post1()
+        >>> mapdl.k(1, 0, 0, 0)
+        Exception:  K is not a recognized POST1 command, abbreviation, or macro.
+
+        Ignore these messages by setting ignore_errors=True
+
+        >>> mapdl.ignore_errors = True
+        2020-06-08 21:39:58,094 [INFO] : K is not a
+        recognized POST1 command, abbreviation, or macro.  This
+        command will be ignored.
+
+        *** WARNING *** CP = 0.372 TIME= 21:39:58
+        K is not a recognized POST1 command, abbreviation, or macro.
+        This command will be ignored.
+
         """
         return self._ignore_errors
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,6 +490,7 @@ def twisted_sheet(mapdl, cleared):
     mapdl.prep7()
     mapdl.et(1, "SHELL181")
     mapdl.mp("EX", 1, 2e5)
+    mapdl.mp("PRXY", 1, 0.3)  # Poisson's Ratio
     mapdl.rectng(0, 1, 0, 1)
     mapdl.sectype(1, "SHELL")
     mapdl.secdata(0.1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -446,7 +446,7 @@ def solved_box(mapdl, cleared):
     # Define a material (nominal steel in SI)
     mapdl.mp("EX", 1, 210e9)  # Elastic moduli in Pa (kg/(m*s**2))
     mapdl.mp("DENS", 1, 7800)  # Density in kg/m3
-    mapdl.mp("NUXY", 1, 0.3)  # Poisson's Ratio
+    mapdl.mp("PRXY", 1, 0.3)  # Poisson's Ratio
     # Fix the left-hand side.
     mapdl.nsel("S", "LOC", "Z", 0)
     mapdl.d("ALL", "UX")

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1681,3 +1681,22 @@ def test_on_docker(mapdl):
         assert mapdl.on_docker
     else:
         assert not mapdl.on_docker
+
+
+def test_deprecation_allow_ignore_warning(mapdl):
+    with pytest.warns(DeprecationWarning, match="'allow_ignore' is being deprecated"):
+        mapdl.allow_ignore = True
+
+
+def test_deprecation_allow_ignore_errors_mapping(mapdl):
+    mapdl.allow_ignore = True
+    assert mapdl.allow_ignore == mapdl.ignore_errors
+
+    mapdl.allow_ignore = False
+    assert mapdl.allow_ignore == mapdl.ignore_errors
+
+    mapdl.ignore_errors = True
+    assert mapdl.allow_ignore == mapdl.ignore_errors
+
+    mapdl.ignore_errors = False
+    assert mapdl.allow_ignore == mapdl.ignore_errors

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1562,6 +1562,7 @@ def test_non_interactive(mapdl, cleared):
 
 
 def test_ignored_command(mapdl, cleared):
+    mapdl.ignore_errors = False
     mapdl.prep7(mute=True)
     mapdl.n(mute=True)
     with pytest.raises(MapdlCommandIgnoredError, match="command is ignored"):


### PR DESCRIPTION
While working on https://github.com/pyansys/pymapdl/issues/1664

I saw that ``ignore_errors`` does nothing, in fact it is redundant with ``allow_ignore``. The later is more common, but I believe the naming is not the best.

So I am redirecting ``allow_ignore`` to ``ignore_errors`` and issuing a Deprecation warning when ``allow_ignore`` is used or set.