### PR TITLE
Improving mapdl.input documentation

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1570,6 +1570,9 @@ class MapdlGrpc(_MapdlCore):
         """Stream a local input file to a remote mapdl instance.
         Stream the response back and deserialize the output.
 
+        **This method does not use the APDL command ``/INPUT``**, although
+        it offers a similar functionality to the APDL counterpart.
+
         Parameters
         ----------
         fname : str
@@ -1602,6 +1605,19 @@ class MapdlGrpc(_MapdlCore):
         str
             Response from MAPDL.
 
+        Notes
+        -----
+        This method does not use the APDL ``/INPUT`` command.
+        However its usage is very similar to it. See *Examples* section.
+
+        If you want to use ``/INPUT`` for some reason, although it is not
+        recommended, you can write the desired input file, upload it using
+        :func:`Mapdl.upload <ansys.mapdl.core.Mapdl.upload>`, and then use
+        run command :func:`Mapdl.run('/INPUT,<FILE>,<EXT>) <ansys.mapdl.core.Mapdl.run>`.
+        This does not avoid to use the gRPC input method, but it allows you to
+        use the APDL ``/INPUT`` command from the generated input file.
+        See *Examples* section for more information.
+
         Examples
         --------
         Load a simple ``"ds.dat"`` input file generated from Ansys
@@ -1612,6 +1628,21 @@ class MapdlGrpc(_MapdlCore):
         Load that same file while streaming the output in real-time.
 
         >>> output = mapdl.input('ds.dat', verbose=True)
+
+        Use the default APDL ``/INPUT`` command:
+
+        >>> with open('myinput.inp','w') as fid:
+        >>>     fid.write("/finish\n/prep7\n/com, my commands")
+        >>> with open('inputtrigger.inp','w') as fid:
+        >>>     fid.write("/input,myinput,inp")
+        >>> mapdl.upload("myinput.inp")
+        Uploading myinput.inp: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 26.0/26.0 [00:00<00:00, 5.86kB/s]
+        'myinput.inp'
+        >>> mapdl.upload("inputtrigger.inp")
+        Uploading inputtrigger.inp: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 32.0/32.0 [00:00<00:00, 8.92kB/s]
+        'inputtrigger.inp'
+        >>> with mapdl.non_interactive:
+            mapdl.run("/input,inputtrigger,inp") # This inputs 'myinput.inp'
 
         """
         # always check if file is present as the grpc and MAPDL errors

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1631,7 +1631,7 @@ class MapdlGrpc(_MapdlCore):
 
         Use the default APDL ``/INPUT`` command:
 
-        >>> with open('myinput.inp','w').write("/finish\n/prep7\n/com, my commands")
+        >>> with open('myinput.inp','w').write("/finish\\n/prep7\\n/com, my commands")
         >>> with open('inputtrigger.inp','w').write("/input,myinput,inp")
         >>> mapdl.upload("myinput.inp")
         Uploading myinput.inp: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 26.0/26.0 [00:00<00:00, 5.86kB/s]
@@ -1640,7 +1640,7 @@ class MapdlGrpc(_MapdlCore):
         Uploading inputtrigger.inp: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 32.0/32.0 [00:00<00:00, 8.92kB/s]
         'inputtrigger.inp'
         >>> with mapdl.non_interactive:
-            mapdl.run("/input,inputtrigger,inp") # This inputs 'myinput.inp'
+                mapdl.run("/input,inputtrigger,inp") # This inputs 'myinput.inp'
 
         """
         # always check if file is present as the grpc and MAPDL errors

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1634,10 +1634,10 @@ class MapdlGrpc(_MapdlCore):
         >>> with open('myinput.inp','w').write("/finish\\n/prep7\\n/com, my commands")
         >>> with open('inputtrigger.inp','w').write("/input,myinput,inp")
         >>> mapdl.upload("myinput.inp")
-        Uploading myinput.inp: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 26.0/26.0 [00:00<00:00, 5.86kB/s]
+        Uploading myinput.inp: 100%|█████████████████████████████████████████████████| 26.0/26.0 [00:00<00:00, 5.86kB/s]
         'myinput.inp'
         >>> mapdl.upload("inputtrigger.inp")
-        Uploading inputtrigger.inp: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 32.0/32.0 [00:00<00:00, 8.92kB/s]
+        Uploading inputtrigger.inp: 100%|████████████████████████████████████████████| 32.0/32.0 [00:00<00:00, 8.92kB/s]
         'inputtrigger.inp'
         >>> with mapdl.non_interactive:
                 mapdl.run("/input,inputtrigger,inp") # This inputs 'myinput.inp'

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1631,10 +1631,8 @@ class MapdlGrpc(_MapdlCore):
 
         Use the default APDL ``/INPUT`` command:
 
-        >>> with open('myinput.inp','w') as fid:
-        >>>     fid.write("/finish\n/prep7\n/com, my commands")
-        >>> with open('inputtrigger.inp','w') as fid:
-        >>>     fid.write("/input,myinput,inp")
+        >>> with open('myinput.inp','w').write("/finish\n/prep7\n/com, my commands")
+        >>> with open('inputtrigger.inp','w').write("/input,myinput,inp")
         >>> mapdl.upload("myinput.inp")
         Uploading myinput.inp: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 26.0/26.0 [00:00<00:00, 5.86kB/s]
         'myinput.inp'


### PR DESCRIPTION
From #1749 

> When using the PyMAPDL input method I get an error when importing a CDB file when not specifying dir=....

Also clarifying the documentation.

Close #1749 