### PR TITLE
Homogenization of input API

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1558,7 +1558,12 @@ class MapdlGrpc(_MapdlCore):
     @protect_grpc
     def input(
         self,
-        fname,
+        fname="",
+        ext="",
+        dir_="",
+        line="",
+        log="",
+        *,
         verbose=False,
         progress_bar=False,
         time_step_stream=None,
@@ -1570,10 +1575,41 @@ class MapdlGrpc(_MapdlCore):
         """Stream a local input file to a remote mapdl instance.
         Stream the response back and deserialize the output.
 
+        .. versionchanged:: 0.65
+            From version 0.65 you can use the APDL commands arguments (``ext``, ``dir``, ``line``)
+            in within this command.
+            However, the gRPC implementation does *not* uses the APDL ``/INPUT`` command,
+            rather the gRPC input method with the appropriate configuration to replicate
+            ``/INPUT`` behaviour.
+
         Parameters
         ----------
         fname : str
             MAPDL input file to stream to the MAPDL grpc server.
+            File name and directory path.
+            An unspecified directory path defaults to the Python working
+            directory; in this case, you can use all 248 characters for the file name.
+            The file name defaults to the current ``Jobname`` if ``Ext`` is specified.
+
+        ext : str
+            Filename extension (eight-character maximum).
+
+        dir : str
+            Directory path. Defaults to current directory.
+
+        line : int
+            A value indicating either a line number in the file from which to
+            begin reading the input file. The first line is the zero line (Python
+            convention).
+
+            (blank), or 0
+                Begins reading from the top of the file (default).
+
+            LINE_NUMBER
+                Begins reading from the specified line number in the file.
+
+        log
+            Not supported in the gRPC implementation.
 
         time_step_stream : int
             Time to wait between streaming updates to send back chunks
@@ -1614,6 +1650,70 @@ class MapdlGrpc(_MapdlCore):
         >>> output = mapdl.input('ds.dat', verbose=True)
 
         """
+        # Checking compatibility
+        # Checking the user is not reusing old api:
+        #
+        # fname,
+        # verbose=False,
+        # progress_bar=False,
+        # time_step_stream=None,
+        # chunk_size=512,
+        # orig_cmd="/INP",
+        # write_to_log=True,
+
+        msg_compat = "\nThe 'mapdl.input' method API changed in v0.65. Please check the documentation for information about the new arguments."
+
+        if log:
+            raise ValueError(
+                "'log' argument is not supported in the gRPC implementation."
+            )
+
+        if not isinstance(ext, (str)) and ext is not None:
+            raise ValueError(
+                "Only strings are allowed in 'ext' argument.\n" + msg_compat
+            )
+
+        if not isinstance(dir_, (str)) and dir_ is not None:
+            raise ValueError(
+                "Only strings are allowed in 'dir_' argument.\n" + msg_compat
+            )
+
+        # Getting arguments rights
+        if not fname and ext:
+            fname = self.jobname
+
+        if not fname:
+            raise ValueError("A file name must be supplied.")
+
+        fname = self._get_file_name(fname=fname, ext=ext)
+
+        if not dir_:
+            self._log.debug(f"Using python working directory as 'dir_' value.")
+            dir_ = os.getcwd()
+        else:
+            fname = os.path.join(dir_, fname)
+
+        if not line:
+            line = 0
+        else:
+            try:
+                line = int(line)
+            except ValueError:
+                raise ValueError(
+                    "Only integers are supported for 'line' argument. Labels are not supported on the gRPC implementation."
+                )
+
+        if line != 0:
+            # Trimming file
+            tmp_modified_file = os.path.join(
+                tempfile.gettempdir(), os.path.basename(fname)
+            )
+            with open(tmp_modified_file, "w") as fid, open(fname, "r") as fid2:
+                fid.writelines(fid2.readlines()[line:])
+
+            fname = tmp_modified_file
+
+        # Running method
         # always check if file is present as the grpc and MAPDL errors
         # are unclear
         filename = self._get_file_path(fname, progress_bar)
@@ -1673,7 +1773,8 @@ class MapdlGrpc(_MapdlCore):
 
         if self._local:
             local_path = self.directory
-            with open(os.path.join(local_path, tmp_name), "w") as f:
+            tmp_name_path = os.path.join(local_path, tmp_name)
+            with open(tmp_name_path, "w") as f:
                 f.write(tmp_dat)
         else:
             self._upload_raw(tmp_dat.encode(), tmp_name)
@@ -1688,17 +1789,18 @@ class MapdlGrpc(_MapdlCore):
 
         # all output (unless redirected) has been written to a temp output
         if self._local:  # pragma: no cover
-            with open(os.path.join(local_path, tmp_out)) as f:
+            tmp_out_path = os.path.join(local_path, tmp_out)
+            with open(tmp_out_path) as f:
                 output = f.read()
 
             # delete the files to avoid overwriting:
             try:
-                os.remove(tmp_name)
+                os.remove(tmp_name_path)
             except OSError:
                 pass
 
             try:
-                os.remove(tmp_out)
+                os.remove(tmp_out_path)
             except OSError:
                 pass
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -390,7 +390,6 @@ def test_input_output(mapdl):
 
     output = mapdl.input(file_)
     assert "/INPUT FILE" in output
-    assert file_ in output
     assert "line 0" in output
     assert "line 3" in output
 
@@ -405,7 +404,6 @@ def test_input_ext_argument(mapdl):
 
     output = mapdl.input("myinput", "inp")
     assert "/INPUT FILE" in output
-    assert file_ in output
     assert "line 0" in output
     assert "line 1" in output
     assert "line 2" in output
@@ -424,7 +422,6 @@ def test_input_dir_argument(mapdl, tmpdir):
 
     output = mapdl.input(file_, "", target_dir)
     assert "/INPUT FILE" in output
-    assert file_ in output
     assert "line 0" in output
     assert "line 1" in output
     assert "line 2" in output
@@ -441,7 +438,6 @@ def test_input_line_argument(mapdl):
 
     output = mapdl.input(file_, line=2)
     assert "/INPUT FILE" in output
-    assert file_ in output
     assert "line 0" not in output
     assert "line 1" not in output
     assert "line 2" in output
@@ -460,7 +456,6 @@ def test_input_multiple_argument(mapdl, tmpdir):
 
     output = mapdl.input("myinput", "inp", target_dir, 2)
     assert "/INPUT FILE" in output
-    assert file_ in output
     assert "line 0" not in output
     assert "line 1" not in output
     assert "line 2" in output

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -380,3 +380,109 @@ def test_mode_corba(mapdl):
     assert mapdl.is_grpc
     assert not mapdl.is_corba
     assert not mapdl.is_console
+
+
+def test_input_output(mapdl):
+    file_ = "myinput.inp"
+    with open(file_, "w") as fid:
+        for i in range(4):
+            fid.write(f"/com, line {i}\n")
+
+    output = mapdl.input(file_)
+    assert "/INPUT FILE" in output
+    assert file_ in output
+    assert "line 0" in output
+    assert "line 3" in output
+
+    os.remove(file_)
+
+
+def test_input_ext_argument(mapdl):
+    file_ = "myinput.inp"
+    with open(file_, "w") as fid:
+        for i in range(4):
+            fid.write(f"/com, line {i}\n")
+
+    output = mapdl.input("myinput", "inp")
+    assert "/INPUT FILE" in output
+    assert file_ in output
+    assert "line 0" in output
+    assert "line 1" in output
+    assert "line 2" in output
+    assert "line 3" in output
+
+    os.remove(file_)
+
+
+def test_input_dir_argument(mapdl, tmpdir):
+    file_ = "myinput.inp"
+    target_dir = str(tmpdir.mkdir(f"tmp_{random_string()}"))
+    file_path = os.path.join(target_dir, file_)
+    with open(file_path, "w") as fid:
+        for i in range(4):
+            fid.write(f"/com, line {i}\n")
+
+    output = mapdl.input(file_, "", target_dir)
+    assert "/INPUT FILE" in output
+    assert file_ in output
+    assert "line 0" in output
+    assert "line 1" in output
+    assert "line 2" in output
+    assert "line 3" in output
+
+    os.remove(file_path)
+
+
+def test_input_line_argument(mapdl):
+    file_ = "myinput.inp"
+    with open(file_, "w") as fid:
+        for i in range(4):
+            fid.write(f"/com, line {i}\n")
+
+    output = mapdl.input(file_, line=2)
+    assert "/INPUT FILE" in output
+    assert file_ in output
+    assert "line 0" not in output
+    assert "line 1" not in output
+    assert "line 2" in output
+    assert "line 3" in output
+
+    os.remove(file_)
+
+
+def test_input_multiple_argument(mapdl, tmpdir):
+    file_ = "myinput.inp"
+    target_dir = str(tmpdir.mkdir(f"tmp_{random_string()}"))
+    file_path = os.path.join(target_dir, file_)
+    with open(file_path, "w") as fid:
+        for i in range(4):
+            fid.write(f"/com, line {i}\n")
+
+    output = mapdl.input("myinput", "inp", target_dir, 2)
+    assert "/INPUT FILE" in output
+    assert file_ in output
+    assert "line 0" not in output
+    assert "line 1" not in output
+    assert "line 2" in output
+    assert "line 3" in output
+
+    os.remove(file_path)
+
+
+def test_input_log_argument(mapdl):
+    with pytest.raises(ValueError, match="'log' argument is not supported"):
+        mapdl.input(log="asdf")
+
+
+def test_input_compatibility_api_change(mapdl):
+    """This test is because the API change happened in 0.65 to homogenise the APDL command
+    with the gRPC method."""
+
+    with pytest.raises(ValueError, match="Only strings are allowed in 'ext'"):
+        mapdl.input(ext=1)
+
+    with pytest.raises(ValueError, match="Only strings are allowed in 'dir_'"):
+        mapdl.input(dir_=1)
+
+    with pytest.raises(ValueError, match="A file name must be supplied."):
+        mapdl.input()


### PR DESCRIPTION

## Remarks
I am enforcing kwargs arguments on the gRPC methods (after ``*``)

Close #1833 