### PR TITLE
Removing XPASS flag

### DIFF
--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -858,11 +858,8 @@ def test_load_array(mapdl, dimx, dimy):
     "array",
     [
         pytest.param([1, 3, 10], marks=pytest.mark.xfail),
-        pytest.param(
-            np.zeros(
-                3,
-            ),
-            marks=pytest.mark.xfail,
+        np.zeros(
+            3,
         ),
         np.zeros((3, 1)),
         np.zeros((3, 3)),

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -93,7 +93,7 @@ gen_status = """ABBREVIATION STATUS-
         1e31,
         1e41,
         1e51,
-        pytest.param(1e61, marks=pytest.mark.xfail),
+        1e61,
     ],
 )
 def test__get_parameter_array(mapdl, number):


### PR DESCRIPTION
These flags were implemented in #957 and they were probably phased out in #942. Although the dates doesn't add up, I guess the change (between XFAIL to XPASS) must be related to one of the mentioned PR.

Close #1844