### PR TITLE
Drop support for VTK v8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,20 @@ dependencies = [
     "ansys-mapdl-reader>=0.51.7",
     "ansys-platform-instancemanagement~=1.0",
     "appdirs>=1.4.0",
+    "click>=8.1.3", # for CLI interface
     "grpcio>=1.30.0",  # tested up to grpcio==1.35
     "importlib-metadata>=4.0",
     "matplotlib>=3.0.0",  # for colormaps for pyvista
     "numpy>=1.14.0",
     "pexpect>=4.8.0 ; platform_system=='Linux'",
     "protobuf>=3.12.2",  # minimum required based on latest ansys-grpc-mapdl
-    "pyiges>=0.1.4",
+    "psutil>=5.9.4",
     "pyansys-tools-versioning>=0.3.3",
+    "pyiges>=0.1.4",
     "pyvista>=0.33.0",
     "scipy>=1.3.0",  # for sparse (consider optional?)
     "tqdm>=4.45.0",
-    "click>=8.1.3", # for CLI interface
-    "psutil>=5.9.4",
+    "vtk>=9.0.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/ansys/mapdl/core/mesh/mesh.py
+++ b/src/ansys/mapdl/core/mesh/mesh.py
@@ -4,7 +4,6 @@ from ansys.mapdl.reader.elements import ETYPE_MAP
 from ansys.mapdl.reader.misc import unique_rows
 import numpy as np
 import pyvista as pv
-from pyvista._vtk import VTK9
 
 INVALID_ALLOWABLE_TYPES = TypeError(
     "`allowable_types` must be an array " "of ANSYS element types from 1 and 300"
@@ -152,10 +151,7 @@ def _parse_vtk(
         cells[cells < 0] = 0
         # cells[cells >= nodes.shape[0]] = 0  # fails when n_nodes < 20
 
-    if VTK9:
-        grid = pv.UnstructuredGrid(cells, celltypes, nodes, deep=True)
-    else:
-        grid = pv.UnstructuredGrid(offset, cells, celltypes, nodes, deep=True)
+    grid = pv.UnstructuredGrid(cells, celltypes, nodes, deep=True)
 
     # Store original ANSYS element and node information
     try:


### PR DESCRIPTION
PyVista v0.39.0 will be released by 1 May and will drop support for VTK v8. We have one minor change to make to be compatible with the to-be-released package.
