### PR TITLE
Fix use name arg

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -3963,11 +3963,18 @@ class _MapdlCore(Commands):
 
     @wraps(Commands.use)
     def use(self, *args, **kwargs):
+        """Wrap the use command."""
         # Because of `name` can be a macro file or a macro block on a macro library
         # file, we are going to test if the file exists locally first, then remote,
         # and if not, silently assume that it is a macro in a macro library.
         # I do not think there is a way to check if the macro exists before use it.
-        name = kwargs.get("name", args[0])
+        if 'name' in kwargs:
+            name = kwargs.pop('name')
+        else:
+            if len(args) < 1:
+                raise ValueError('Missing `name` argument')
+            name = args[0]
+
         base_name = os.path.basename(name)
 
         # Check if it is a file local

--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -3968,11 +3968,11 @@ class _MapdlCore(Commands):
         # file, we are going to test if the file exists locally first, then remote,
         # and if not, silently assume that it is a macro in a macro library.
         # I do not think there is a way to check if the macro exists before use it.
-        if 'name' in kwargs:
-            name = kwargs.pop('name')
+        if "name" in kwargs:
+            name = kwargs.pop("name")
         else:
             if len(args) < 1:
-                raise ValueError('Missing `name` argument')
+                raise ValueError("Missing `name` argument")
             name = args[0]
 
         base_name = os.path.basename(name)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1643,7 +1643,7 @@ def test_use_uploading(mapdl, cleared, tmpdir):
         fid.write(f"/prep7\n/com, {msg}\n/eof")
 
     # Uploading from local
-    out = mapdl.use(mymacrofile)
+    out = mapdl.use(name=mymacrofile)
     assert f"USE MACRO FILE  {mymacrofile_name}" in out
     assert msg in out
     assert mymacrofile_name in mapdl.list_files()

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1642,6 +1642,9 @@ def test_use_uploading(mapdl, cleared, tmpdir):
     with open(mymacrofile, "w") as fid:
         fid.write(f"/prep7\n/com, {msg}\n/eof")
 
+    with pytest.raises(ValueError, match="Missing `name` argument"):
+        mapdl.use()
+
     # Uploading from local
     out = mapdl.use(name=mymacrofile)
     assert f"USE MACRO FILE  {mymacrofile_name}" in out


### PR DESCRIPTION
Fix `Mapdl.use` to handle `name` specified as a kwarg.
