### PR TITLE
Adding ``avoid non interactive`` non-documented argument

### DIFF
--- a/doc/source/user_guide/troubleshoot.rst
+++ b/doc/source/user_guide/troubleshoot.rst
@@ -170,8 +170,7 @@ either Windows or Linux.
     printenv | grep ANSYSLMD_LICENSE_FILE
 
 
-.. _missing_dependencies_on_linux:
-
+.. _vpn_issues_troubleshooting:
 
 Virtual private network (VPN) issues
 ====================================
@@ -209,6 +208,8 @@ On Windows, you can find the license configuration file that points to the licen
     C:\Program Files\ANSYS Inc\Shared Files\Licensing\ansyslmd.ini
 
 
+
+.. _missing_dependencies_on_linux:
 
 Missing dependencies on Linux
 =============================

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1421,19 +1421,19 @@ def launch_mapdl(
         development purposes. See Notes for more details.
 
         set_no_abort : :class:`bool`
-          _(Development use only)_
+          *(Development use only)*
           Sets MAPDL to not abort at the first error within /BATCH mode.
           Defaults to ``True``.
 
         force_intel : :class:`bool`
-          _(Development use only)_
+          *(Development use only)*
           Forces the use of Intel message pass interface (MPI) in versions between
           Ansys 2021R0 and 2022R2, where because of VPNs issues this MPI is deactivated
           by default. See :ref:`vpn_issues_troubleshooting` for more information.
           Defaults to ``False``.
 
         log_broadcast : :class:`bool`
-          (Only for CORBA mode)
+          *(Only for CORBA mode)*
           Enables a logger to record broadcasted commands.
           Defaults to ``False``.
 

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1420,6 +1420,19 @@ def launch_mapdl(
         These keyword arguments are interface specific or for
         development purposes. See Notes for more details.
 
+        set_no_abort : :class:`bool`
+          Sets MAPDL to not abort at the first error within /BATCH mode.
+          Defaults to ``True``.
+
+        force_intel : :class:`bool`
+          Forces the use of Intel message pass interface (MPI) in versions between
+          Ansys 2021R0 and 2022R2, where because of VPNs issues this MPI is deactivated
+          by default. See :ref:`vpn_issues_troubleshooting` for more information.
+          Defaults to ``False``.
+
+        log_broadcast : :class:`bool`
+          (Only for CORBA mode) Enables a logger to record broadcasted commands.
+          Defaults to ``False``.
 
     Returns
     -------
@@ -1433,23 +1446,6 @@ def launch_mapdl(
 
     If an Ansys Student version is detected, PyMAPDL will launch MAPDL in
     shared-memory parallelism (SMP) mode unless another option is specified.
-
-    **Kwarg arguments**
-
-    The following keyword arguments are available:
-
-    * ``set_no_abort`` : bool.
-      Sets MAPDL to not abort at the first error within /BATCH mode.
-      Defaults to ``True``.
-
-    * ``force_intel`` : bool
-      Forces the use of Intel message pass interface (MPI) in versions between
-      Ansys 2021R0 and 2022R2, where because of VPNs issues this MPI is deactivated
-      by default. See :ref:`vpn_issues_troubleshooting` for more information. Defaults to ``False``.
-
-    * ``log_broadcast`` : bool.
-      (Only for CORBA mode) Enables a logger to record broadcasted commands.
-      Defaults to ``False``.
 
     **Additional switches**
 

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1416,6 +1416,11 @@ def launch_mapdl(
 
               export PYMAPDL_MAPDL_VERSION=22.2
 
+    kwargs : dict, optional
+        These keyword arguments are interface specific or for
+        development purposes. See Notes for more details.
+
+
     Returns
     -------
     ansys.mapdl.core.mapdl._MapdlCore
@@ -1423,8 +1428,30 @@ def launch_mapdl(
 
     Notes
     -----
+
+    **Ansys Student Version**
+
     If an Ansys Student version is detected, PyMAPDL will launch MAPDL in
     shared-memory parallelism (SMP) mode unless another option is specified.
+
+    **Kwarg arguments**
+
+    The following keyword arguments are available:
+
+    * ``set_no_abort`` : bool.
+      Sets MAPDL to not abort at the first error within /BATCH mode.
+      Defaults to ``True``.
+
+    * ``force_intel`` : bool
+      Forces the use of Intel message pass interface (MPI) in versions between
+      Ansys 2021R0 and 2022R2, where because of VPNs issues this MPI is deactivated
+      by default. See :ref:`vpn_issues_troubleshooting` for more information. Defaults to ``False``.
+
+    * ``log_broadcast`` : bool.
+      (Only for CORBA mode) Enables a logger to record broadcasted commands.
+      Defaults to ``False``.
+
+    **Additional switches**
 
     These are the MAPDL switch options as of 2020R2 applicable for
     running MAPDL as a service via gRPC.  Excluded switches such as

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1421,17 +1421,20 @@ def launch_mapdl(
         development purposes. See Notes for more details.
 
         set_no_abort : :class:`bool`
+          _(Development use only)_
           Sets MAPDL to not abort at the first error within /BATCH mode.
           Defaults to ``True``.
 
         force_intel : :class:`bool`
+          _(Development use only)_
           Forces the use of Intel message pass interface (MPI) in versions between
           Ansys 2021R0 and 2022R2, where because of VPNs issues this MPI is deactivated
           by default. See :ref:`vpn_issues_troubleshooting` for more information.
           Defaults to ``False``.
 
         log_broadcast : :class:`bool`
-          (Only for CORBA mode) Enables a logger to record broadcasted commands.
+          (Only for CORBA mode)
+          Enables a logger to record broadcasted commands.
           Defaults to ``False``.
 
     Returns

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2742,7 +2742,7 @@ class _MapdlCore(Commands):
             development purposes.
 
             avoid_non_interactive : :class:`bool`
-              _(Development use only)_
+              *(Development use only)*
               Avoids the non-interactive mode for this specific command.
               Defaults to ``False``.
 

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2776,7 +2776,10 @@ class _MapdlCore(Commands):
         if "\n" in command or "\r" in command:
             raise ValueError("Use ``input_strings`` for multi-line commands")
 
-        if self._store_commands:
+        # check if we want to avoid the current non-interactive context.
+        avoid_non_interactive = kwargs.get("avoid_non_interactive", False)
+
+        if self._store_commands and not avoid_non_interactive:
             # If we are using NBLOCK on input, we should not strip the string
             self._stored_commands.append(command)
             return

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2737,8 +2737,9 @@ class _MapdlCore(Commands):
             to ``False``, will not write command to log, even if APDL
             command logging is enabled.
 
-        kwargs : Optional keyword arguments
-            These keyword arguments are interface specific.
+        kwargs : dict, optional
+            These keyword arguments are interface specific or for
+            development purposes. See Notes for more details.
 
         Returns
         -------
@@ -2747,6 +2748,9 @@ class _MapdlCore(Commands):
 
         Notes
         -----
+
+        **Running non-interactive commands**
+
         When two or more commands need to be run non-interactively
         (i.e. ``*VWRITE``) use
 
@@ -2757,6 +2761,16 @@ class _MapdlCore(Commands):
         Alternatively, you can simply run a block of commands with:
 
         >>> mapdl.input_strings(cmd)
+
+        **Kwarg arguments**
+
+        The following keyword arguments are available:
+
+        * ``avoid_non_interactive`` : bool
+          Avoids the non-interactive mode for this specific command.
+
+        * ``verbose`` : bool
+          Prints the command to the screen before running it.
 
         Examples
         --------
@@ -2778,7 +2792,7 @@ class _MapdlCore(Commands):
             raise ValueError("Use ``input_strings`` for multi-line commands")
 
         # check if we want to avoid the current non-interactive context.
-        avoid_non_interactive = kwargs.get("avoid_non_interactive", False)
+        avoid_non_interactive = kwargs.pop("avoid_non_interactive", False)
 
         if self._store_commands and not avoid_non_interactive:
             # If we are using NBLOCK on input, we should not strip the string

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2742,6 +2742,7 @@ class _MapdlCore(Commands):
             development purposes.
 
             avoid_non_interactive : :class:`bool`
+              _(Development use only)_
               Avoids the non-interactive mode for this specific command.
               Defaults to ``False``.
 

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2739,7 +2739,15 @@ class _MapdlCore(Commands):
 
         kwargs : dict, optional
             These keyword arguments are interface specific or for
-            development purposes. See Notes for more details.
+            development purposes.
+
+            avoid_non_interactive : :class:`bool`
+              Avoids the non-interactive mode for this specific command.
+              Defaults to ``False``.
+
+            verbose : :class:`bool`
+              Prints the command to the screen before running it.
+              Defaults to ``False``.
 
         Returns
         -------
@@ -2761,16 +2769,6 @@ class _MapdlCore(Commands):
         Alternatively, you can simply run a block of commands with:
 
         >>> mapdl.input_strings(cmd)
-
-        **Kwarg arguments**
-
-        The following keyword arguments are available:
-
-        * ``avoid_non_interactive`` : bool
-          Avoids the non-interactive mode for this specific command.
-
-        * ``verbose`` : bool
-          Prints the command to the screen before running it.
 
         Examples
         --------

--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -280,7 +280,7 @@ class Parameters:
     @supress_logging
     def _parm(self):
         """Current MAPDL parameters"""
-        params = interp_star_status(self._mapdl.starstatus())
+        params = interp_star_status(self._mapdl.starstatus(avoid_non_interactive=True))
 
         if self.show_leading_underscore_parameters:
             _params = interp_star_status(self._mapdl.starstatus("_PRM"))
@@ -418,6 +418,8 @@ class Parameters:
                 self._mapdl.run(format_str)
 
             st = self._mapdl.last_response.rfind(format_str) + len(format_str) + 1
+            output = self._mapdl.last_response
+            u = output[st:]
 
             if "**" not in self._mapdl.last_response[st:]:
                 escaped = True

--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -418,10 +418,9 @@ class Parameters:
                 self._mapdl.run(format_str)
 
             st = self._mapdl.last_response.rfind(format_str) + len(format_str) + 1
-            output = self._mapdl.last_response
-            u = output[st:]
+            output = self._mapdl.last_response[st:]
 
-            if "**" not in self._mapdl.last_response[st:]:
+            if "**" not in output:
                 escaped = True
                 break
 
@@ -431,9 +430,7 @@ class Parameters:
                 "that could not be read using '{format_str}'."
             )
 
-        arr_flat = np.fromstring(self._mapdl.last_response[st:], sep="\n").reshape(
-            shape
-        )
+        arr_flat = np.fromstring(output, sep="\n").reshape(shape)
 
         if len(shape) == 3:
             if shape[2] == 1:

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1701,3 +1701,16 @@ def test_deprecation_allow_ignore_errors_mapping(mapdl):
 
     mapdl.ignore_errors = False
     assert mapdl.allow_ignore == mapdl.ignore_errors
+
+
+def test_avoid_non_interactive(mapdl):
+
+    with mapdl.non_interactive:
+        mapdl.com("comment A")
+        mapdl.com("comment B", avoid_non_interactive=True)
+        mapdl.com("comment C")
+
+        stored_commands = mapdl._stored_commands
+        assert any(["comment A" in cmd for cmd in stored_commands])
+        assert all(["comment B" not in cmd for cmd in stored_commands])
+        assert any(["comment C" in cmd for cmd in stored_commands])


### PR DESCRIPTION
This should avoid the command not being executed when you are in ``non_interactive`` or ``mapdl.input``.

It add the following argument ``avoid_non_interactive`` to each ``mapdl.run`` call.

I'm not documented this command because I believe its usage is going to be very restricted. But I'm conflicted about document it anyway
