### PR TITLE
on_docker tests not correctly designed

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -4018,6 +4018,8 @@ class _MapdlCore(Commands):
     def _check_on_docker(self):
         """Check if MAPDL is running on docker."""
         # self.get_mapdl_envvar("ON_DOCKER") # for later
+        if not self.is_grpc:  # pragma: no cover
+            return False
 
         if self.platform == "linux":
             self.sys(
@@ -4026,12 +4028,17 @@ class _MapdlCore(Commands):
         elif self.platform == "windows":  # pragma: no cover
             return False  # TODO: check if it is running a windows docker container. So far it is not supported.
 
-        if self.is_grpc and not self.is_local:
-            return self._download_as_raw("__outputcmd__.txt").decode().strip() == "true"
+        if not self.is_local:
+            sys_output = self._download_as_raw("__outputcmd__.txt").decode().strip()
+
         else:  # pragma: no cover
             file_ = os.path.join(self.directory, "__outputcmd__.txt")
             with open(file_, "r") as f:
-                return f.read().strip() == "true"
+                sys_output = f.read().strip()
+
+        self._log.debug(f"The output of sys command is: '{sys_output}'.")
+        self.slashdelete("__outputcmd__.txt")  # cleaning
+        return sys_output == "true"
 
     @property
     def on_docker(self):

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1713,7 +1713,7 @@ def test_is_local(mapdl):
 
 def test_on_docker(mapdl):
     assert mapdl.on_docker == mapdl._on_docker
-    if os.getenv("PYMAPDL_START_INSTANCE", "false") == "true":
+    if os.getenv("PYMAPDL_START_INSTANCE", "true").lower() == "false":
         assert mapdl.on_docker
     else:
         assert not mapdl.on_docker

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1713,10 +1713,8 @@ def test_is_local(mapdl):
 
 def test_on_docker(mapdl):
     assert mapdl.on_docker == mapdl._on_docker
-    if os.getenv("PYMAPDL_START_INSTANCE", "true").lower() == "false":
+    if os.getenv("ON_CI", "false").lower() == "true":
         assert mapdl.on_docker
-    else:
-        assert not mapdl.on_docker
 
 
 def test_deprecation_allow_ignore_warning(mapdl):

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1713,8 +1713,6 @@ def test_is_local(mapdl):
 
 def test_on_docker(mapdl):
     assert mapdl.on_docker == mapdl._on_docker
-    if os.getenv("ON_CI", "false").lower() == "true":
-        assert mapdl.on_docker
 
 
 def test_deprecation_allow_ignore_warning(mapdl):


### PR DESCRIPTION
@dts12263 realised this tests is not properly done.

The line:
```py
if os.getenv("PYMAPDL_START_INSTANCE", "false") == "true":
```
was always evaluated ``False``
