### PR TITLE
corrected doc string for example - on windows, folder is winx64

### DIFF
--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1580,7 +1580,7 @@ def launch_mapdl(
     Run MAPDL with shared memory parallel and specify the location of
     the Ansys binary.
 
-    >>> exec_file = 'C:/Program Files/ANSYS Inc/v201/ansys/bin/winx64/ANSYS201.exe'
+    >>> exec_file = 'C:/Program Files/ANSYS Inc/v231/ansys/bin/winx64/ANSYS231.exe'
     >>> mapdl = launch_mapdl(exec_file, additional_switches='-smp')
 
     Connect to an existing instance of MAPDL at IP 192.168.1.30 and

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -114,7 +114,7 @@ def _version_from_path(path):
     """Extract ansys version from a path.  Generally, the version of
     ANSYS is contained in the path:
 
-    C:/Program Files/ANSYS Inc/v202/ansys/bin/win64/ANSYS202.exe
+    C:/Program Files/ANSYS Inc/v202/ansys/bin/winx64/ANSYS202.exe
 
     /usr/ansys_inc/v211/ansys/bin/mapdl
 
@@ -395,7 +395,7 @@ def launch_grpc(
     Run MAPDL with shared memory parallel and specify the location of
     the ansys binary.
 
-    >>> exec_file = 'C:/Program Files/ANSYS Inc/v202/ansys/bin/win64/ANSYS202.exe'
+    >>> exec_file = 'C:/Program Files/ANSYS Inc/v202/ansys/bin/winx64/ANSYS202.exe'
     >>> mapdl = launch_mapdl(exec_file, additional_switches='-smp')
 
     """
@@ -968,7 +968,7 @@ def change_default_ansys_path(exe_loc):
 
     Change default Ansys location on Windows
 
-    >>> ans_pth = 'C:/Program Files/ANSYS Inc/v193/ansys/bin/win64/ANSYS193.exe'
+    >>> ans_pth = 'C:/Program Files/ANSYS Inc/v193/ansys/bin/winx64/ANSYS193.exe'
     >>> launcher.change_default_ansys_path(ans_pth)
     >>> launcher.check_valid_ansys()
     True
@@ -1580,7 +1580,7 @@ def launch_mapdl(
     Run MAPDL with shared memory parallel and specify the location of
     the Ansys binary.
 
-    >>> exec_file = 'C:/Program Files/ANSYS Inc/v201/ansys/bin/win64/ANSYS201.exe'
+    >>> exec_file = 'C:/Program Files/ANSYS Inc/v201/ansys/bin/winx64/ANSYS201.exe'
     >>> mapdl = launch_mapdl(exec_file, additional_switches='-smp')
 
     Connect to an existing instance of MAPDL at IP 192.168.1.30 and

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -99,7 +99,7 @@ class LocalMapdlPool:
 
     Create a pool while specifying the MAPDL executable in Windows.
 
-    >>> exec_file = 'C:/Program Files/ANSYS Inc/v212/ansys/bin/win64/ANSYS212.exe'
+    >>> exec_file = 'C:/Program Files/ANSYS Inc/v212/ansys/bin/winx64/ANSYS212.exe'
     >>> pool = LocalMapdlPool(10, exec_file=exec_file)
     Creating Pool: 100%|########| 10/10 [00:01<00:00,  1.43it/s]
 


### PR DESCRIPTION
in function doc strings for `launch_mapdl` the examples were not pointing to the correct folder or exe.

![grafik](https://user-images.githubusercontent.com/82146655/212853862-f8eab316-cb13-44ce-b3b9-7f56bdafc8fb.png)


while in the examples it is without `x`, which may lead to confusion

![grafik](https://user-images.githubusercontent.com/82146655/212854139-859e1f92-2248-41f5-93cb-95cbabac8372.png)
