### PR TITLE
Recache processes to make sure we close them all.

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -161,6 +161,7 @@ class _MapdlCore(Commands):
         **start_parm,
     ):
         """Initialize connection with MAPDL."""
+        atexit.register(self.__del__)  # registering to exit properly
         self._name = None  # For naming the instance.
         self._show_matplotlib_figures = True  # for testing
         self._query = None
@@ -3221,7 +3222,6 @@ class _MapdlCore(Commands):
         """Exit from MAPDL"""
         raise NotImplementedError("Implemented by child class")
 
-    @atexit.register
     def __del__(self):  # pragma: no cover
         """Clean up when complete"""
         if self._cleanup:

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1,5 +1,6 @@
 """Module to control interaction with MAPDL through Python"""
 
+import atexit
 from functools import wraps
 import glob
 import logging
@@ -3220,6 +3221,7 @@ class _MapdlCore(Commands):
         """Exit from MAPDL"""
         raise NotImplementedError("Implemented by child class")
 
+    @atexit.register
     def __del__(self):  # pragma: no cover
         """Clean up when complete"""
         if self._cleanup:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1036,6 +1036,8 @@ class MapdlGrpc(_MapdlCore):
         self._log.debug("Exiting MAPDL")
 
         if self._local:
+            self._cache_pids()  # Recache processes
+
             if os.name == "nt":
                 self._kill_server()
             self._close_process()


### PR DESCRIPTION
This come from internal request:

> this is a follow-up on my last service request.
> We had issues with closing processes when using the SMP mode within a PyAnsys script.
> Your service member O.R. helped a lot and suggested to upgrade our python package with the following command.
> pip install --upgrade --upgrade-strategy eager ansys-mapdl-core The issue unfortunately still exists.
> DMP mode seem to work just fine with my crack growth (SMART) analysis.

I did try locally in ubuntu container, and on Windows 11; and it seems to work.

I will ask for internal feedback.

=Edit=
I have also added the module `atexit` to track exiting python using ``__del__`` method properly.
Close #1812 