### PR TITLE
Skipping license check on launching MAPDL instance for test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,6 +319,8 @@ def mapdl(request, tmpdir_factory):
         override=True,
         run_location=run_path,
         cleanup_on_exit=cleanup,
+        license_server_check=False,
+        additional_switches="-smp",
     )
     mapdl._show_matplotlib_figures = False  # CI: don't show matplotlib figures
 


### PR DESCRIPTION
Improving ubuntu local tests