### PR TITLE
Passing plotter not requiring return_plotter

### DIFF
--- a/examples/00-mapdl-examples/3d_notch.py
+++ b/examples/00-mapdl-examples/3d_notch.py
@@ -15,6 +15,7 @@ from matplotlib import pyplot as plt
 
 # sphinx_gallery_thumbnail_number = 3
 import numpy as np
+import pyvista as pv
 
 from ansys.mapdl.core import launch_mapdl
 
@@ -64,21 +65,30 @@ rect_anum = mapdl.blc4(width=length, height=width)
 # plate_with_hole_anum = mapdl.asba(rect_anum, circ_anum)
 cut_area = mapdl.asba(rect_anum, "ALL")  # cut all areas except the plate
 
-# mapdl.aplot(vtk=True, show_line_numbering=True)
+plotter = pv.Plotter(shape=(1, 3))
+
+plotter.subplot(0, 0)
 mapdl.lsla("S")
-mapdl.lplot(vtk=True, show_keypoint_numbering=True)
+mapdl.lplot(vtk=True, show_keypoint_numbering=True, plotter=plotter)
 mapdl.lsel("all")
 
 # plot the area using vtk/pyvista
-mapdl.aplot(vtk=True, show_area_numbering=True, show_lines=True, cpos="xy")
+plotter.subplot(0, 1)
+mapdl.aplot(
+    vtk=True, show_area_numbering=True, show_lines=True, cpos="xy", plotter=plotter
+)
 
 # Next, extrude the area to create volume
 thickness = 0.01
 mapdl.vext(cut_area, dz=thickness)
 
 # Checking volume plot
-mapdl.vplot(vtk=True, show_lines=True, show_axes=True, smooth_shading=True)
+plotter.subplot(0, 2)
+mapdl.vplot(
+    vtk=True, show_lines=True, show_axes=True, smooth_shading=True, plotter=plotter
+)
 
+plotter.show()
 
 ###############################################################################
 # Meshing

--- a/src/ansys/mapdl/core/plotting.py
+++ b/src/ansys/mapdl/core/plotting.py
@@ -659,10 +659,11 @@ def general_plotter(
         By default it is 16.
 
     plotter : pyvista.Plotter, optional
-        If a :class:`pyvista.Plotter` not is provided, then creates its
-        own plotter. If a :class:`pyvista.Plotter` is provided, the arguments
-        ``notebook``, ``off_screen`` and ``theme`` are ignored, since
-        they should be set when instantiated the provided plotter.
+        If a :class:`pyvista.Plotter` is not provided, then creates its
+        own plotter. If a :class:`pyvista.Plotter` is provided, the plotter
+        is not shown (you need to issue :meth:`pyvista.Plotter.show` manually)
+        and the arguments ``notebook``, ``off_screen`` and ``theme`` are ignored,
+        since they should be set when instantiated the provided plotter.
         Defaults to ``None`` (create the Plotter object).
 
     Returns
@@ -806,7 +807,7 @@ def general_plotter(
         pl.close()
 
     else:
-        if not return_plotter:
+        if not return_plotter and not plotter:
             pl.show()
 
     if return_plotter:


### PR DESCRIPTION
As the title. It allows us to get rid of `return_plotter` specification when using ``plotter``.

Close #1825