### PR TITLE
Clean artefact attached to Github release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,13 @@ jobs:
 
       - uses: actions/download-artifact@v3
 
+      - name: 'Download the previously generated coverage reports'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: documentation-html.zip
+          skip_unpack: true
+          github_token: ${{secrets.GITHUB_TOKEN}}
+
       - name: Display structure of downloaded files
         run: ls -R
 
@@ -567,8 +574,9 @@ jobs:
           files: |
             ./**/*.whl
             ./**/*.tar.gz
-            ./**/*.pdf
+            ./**/*pymapdl-Documentation-*.pdf
             ./**/*.zip
+            ./*documentation-html*.zip
 
       - name: Upload to Public PyPi
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ doc = [
     "sphinxcontrib-websupport==1.2.4",
     "sphinxemoji==0.2.0",
     "vtk==9.2.5",
-    "sphinxcontrib-googleanalytics @ git+https://github.com/sphinx-contrib/googleanalytics.git",
+    "sphinxcontrib-googleanalytics==0.4",
 ]
 
 [tool.flit.module]


### PR DESCRIPTION
As the title. 

Previously:

<img width="926" alt="image" src="https://user-images.githubusercontent.com/28149841/213198651-bb8240c5-7e7f-4e7c-b3ef-d1258bbfc959.png">

We amin to not attach the some of the pdfs but also attach the html documentation.