### PR TITLE
Reducing MAPDL versions testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - "*"     
     branches:
        - main
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '30 4 * * 1,3,5'
 
 env:
   PROJECT_NAME: 'PyMAPDL'
@@ -256,6 +259,19 @@ jobs:
       fail-fast: false
       matrix:
         mapdl-version: ['v21.1.1', 'v21.2.1', 'v22.1.0', 'v22.2.0', 'v22.2-ubuntu', 'v23.1.0']
+        on_schedule:
+          - ${{ github.event_name != 'schedule' || github.event_name != 'workflow_dispatch' }}
+        exclude:
+          - on_schedule: false
+            mapdl-version: 'v21.1.1'
+          - on_schedule: false
+            mapdl-version: 'v21.2.1'
+          - on_schedule: false
+            mapdl-version: 'v22.1.0'
+          - on_schedule: false
+            mapdl-version: 'v22.2.0'
+          - on_schedule: false
+            mapdl-version: 'v22.2-ubuntu'
     env:
       PYMAPDL_PORT: 21000  # default won't work on GitHub runners
       PYMAPDL_DB_PORT: 21001  # default won't work on GitHub runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,18 +259,18 @@ jobs:
       fail-fast: false
       matrix:
         mapdl-version: ['v21.1.1', 'v21.2.1', 'v22.1.0', 'v22.2.0', 'v22.2-ubuntu', 'v23.1.0']
-        on_schedule:
-          - ${{ github.event_name != 'schedule' || github.event_name != 'workflow_dispatch' }}
+        extended_testing:
+          - ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         exclude:
-          - on_schedule: false
+          - extended_testing: false
             mapdl-version: 'v21.1.1'
-          - on_schedule: false
+          - extended_testing: false
             mapdl-version: 'v21.2.1'
-          - on_schedule: false
+          - extended_testing: false
             mapdl-version: 'v22.1.0'
-          - on_schedule: false
+          - extended_testing: false
             mapdl-version: 'v22.2.0'
-          - on_schedule: false
+          - extended_testing: false
             mapdl-version: 'v22.2-ubuntu'
     env:
       PYMAPDL_PORT: 21000  # default won't work on GitHub runners


### PR DESCRIPTION
Reducing the amount of MAPDL versions where we do the testing.

I am trying to keep everything in the same YML, so this increases its complexity a bit but keep everything centralised.