### PR TITLE
Allowing to use ``input`` and ``input_strings``  inside ``non_interactive``

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -661,6 +661,7 @@ class _MapdlCore(Commands):
         def __exit__(self, *args):
             self._parent()._log.debug("Exiting non-interactive mode")
             self._parent()._flush_stored()
+            self._parent()._store_commands = False
 
     class _chain_commands:
         """Store MAPDL commands and send one chained command."""
@@ -2830,9 +2831,12 @@ class _MapdlCore(Commands):
         if isinstance(commands, str):
             commands = commands.splitlines()
 
-        self._stored_commands = commands
-        self._flush_stored()
-        return self._response
+        self._stored_commands.extend(commands)
+        if self._store_commands:
+            return None
+        else:
+            self._flush_stored()
+            return self._response
 
     def run(self, command, write_to_log=True, mute=None, **kwargs) -> str:
         """

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1815,7 +1815,7 @@ class MapdlGrpc(_MapdlCore):
         if write_to_log and self._apdl_log is not None:
             if not self._apdl_log.closed:
                 self._apdl_log.write(tmp_dat)
-        
+
         # Escaping early if inside non_interactive context
         if self._store_commands:
             self._stored_commands.append(tmp_dat.splitlines()[1])

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1815,6 +1815,11 @@ class MapdlGrpc(_MapdlCore):
         if write_to_log and self._apdl_log is not None:
             if not self._apdl_log.closed:
                 self._apdl_log.write(tmp_dat)
+        
+        # Escaping early if inside non_interactive context
+        if self._store_commands:
+            self._stored_commands.append(tmp_dat.splitlines()[1])
+            return None
 
         if self._local:
             local_path = self.directory

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -21,7 +21,6 @@ from ansys.mapdl.core.errors import (
     MapdlConnectionError,
     MapdlRuntimeError,
 )
-from ansys.mapdl.core.examples import vmfiles
 from ansys.mapdl.core.launcher import get_start_instance, launch_mapdl
 from ansys.mapdl.core.misc import random_string
 
@@ -1900,7 +1899,6 @@ def test_input_strings_inside_non_interactive(mapdl, cleared):
     assert "PREP7" in mapdl._response
     assert "General Kenobi. You are a bold one.  Kill him!" in mapdl._response
     assert "Back away! I will deal with this Jedi slime myself." in mapdl._response
-
 
 
 def test_input_inside_non_interactive(mapdl, cleared):

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -23,6 +23,7 @@ from ansys.mapdl.core.errors import (
 )
 from ansys.mapdl.core.launcher import get_start_instance, launch_mapdl
 from ansys.mapdl.core.misc import random_string
+from ansys.mapdl.core.examples import vmfiles
 
 skip_in_cloud = pytest.mark.skipif(
     not get_start_instance(),
@@ -1886,3 +1887,35 @@ def test_cuadratic_beam(mapdl, cuadratic_beam_problem):
         )
         is None
     )
+
+
+def test_input_strings_inside_non_interactive(mapdl, cleared):
+    cmd = """/com General Kenobi. You are a bold one.  Kill him!\n/prep7"""
+    with mapdl.non_interactive:
+        mapdl.com("Hello there")
+        mapdl.input_strings(cmd)
+        mapdl.com("Back away! I will deal with this Jedi slime myself.")
+
+    assert "Hello there" in mapdl._response
+    assert "PREP7" in mapdl._response
+    assert "General Kenobi. You are a bold one.  Kill him!" in mapdl._response
+    assert "Back away! I will deal with this Jedi slime myself." in mapdl._response
+
+
+
+def test_input_inside_non_interactive(mapdl, cleared):
+    cmd = """/com General Kenobi. You are a bold one.  Kill him!\n/prep7"""
+    with open("myinput.inp", "w") as fid:
+        fid.write(cmd)
+
+    with mapdl.non_interactive:
+        mapdl.com("Hello there")
+        mapdl.input("myinput.inp")
+        mapdl.com("Back away! I will deal with this Jedi slime myself.")
+
+    assert "Hello there" in mapdl._response
+    assert "PREP7" in mapdl._response
+    assert "General Kenobi. You are a bold one.  Kill him!" in mapdl._response
+    assert "Back away! I will deal with this Jedi slime myself." in mapdl._response
+
+    os.remove("myinput.inp")

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -21,9 +21,9 @@ from ansys.mapdl.core.errors import (
     MapdlConnectionError,
     MapdlRuntimeError,
 )
+from ansys.mapdl.core.examples import vmfiles
 from ansys.mapdl.core.launcher import get_start_instance, launch_mapdl
 from ansys.mapdl.core.misc import random_string
-from ansys.mapdl.core.examples import vmfiles
 
 skip_in_cloud = pytest.mark.skipif(
     not get_start_instance(),


### PR DESCRIPTION
Allowing to use ``input`` and ``input_strings`` inside ``non_interactive`` context manager.

Close #1246 