### PR TITLE
Avoiding use 'self._path' in '_verify_local'

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -3174,16 +3174,25 @@ class _MapdlCore(Commands):
         a warning.
         """
         # always attempt to cache the path
-        try:
-            self._path = self.inquire("", "DIRECTORY")
-        except Exception:
-            pass
+        self._path = None
+        i = 0
+        while not self._path and i > 5:
+            try:
+                self._path = self.inquire("", "DIRECTORY")
+            except Exception:
+                pass
+            i += 1
 
         # os independent path format
         if self._path:  # self.inquire might return ''.
             self._path = self._path.replace("\\", "/")
             # new line to fix path issue, see #416
             self._path = repr(self._path)[1:-1]
+        else:
+            raise IOError(
+                f"The directory returned by /INQUIRE is not valid ('{self._path}')."
+            )
+
         return self._path
 
     @directory.setter

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -3174,14 +3174,15 @@ class _MapdlCore(Commands):
         a warning.
         """
         # always attempt to cache the path
-        self._path = None
         i = 0
-        while not self._path and i > 5:
+        while (not self._path and i > 5) or i == 0:
             try:
                 self._path = self.inquire("", "DIRECTORY")
             except Exception:
                 pass
             i += 1
+            if not self._path:
+                time.sleep(0.1)
 
         # os independent path format
         if self._path:  # self.inquire might return ''.

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -3178,10 +3178,10 @@ class _MapdlCore(Commands):
         while (not self._path and i > 5) or i == 0:
             try:
                 self._path = self.inquire("", "DIRECTORY")
-            except Exception:
+            except Exception:  # pragma: no cover
                 pass
             i += 1
-            if not self._path:
+            if not self._path:  # pragma: no cover
                 time.sleep(0.1)
 
         # os independent path format
@@ -3189,7 +3189,7 @@ class _MapdlCore(Commands):
             self._path = self._path.replace("\\", "/")
             # new line to fix path issue, see #416
             self._path = repr(self._path)[1:-1]
-        else:
+        else:  # pragma: no cover
             raise IOError(
                 f"The directory returned by /INQUIRE is not valid ('{self._path}')."
             )

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -573,10 +573,7 @@ class MapdlGrpc(_MapdlCore):
         """Check if Python is local to the MAPDL instance."""
         # Verify if python has assess to the MAPDL directory.
         if self._local:
-            if self._path is None:
-                directory = self.directory
-            else:
-                directory = self._path
+            directory = self.directory
 
             if self._jobname is None:
                 jobname = self.jobname


### PR DESCRIPTION
It should fix:

https://github.com/pyansys/pymapdl-examples/actions/runs/3938504282/jobs/6737289359#step:11:109

Let's enforce to use ``Mapdl.directory`` instead of ``Mapdl._path``. 