### PR TITLE
Homogenising error handling

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1985,8 +1985,8 @@ class MapdlGrpc(_MapdlCore):
         self._response = out[out.find("LINE=       0") + 13 :]
         self._log.info(self._response)
 
-        if "*** ERROR ***" in self._response and not self._ignore_errors:
-            self._raise_output_errors(self._response)
+        if not self._ignore_errors:
+            self._raise_errors(self._response)
 
         # try/except here because MAPDL might have not closed the temp file
         try:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -579,6 +579,8 @@ def test_cmd_class_dlist_vm(mapdl, cleared):
     # Run only the first 100 lines of VM223
     with open(verif_files.vmfiles["vm223"]) as fid:
         cmds = fid.readlines()
+
+    mapdl.finish()
     mapdl.input_strings("\n".join(cmds[:100]))
 
     mapdl.allsel("all")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -103,6 +103,8 @@ def test_raise_output_errors(mapdl, response, expected_error):
         MapdlInfo,
         MapdlVersionError,
         MapdlInvalidRoutineError,
+        MapdlCommandIgnoredError,
+        MapdlRuntimeError,
     ],
 )
 def test_exception_classes(error_class):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,10 +1,12 @@
 import pytest
 
 from ansys.mapdl.core.errors import (
+    MapdlCommandIgnoredError,
     MapdlDidNotStart,
     MapdlError,
     MapdlException,
     MapdlInfo,
+    MapdlInvalidRoutineError,
     MapdlNote,
     MapdlRuntimeError,
     MapdlVersionError,
@@ -100,9 +102,24 @@ def test_raise_output_errors(mapdl, response, expected_error):
         MapdlNote,
         MapdlInfo,
         MapdlVersionError,
+        MapdlInvalidRoutineError,
     ],
 )
 def test_exception_classes(error_class):
     message = "Exception message"
     with pytest.raises(error_class):
         raise error_class(message)
+
+
+def test_error_handler(mapdl):
+    text = "is not a recognized"
+    with pytest.raises(MapdlInvalidRoutineError, match="recognized"):
+        mapdl._raise_errors(text)
+
+    text = "command is ignored"
+    with pytest.raises(MapdlCommandIgnoredError, match="ignored"):
+        mapdl._raise_errors(text)
+
+    text = "*** ERROR ***\n This is my own errorrrr"
+    with pytest.raises(MapdlRuntimeError, match="errorrrr"):
+        mapdl._raise_errors(text)

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -6,7 +6,7 @@ import pytest
 
 from ansys.mapdl.core import examples
 from ansys.mapdl.core.common_grpc import DEFAULT_CHUNKSIZE
-from ansys.mapdl.core.errors import MapdlRuntimeError
+from ansys.mapdl.core.errors import MapdlCommandIgnoredError, MapdlRuntimeError
 from ansys.mapdl.core.launcher import check_valid_ansys, get_start_instance
 from ansys.mapdl.core.misc import random_string
 
@@ -124,7 +124,7 @@ def test_clear_multiple(mapdl):
 
 
 def test_invalid_get(mapdl):
-    with pytest.raises(MapdlRuntimeError):
+    with pytest.raises((MapdlRuntimeError, MapdlCommandIgnoredError)):
         mapdl.get_value("ACTIVE", item1="SET", it1num="invalid")
 
 
@@ -241,7 +241,7 @@ def test_read_input_file(mapdl, file_name):
 
 
 def test_no_get_value_non_interactive(mapdl):
-    with pytest.raises(RuntimeError, match="Cannot use gRPC enabled ``GET``"):
+    with pytest.raises((RuntimeError, MapdlCommandIgnoredError)):
         with mapdl.non_interactive:
             mapdl.get_value("ACTIVE", item1="CSYS")
 

--- a/tests/test_inline_functions/test_query.py
+++ b/tests/test_inline_functions/test_query.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ansys.mapdl.core.errors import MapdlCommandIgnoredError, MapdlRuntimeError
+
 
 class TestParseParameter:
     @pytest.mark.parametrize(
@@ -69,10 +71,10 @@ class TestRunQuery:
         assert isinstance(v, type_)
 
     def test_interactive_mode_error(self, mapdl, line_geometry):
-        q, kps, l0 = line_geometry
-        with mapdl.non_interactive:
-            with pytest.raises(RuntimeError):
-                v = q.kx(1)
+        q, _, _ = line_geometry
+        with pytest.raises((MapdlRuntimeError, MapdlCommandIgnoredError)):
+            with mapdl.non_interactive:
+                q.kx(1)
 
     @pytest.mark.skip_grpc  # only works in gRPC mode
     def test_nopr_mode(self, mapdl, line_geometry):


### PR DESCRIPTION
As the title.

Use the same functions/methods for error handling.

This has been taken from #1912 