### PR TITLE
Expose Vector Scaling introduced in MAPDL V232

### DIFF
--- a/src/ansys/mapdl/core/_commands/apdl/matrix_op.py
+++ b/src/ansys/mapdl/core/_commands/apdl/matrix_op.py
@@ -752,7 +752,7 @@ class MatrixOP:
         return self.run(f"REMOVE,{name},{val1},{val2},{val3}", **kwargs)
 
     def scal(self, name="", val1="", val2="", **kwargs):
-        """Scales a vector or matrix by a constant.
+        """Scales a vector or matrix by a constant or a vector.
 
         APDL Command: ``*SCAL``
 
@@ -763,17 +763,34 @@ class MatrixOP:
             be specified.
 
         val1
-            The real part of the constant to use (default = 1).
+            When scaling a matrix or a vector by a scalar value, Val1 is
+            the real part of the constant to use (default = 1).
+
+            When scaling a matrix or a vector by a vector, Val1 is the
+            name of the vector used for the scaling operation.
 
         val2
-            The imaginary part of the constant to use (default = 0). This
-            value is used only if the vector or matrix specified by Name
-            is complex.
+            The imaginary part of the constant to use (default = 0).
+            This value is used only if the vector or matrix specified by
+            Name is complex.
+
+            val2 is only valid for scaling by a constant. It is not
+            used when scaling by a vector.
 
         Notes
         -----
         This command can be applied to vectors and matrices created by the
         ``*VEC``, ``*DMAT`` and ``*SMAT`` commands.
+
+        Data types must be consistent between the vectors and matrices
+        being scaled and the scaling vector (or constant value).
+
+        When scaling a matrix with a vector, the matrix must be square
+        and the scaling vector must be the same size.
+
+        Scaling a matrix with a vector, is available only on
+        MAPDL V23.2 and greater.
+
         """
         return self.run(f"*SCAL,{name},{val1},{val2}", **kwargs)
 

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1355,7 +1355,9 @@ class ApdlMathObj:
 
         if isinstance(val, AnsVec):
             if mapdl_version < 23.2:  # pragma: no cover
-                raise VersionError("Scaling by a vector requires MAPDL version 2023R2 or superior.")
+                raise VersionError(
+                    "Scaling by a vector requires MAPDL version 2023R2 or superior."
+                )
             else:
                 self._mapdl._log.info(f"Scaling ({self.type}) by a vector")
                 self._mapdl.run(f"*SCAL,{self.id},{val.id}", mute=False)

--- a/src/ansys/mapdl/core/math.py
+++ b/src/ansys/mapdl/core/math.py
@@ -1355,12 +1355,14 @@ class ApdlMathObj:
 
         if isinstance(val, AnsVec):
             if mapdl_version < 23.2:  # pragma: no cover
-                raise VersionError("scaling by a vector requires MAPDL version 2023R2")
+                raise VersionError("Scaling by a vector requires MAPDL version 2023R2 or superior.")
             else:
                 self._mapdl._log.info(f"Scaling ({self.type}) by a vector")
                 self._mapdl.run(f"*SCAL,{self.id},{val.id}", mute=False)
-        else:
+        elif isinstance(val, (int, float)):
             self._mapdl.run(f"*SCAL,{self.id},{val}", mute=True)
+        else:
+            raise TypeError(f"The provided type {type(val)} is not supported.")
 
         return self
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -99,6 +99,19 @@ def test_inplace_mult(mm):
     assert v[0] == 2
 
 
+def test_inplace_mult_with_vec(mm):
+    mapdl_version = mm._mapdl.version
+    if mapdl_version < 23.2:
+        pytest.skip("Requires MAPDL 2023 R2 or later.")
+
+    m1 = mm.rand(3, 3)
+    m2 = m1.copy()
+    v1 = mm.ones(3)
+    v1.const(2)
+    m2 *= v1
+    assert np.allclose(m2, np.multiply(m1, v1) * v1)
+
+
 def test_set_vec_large(mm):
     # send a vector larger than the gRPC size limit of 4 MB
     sz = 1000000


### PR DESCRIPTION
MAPDL V232 can perform Scaling (*SCAL) of a AnsMat / AnsVec by a vector. (New feature)
Introduce this feature in PyMAPDL Math Library by updating the existing inplace multiplication function __imul__.
This Feature is available only in MAPDL V232 and above.