### PR TITLE
Limiting the number of scalars values for colour in aplot.

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1597,8 +1597,11 @@ class _MapdlCore(Commands):
         show_line_numbering : bool, optional
             Display line numbers when ``vtk=True``.
 
-        color_areas : bool, optional
-            Randomly color areas when ``True`` and ``vtk=True``.
+        color_areas : np.array, optional
+            Only used when ``vtk=True``.
+            If ``color_areas`` is a bool, randomly color areas when ``True`` .
+            If ``color_areas`` is an array or list, it colors each area with
+            the RGB colors, specified in that array or list.
 
         show_lines : bool, optional
             Plot lines and areas.  Change the thickness of the lines
@@ -1656,22 +1659,28 @@ class _MapdlCore(Commands):
             # individual surface isolation is quite slow, so just
             # color individual areas
             if color_areas:  # pragma: no cover
-                anum = surf["entity_num"]
-                size_ = max(anum) + 1
-                # Because this is only going to be used for plotting purpuses, we don't need to allocate
-                # a huge vector with random numbers (colours).
-                # By default `pyvista.DataSetMapper.set_scalars` `n_colors` argument is set to 256, so let
-                # do here the same.
-                # We will limit the number of randoms values (colours) to 256
-                #
-                # Link: https://docs.pyvista.org/api/plotting/_autosummary/pyvista.DataSetMapper.set_scalars.html#pyvista.DataSetMapper.set_scalars
-                size_ = min([256, size_])
-                # Generating a colour array,
-                # Size = number of areas.
-                # Values are random between 0 and min(256, number_areas)
-                rng = np.random.default_rng()
-                area_color = rng.integers(size_, size=len(anum), dtype=np.uint8)
-                meshes.append({"mesh": surf, "scalars": area_color})
+                if isinstance(color_areas, bool):
+                    anum = surf["entity_num"]
+                    size_ = max(anum) + 1
+                    # Because this is only going to be used for plotting purpuses, we don't need to allocate
+                    # a huge vector with random numbers (colours).
+                    # By default `pyvista.DataSetMapper.set_scalars` `n_colors` argument is set to 256, so let
+                    # do here the same.
+                    # We will limit the number of randoms values (colours) to 256
+                    #
+                    # Link: https://docs.pyvista.org/api/plotting/_autosummary/pyvista.DataSetMapper.set_scalars.html#pyvista.DataSetMapper.set_scalars
+                    size_ = min([256, size_])
+                    # Generating a colour array,
+                    # Size = number of areas.
+                    # Values are random between 0 and min(256, number_areas)
+                    area_color = np.random.choice(range(size_), size=(len(anum), 3))
+                else:
+                    if len(surf["entity_num"]) != len(color_areas):
+                        raise ValueError(
+                            f"The length of the parameter array 'color_areas' should be the same as the number of areas."
+                        )
+                    area_color = color_areas
+                meshes.append({"mesh": surf, "color": area_color})
             else:
                 meshes.append({"mesh": surf, "color": kwargs.get("color", "white")})
 

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1670,7 +1670,7 @@ class _MapdlCore(Commands):
                 # Size = number of areas.
                 # Values are random between 0 and min(256, number_areas)
                 rng = np.random.default_rng()
-                rand = rng.integers(size_, size=len(anum))
+                rand = rng.integers(size_, size=len(anum), dtype=np.uint8)
                 area_color = rand[anum]
                 meshes.append({"mesh": surf, "scalars": area_color})
             else:

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1670,8 +1670,7 @@ class _MapdlCore(Commands):
                 # Size = number of areas.
                 # Values are random between 0 and min(256, number_areas)
                 rng = np.random.default_rng()
-                rand = rng.integers(size_, size=len(anum), dtype=np.uint8)
-                area_color = rand[anum]
+                area_color = rng.integers(size_, size=len(anum), dtype=np.uint8)
                 meshes.append({"mesh": surf, "scalars": area_color})
             else:
                 meshes.append({"mesh": surf, "color": kwargs.get("color", "white")})

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -1658,7 +1658,19 @@ class _MapdlCore(Commands):
             if color_areas:  # pragma: no cover
                 anum = surf["entity_num"]
                 size_ = max(anum) + 1
-                rand = np.random.random(size_)
+                # Because this is only going to be used for plotting purpuses, we don't need to allocate
+                # a huge vector with random numbers (colours).
+                # By default `pyvista.DataSetMapper.set_scalars` `n_colors` argument is set to 256, so let
+                # do here the same.
+                # We will limit the number of randoms values (colours) to 256
+                #
+                # Link: https://docs.pyvista.org/api/plotting/_autosummary/pyvista.DataSetMapper.set_scalars.html#pyvista.DataSetMapper.set_scalars
+                size_ = min([256, size_])
+                # Generating a colour array,
+                # Size = number of areas.
+                # Values are random between 0 and min(256, number_areas)
+                rng = np.random.default_rng()
+                rand = rng.integers(size_, size=len(anum))
                 area_color = rand[anum]
                 meshes.append({"mesh": surf, "scalars": area_color})
             else:


### PR DESCRIPTION
The ``mapdl.aplot`` seems to give errors from time to time because it tries to allocate a huge array for area colouring. 

In this PR we limite the number of colours to be 256. The array size is still the same (number of areas), but now we use an ints instead of floats. 

Close #1691 and #1791 