### PR TITLE
Fixing spaces in parameter string

### DIFF
--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -699,11 +699,11 @@ def interp_star_status(status):
 
         # line will contain either a character, scalar, or array
         name = items[0]
-        if len(items) == 2:
-            if items[1][-9:] == "CHARACTER":
-                parameters[name] = {"type": "CHARACTER", "value": items[1][:-9]}
-            # else:
-            # log.warning(
+        if len(items) == 2 or "CHARACTER" in items[-1].upper():
+            name = line[:32].strip()
+            value = line.replace(items[-1], "")[33:].strip()
+            parameters[name] = {"type": "CHARACTER", "value": value}
+
         elif len(items) == 3:
             if items[2] == "SCALAR":
                 value = float(items[1])
@@ -713,7 +713,6 @@ def interp_star_status(status):
         elif len(items) == 4:
             # it is an array or string array
             if is_array_listing(status):
-                # Probably I could get rid of this loop
                 myarray[
                     int(items[0]) - 1, int(items[1]) - 1, int(items[2]) - 1
                 ] = float(items[3])

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -380,3 +380,15 @@ def test_3d_array(mapdl):
         mapdl.parameters["myarr"],
         np.array([[[100.0, 200.0], [0.0, 300.0]], [[0.0, 400.0], [0.0, 0.0]]]),
     )
+
+
+def test_parameter_with_spaces(mapdl):
+    string_ = "DEV:F10X, front weights     "
+    mapdl.run(f"*SET,SIMULATION,'{string_}'")
+    mapdl.parsav()
+    mapdl.clear()
+    mapdl.parres('NEW',fname='file',ext='parm')
+    assert mapdl.starstatus()
+    assert mapdl.parameters
+    assert "simulation" in mapdl.parameters
+    assert string_.strip() == mapdl.parameters['SIMULATION']

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -390,5 +390,5 @@ def test_parameter_with_spaces(mapdl):
     mapdl.parres("NEW", fname="file", ext="parm")
     assert mapdl.starstatus()
     assert mapdl.parameters
-    assert "simulation" in mapdl.parameters
+    assert "SIMULATION" in mapdl.parameters
     assert string_.strip() == mapdl.parameters["SIMULATION"]

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -387,8 +387,8 @@ def test_parameter_with_spaces(mapdl):
     mapdl.run(f"*SET,SIMULATION,'{string_}'")
     mapdl.parsav()
     mapdl.clear()
-    mapdl.parres('NEW',fname='file',ext='parm')
+    mapdl.parres("NEW", fname="file", ext="parm")
     assert mapdl.starstatus()
     assert mapdl.parameters
     assert "simulation" in mapdl.parameters
-    assert string_.strip() == mapdl.parameters['SIMULATION']
+    assert string_.strip() == mapdl.parameters["SIMULATION"]


### PR DESCRIPTION
Close #1826 by making sure a correct parsing when string parameters contain spaces.
