### PR TITLE
Removing temporary files at the end of execution

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -3006,6 +3006,8 @@ class _MapdlCore(Commands):
 
         if self._local:
             os.remove(filename)
+        else:
+            self.slashdelete(filename)
 
     def load_table(self, name, array, var1="", var2="", var3="", csysid=""):
         """Load a table from Python to into MAPDL.
@@ -3127,6 +3129,11 @@ class _MapdlCore(Commands):
             filename = base_name
         # skip the first line its a header we wrote in np.savetxt
         self.tread(name, filename, nskip=1, mute=True)
+
+        if self._local:
+            os.remove(filename)
+        else:
+            self.slashdelete(filename)
 
     def _display_plot(self, *args, **kwargs):  # pragma: no cover
         raise NotImplementedError("Implemented by child class")

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1563,9 +1563,12 @@ class MapdlGrpc(_MapdlCore):
             # Using CDREAD
             option = kwargs.get("cd_read_option", "COMB")
             tmp_dat = f"/OUT,{tmp_out}\n{orig_cmd},'{option}','{filename}'\n"
+            delete_uploaded_files = False
+
         else:
             # Using default INPUT
             tmp_dat = f"/OUT,{tmp_out}\n{orig_cmd},'{filename}'\n"
+            delete_uploaded_files = True
 
         if write_to_log and self._apdl_log is not None:
             if not self._apdl_log.closed:
@@ -1609,7 +1612,7 @@ class MapdlGrpc(_MapdlCore):
             # Deleting the previous files
             self.slashdelete(tmp_name)
             self.slashdelete(tmp_out)
-            if filename in self.list_files():
+            if filename in self.list_files() and delete_uploaded_files:
                 self.slashdelete(filename)
 
         return output

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1218,8 +1218,12 @@ class MapdlGrpc(_MapdlCore):
         super().sys(f"{cmd} > {tmp_file}")
         if self._local:  # no need to download when local
             with open(os.path.join(self.directory, tmp_file)) as fobj:
-                return fobj.read()
-        return self._download_as_raw(tmp_file).decode()
+                obj = fobj.read()
+        else:
+            obj = self._download_as_raw(tmp_file).decode()
+
+        self.slashdelete(tmp_file)
+        return obj
 
     def download_result(self, path=None, progress_bar=False, preference=None):
         """Download remote result files to a local directory
@@ -1605,6 +1609,8 @@ class MapdlGrpc(_MapdlCore):
             # Deleting the previous files
             self.slashdelete(tmp_name)
             self.slashdelete(tmp_out)
+            if filename in self.list_files():
+                self.slashdelete(filename)
 
         return output
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1416,13 +1416,13 @@ def test_mpfunctions(mapdl, cube_solve, capsys):
     assert "PROPERTY TEMPERATURE TABLE    NUM. TEMPS=  1" in output
     assert "TEMPERATURE TABLE ERASED." in output
     assert "0.4000000" in output
-    assert fname_ in mapdl.list_files()
     # check if materials are read into the db
     assert mapdl.get_value("NUXY", "1", "TEMP", 0) == nuxy
     assert np.allclose(mapdl.get_value("EX", 1, "TEMP", 0), ex)
 
     # Reding file in remote
     fname_ = f"{fname}.{ext}"
+    mapdl.upload(fname_)
     os.remove(fname_)
     assert not os.path.exists(fname_)
     assert f"{fname}.{ext}" in mapdl.list_files()


### PR DESCRIPTION
Some functions such as ``load_array``, ``load_table``, ``input``, etc ... left some temporary files behind. This PR fixes that.