### PR TITLE
Removing gcc console output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,7 @@ jobs:
       PYMAPDL_DB_PORT: 21001  # default won't work on GitHub runners
       PYMAPDL_START_INSTANCE: FALSE
       ON_REMOTE: TRUE
+      ON_UBUNTU: FALSE
 
     steps:
       - name: "Install Git and checkout project"
@@ -338,6 +339,7 @@ jobs:
 
       - name: "Unit testing"
         run: |
+          if [[ "${{ matrix.mapdl-version }}" == *"ubuntu"* ]]; then export ON_UBUNTU=true;fi
           xvfb-run pytest -v --durations=10 \
               --maxfail=10  --reruns 7 --reruns-delay 3 --only-rerun MapdlExitedError --only-rerun EmptyRecordError \
               --cov=ansys.mapdl.core --cov-report=xml:centos-${{ matrix.mapdl-version }}-remote.xml --cov-report=html
@@ -436,6 +438,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       ON_LOCAL: true
+      ON_UBUNTU: true
 
     steps:
       - name: "Install Git and checkout project"

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -97,7 +97,11 @@ def _is_ubuntu():
         return False
 
     # gcc is installed by default except when on docker.
-    proc = subprocess.Popen("gcc --version", shell=True, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(
+        "awk -F= '/^NAME/{print $2}' /etc/os-release",
+        shell=True,
+        stdout=subprocess.PIPE,
+    )
     if "ubuntu" in proc.stdout.read().decode().lower():
         return True
 

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -96,7 +96,6 @@ def _is_ubuntu():
     if os.name != "posix":
         return False
 
-    # gcc is installed by default except when on docker.
     proc = subprocess.Popen(
         "awk -F= '/^NAME/{print $2}' /etc/os-release",
         shell=True,
@@ -105,7 +104,7 @@ def _is_ubuntu():
     if "ubuntu" in proc.stdout.read().decode().lower():
         return True
 
-    # try lsb_release as this is more reliable
+    # try lsb_release as this is more reliable, but not always available.
     try:
         import lsb_release
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -11,6 +11,7 @@ from ansys.mapdl.core.errors import LicenseServerConnectionError
 from ansys.mapdl.core.launcher import (
     _check_license_argument,
     _force_smp_student_version,
+    _is_ubuntu,
     _validate_MPI,
     _verify_version,
     _version_from_path,
@@ -53,6 +54,10 @@ paths = [
     ("C:/Program Files/ANSYS Inc/v202/ansys/bin/win64/ANSYS202.exe", 202),
     ("/usr/ansys_inc/v211/ansys/bin/mapdl", 211),
 ]
+
+skip_on_ci = pytest.mark.skipif(
+    os.environ.get("ON_CI", "").upper() == "TRUE", reason="Skipping on CI"
+)
 
 skip_on_ci = pytest.mark.skipif(
     os.environ.get("ON_CI", "").upper() == "TRUE", reason="Skipping on CI"
@@ -525,3 +530,10 @@ def test_version(mapdl):
 def test_raise_exec_path_and_version_launcher():
     with pytest.raises(ValueError):
         launch_mapdl(exec_file="asdf", version="asdf", start_timeout=start_timeout)
+
+
+def test_is_ubuntu():
+    if os.environ.get("ON_UBUNTU", "false").lower() == "true":
+        assert _is_ubuntu()
+    else:
+        assert not _is_ubuntu()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -70,6 +70,7 @@ skip_on_not_local = pytest.mark.skipif(
 
 start_timeout = 30  # Seconds
 
+
 @pytest.mark.skipif(
     get_start_instance() is False,
     reason="Skip when start instance is disabled",

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -533,7 +533,8 @@ def test_raise_exec_path_and_version_launcher():
 
 
 def test_is_ubuntu():
-    if os.environ.get("ON_UBUNTU", "false").lower() == "true":
+    if (
+        os.environ.get("ON_LOCAL", "false").lower() == "true"
+        and os.environ.get("ON_UBUNTU", "false").lower() == "true"
+    ):
         assert _is_ubuntu()
-    else:
-        assert not _is_ubuntu()


### PR DESCRIPTION
Getting rid of the following message:

> /bin/sh: 1: gcc: not found