### PR TITLE
Use grpcio==1.51.1 for docbuild

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ doc = [
     "ansys-dpf-core==0.7.2",
     "ansys-mapdl-reader==0.52.7",
     "ansys-sphinx-theme==0.8.0",
-    "grpcio==1.43.0",
+    "grpcio==1.51.1",
     "imageio-ffmpeg==0.4.8",
     "imageio==2.24.0",
     "jupyter_sphinx==0.4.0",


### PR DESCRIPTION
Use the latest grpcio to better support Python 3.11 for doc builds.