### PR TITLE
Making contains method case insenstive

### DIFF
--- a/src/ansys/mapdl/core/docs.py
+++ b/src/ansys/mapdl/core/docs.py
@@ -70,14 +70,14 @@ def linkcode_resolve(domain, info, edit=False):
     from ansys.mapdl.core.inline_functions import core  # noqa: F401
     from ansys.mapdl.core.inline_functions import inline_functions  # noqa: F401
 
-    if domain != "py":
+    if domain != "py":  # pragma: no cover
         return None
 
     modname = info["module"]
     fullname = info["fullname"]
 
     submod = sys.modules.get(modname)
-    if submod is None:  # Pragma: no cover
+    if submod is None:  # pragma: no cover
         return None
 
     obj = submod
@@ -111,7 +111,7 @@ def linkcode_resolve(domain, info, edit=False):
 
     if "site-packages" in repo_path:
         src = "site-packages"
-    else:
+    else:  # pragma: no cover
         src = "src"
 
     repo_path = repo_path[: repo_path.find(src)]

--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -369,7 +369,7 @@ class Parameters:
             True if the key is in the dictionary, False otherwise.
 
         """
-        return key in self._parm.keys()
+        return key.upper() in self._parm.keys()
 
     def __iter__(self):
         """

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -6,6 +6,7 @@ import shutil
 import time
 
 from ansys.mapdl.reader import examples
+from ansys.mapdl.reader.rst import Result
 import grpc
 import numpy as np
 import psutil
@@ -1511,7 +1512,7 @@ def test_file_command_remote(mapdl, cube_solve, tmpdir):
 
     mapdl.post1()
     # this file already exists remotely
-    mapdl.file("file.rst")
+    mapdl.file("file", ".rst")
 
     with pytest.raises(FileNotFoundError):
         mapdl.file()
@@ -1942,3 +1943,8 @@ def test_rlblock_rlblock_num(mapdl):
             assert comparison[i][j] == rlblock[i][j]
 
     assert [1, 2, 4] == mapdl.mesh.rlblock_num
+
+
+def test_download_results_non_local(mapdl, cube_solve):
+    assert mapdl.result is not None
+    assert isinstance(mapdl.result, Result)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -392,3 +392,40 @@ def test_parameter_with_spaces(mapdl):
     assert mapdl.parameters
     assert "SIMULATION" in mapdl.parameters
     assert string_.strip() == mapdl.parameters["SIMULATION"]
+
+
+def test_parameters_keys(mapdl):
+    mapdl.parameters["MYPAR"] = 1234
+
+    assert "MYPAR" in list(mapdl.parameters.keys())
+    assert mapdl.parameters.keys() is not None
+    assert mapdl.parameters["MYPAR"] == 1234
+
+
+def test_parameters_values(mapdl, cleared):
+    mapdl.parameters["MYPAR"] = 9876
+
+    assert 9876 == list(mapdl.parameters.values())[0]["value"]
+    assert mapdl.parameters["MYPAR"] == 9876
+
+
+def test_parameters_copy(mapdl, cleared):
+    mapdl.parameters["MYPAR"] = 9876
+
+    copy = mapdl.parameters.copy()
+    assert isinstance(copy, dict)
+    assert copy["MYPAR"]["value"] == 9876
+
+
+def test_parameters_items(mapdl, cleared):
+    mapdl.parameters["MYPAR"] = 9876
+
+    for each_key, each_item in mapdl.parameters.items():
+        assert each_key == "MYPAR"
+        assert each_item["value"] == 9876
+
+
+def test_parameter_contains(mapdl, cleared):
+    mapdl.parameters["mypar"] = 9876
+
+    assert "mypar" in mapdl.parameters


### PR DESCRIPTION
As the title.

So we can do:
```py
mapdl.parameters["mypar"] = 1234
assert "mypar" in mapdl.parameters # True
assert "MYPAR" in mapdl.parameters # True also
```