### PR TITLE
Add additional common ansys root path for linux.

### DIFF
--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -11,7 +11,7 @@ LOG.debug("Loaded logging module as LOG")
 
 _LOCAL_PORTS = []
 
-LINUX_DEFAULT_DIRS = [["/", "usr", "ansys_inc"], ["/", "ansys_inc"]]
+LINUX_DEFAULT_DIRS = [["/", "usr", "ansys_inc"], ["/", "ansys_inc"], ["/", "opt", "ansys_inc"]]
 LINUX_DEFAULT_DIRS = [os.path.join(*each) for each in LINUX_DEFAULT_DIRS]
 
 # Per contract with Sphinx-Gallery, this method must be available at top level

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -11,7 +11,11 @@ LOG.debug("Loaded logging module as LOG")
 
 _LOCAL_PORTS = []
 
-LINUX_DEFAULT_DIRS = [["/", "usr", "ansys_inc"], ["/", "ansys_inc"], ["/", "opt", "ansys_inc"]]
+LINUX_DEFAULT_DIRS = [
+    ["/", "usr", "ansys_inc"],
+    ["/", "ansys_inc"],
+    ["/", "opt", "ansys_inc"],
+]
 LINUX_DEFAULT_DIRS = [os.path.join(*each) for each in LINUX_DEFAULT_DIRS]
 
 # Per contract with Sphinx-Gallery, this method must be available at top level


### PR DESCRIPTION
/opt/ansys_inc is another common path for Ansys installation in Linux.