### PR TITLE
Remove direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ doc = [
     "sphinxcontrib-websupport==1.2.4",
     "sphinxemoji==0.2.0",
     "vtk==9.2.5",
-    "sphinxcontrib-googleanalytics @ git+https://github.com/sphinx-contrib/googleanalytics.git",
+    "sphinxcontrib-googleanalytics==0.4",
 ]
 
 [tool.flit.module]


### PR DESCRIPTION
To do a release we need to remove all the direct (git based) dependencies.

The direct dependency was there because there was no release with the changes I proposed to this library in here: https://github.com/sphinx-contrib/googleanalytics/pull/7