### PR TITLE
Code update for Ansvec __getitem__ to handle complex dtype

### DIFF
--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1410,12 +1410,13 @@ class AnsVec(ApdlMathObj):
         if MYCTYPE[dtype].upper() in ["C", "Z"]:
             self._mapdl.run(f"pyval_img_={self.id}({num+1},2)", mute=True)
             img_val = self._mapdl.scalar_param("pyval_img_")
+            item_val = item_val + img_val * 1j
 
             # Clean parameters
             self._mapdl.run("item_val =")
             self._mapdl.run("pyval_img_=")
 
-        return item_val + img_val * 1j
+        return item_val
 
     def __mul__(self, vec):
         """Element-Wise product with another Ansys vector object.

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1404,14 +1404,18 @@ class AnsVec(ApdlMathObj):
         if num < 0:
             raise ValueError("Negative indices not permitted")
 
-        self._mapdl.run(f"pyval={self.id}({num+1})", mute=True)
-        item_val = self._mapdl.scalar_param("pyval")
+        self._mapdl.run(f"pyval_={self.id}({num+1})", mute=True)
+        item_val = self._mapdl.scalar_param("pyval_")
 
-        if MYCTYPE[dtype] == "C" or MYCTYPE[dtype] == "Z":
-            self._mapdl.run(f"pyval_img={self.id}({num+1},2)", mute=True)
-            img_val = self._mapdl.scalar_param("pyval_img")
-            item_val = item_val + img_val * 1j
-        return item_val
+        if MYCTYPE[dtype].upper() in ["C", "Z"]:
+            self._mapdl.run(f"pyval_img_={self.id}({num+1},2)", mute=True)
+            img_val = self._mapdl.scalar_param("pyval_img_")
+            
+            # Clean parameters
+            self._mapdl.run("item_val =")
+            self._mapdl.run("pyval_img_=")
+
+        return item_val + img_val * 1j
 
     def __mul__(self, vec):
         """Element-Wise product with another Ansys vector object.

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1399,10 +1399,19 @@ class AnsVec(ApdlMathObj):
         return f"APDLMath Vector Size {self.size}"
 
     def __getitem__(self, num):
+        info = self._mapdl._data_info(self.id)
+        dtype = ANSYS_VALUE_TYPE[info.stype]
         if num < 0:
             raise ValueError("Negative indices not permitted")
+
         self._mapdl.run(f"pyval={self.id}({num+1})", mute=True)
-        return self._mapdl.scalar_param("pyval")
+        item_val = self._mapdl.scalar_param("pyval")
+
+        if MYCTYPE[dtype] == "C" or MYCTYPE[dtype] == "Z":
+            self._mapdl.run(f"pyval_img={self.id}({num+1},2)", mute=True)
+            img_val = self._mapdl.scalar_param("pyval_img")
+            item_val = item_val + img_val * 1j
+        return item_val
 
     def __mul__(self, vec):
         """Element-Wise product with another Ansys vector object.

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1410,7 +1410,7 @@ class AnsVec(ApdlMathObj):
         if MYCTYPE[dtype].upper() in ["C", "Z"]:
             self._mapdl.run(f"pyval_img_={self.id}({num+1},2)", mute=True)
             img_val = self._mapdl.scalar_param("pyval_img_")
-            
+
             # Clean parameters
             self._mapdl.run("item_val =")
             self._mapdl.run("pyval_img_=")

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -252,7 +252,9 @@ def test_getitem_AnsMat(mm):
 def test_getitem_AnsVec(mm, dtype_):
     size_i = 3
     vec = mm.rand(size_i, dtype=dtype_)
-    assert np.allclose(vec, vec.asarray())
+    np_vec = np.asarray()
+    for i in range(size_i):
+        assert vec[i] == np_vec[i]
 
 
 def test_load_stiff_mass(mm, cube_solve, tmpdir):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -252,7 +252,7 @@ def test_getitem_AnsMat(mm):
 def test_getitem_AnsVec(mm, dtype_):
     size_i = 3
     vec = mm.rand(size_i, dtype=dtype_)
-    np_vec = np.asarray()
+    np_vec = vec.asarray()
     for i in range(size_i):
         assert vec[i] == np_vec[i]
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -252,8 +252,7 @@ def test_getitem_AnsMat(mm):
 def test_getitem_AnsVec(mm, dtype_):
     size_i = 3
     vec = mm.rand(size_i, dtype=dtype_)
-    np_vec = vec.asarray()
-    assert vec[1] == np_vec[1]
+    assert np.allclose(vec, vec.asarray())
 
 
 def test_load_stiff_mass(mm, cube_solve, tmpdir):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -236,7 +236,7 @@ def test_matrix_matmult(mm):
     assert np.allclose(m1.asarray() @ m2.asarray(), m3.asarray())
 
 
-def test_getitem(mm):
+def test_getitem_AnsMat(mm):
     size_i, size_j = (3, 3)
     mat = mm.rand(size_i, size_j)
     np_mat = mat.asarray()
@@ -246,6 +246,14 @@ def test_getitem(mm):
         for j in range(size_j):
             # recall that MAPDL uses fortran order
             assert vec[j] == np_mat[j, i]
+
+
+@pytest.mark.parametrize("dtype_", [np.int64, np.double, np.complex128])
+def test_getitem_AnsVec(mm, dtype_):
+    size_i = 3
+    vec = mm.rand(size_i, dtype=dtype_)
+    np_vec = vec.asarray()
+    assert vec[1] == np_vec[1]
 
 
 def test_load_stiff_mass(mm, cube_solve, tmpdir):


### PR DESCRIPTION
Code change to handle Issue  #1881  

Description of the Issue :
Indexing Items from a AnsVec of complex datatype which has both real and imag values, returns only the real value.
There is no way of accessing the imaginary value unless AnsVec is changed to numpy array.

![image](https://user-images.githubusercontent.com/106647677/220919273-59a254cd-a4f6-435d-b90d-3ffd4c5bacda.png)

Close #1881 
