### PR TITLE
Avoid checking non-existing process.

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -466,16 +466,22 @@ class MapdlGrpc(_MapdlCore):
                 f"Reached either maximum amount of connection attempts ({n_attempts}) or timeout ({timeout} s)."
             )
 
-            if psutil.pid_exists(self._mapdl_process.pid):
+            if self._mapdl_process is not None and psutil.pid_exists(
+                self._mapdl_process.pid
+            ):
                 # Process is alive
                 raise MapdlConnectionError(
                     msg
                     + f"The MAPDL process seems to be alive (PID: {self._mapdl_process.pid}) but PyMAPDL cannot connect to it."
                 )
             else:
+                pid_msg = (
+                    f" PID: {self._mapdl_process.pid}"
+                    if self._mapdl_process is not None
+                    else ""
+                )
                 raise MapdlConnectionError(
-                    msg
-                    + f"The MAPDL process has died (PID: {self._mapdl_process.pid})."
+                    msg + f"The MAPDL process has died{pid_msg}."
                 )
 
         self._exited = False


### PR DESCRIPTION
As the title.